### PR TITLE
gpui: Multi-shape lens, gradient blur, and mirror primitives

### DIFF
--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -38,6 +38,7 @@ pub struct Scene {
     pub surfaces: Vec<PaintSurface>,
     pub blur_rects: Vec<BlurRect>,
     pub lens_rects: Vec<LensRect>,
+    pub mirror_rects: Vec<MirrorRect>,
     /// Per-shape data for `LensRect`s that represent a multi-shape union.
     /// Each `LensRect` points at a `shape_offset..shape_offset+shape_count`
     /// slice of this vec. Shapes are never reordered after insertion, so the
@@ -61,6 +62,7 @@ impl Scene {
         self.surfaces.clear();
         self.blur_rects.clear();
         self.lens_rects.clear();
+        self.mirror_rects.clear();
         self.lens_shapes.clear();
     }
 
@@ -140,6 +142,10 @@ impl Scene {
                 self.lens_shapes.extend_from_slice(&lens.shapes);
                 self.lens_rects.push(lens.rect);
             }
+            Primitive::MirrorRect(mirror) => {
+                mirror.order = order;
+                self.mirror_rects.push(*mirror);
+            }
         }
         self.paint_operations
             .push(PaintOperation::Primitive(primitive));
@@ -169,12 +175,13 @@ impl Scene {
         self.surfaces.sort_by_key(|surface| surface.order);
         self.blur_rects.sort_by_key(|blur| blur.order);
         self.lens_rects.sort_by_key(|lens| lens.order);
+        self.mirror_rects.sort_by_key(|mirror| mirror.order);
     }
 
-    /// Maximum `kernel_levels` requested by any `BlurRect` or `LensRect`
-    /// in the scene, clamped to `1..=5`. Used by renderers to size the
-    /// dual-Kawase snapshot chain for the frame. Returns 0 when neither
-    /// primitive kind is present.
+    /// Maximum `kernel_levels` requested by any `BlurRect`, `LensRect`, or
+    /// `MirrorRect` in the scene, clamped to `1..=5`. Used by renderers
+    /// to size the dual-Kawase snapshot chain for the frame. Returns 0
+    /// when no blur-consuming primitive is present.
     pub fn max_blur_kernel_levels(&self) -> u32 {
         let blur = self
             .blur_rects
@@ -188,14 +195,21 @@ impl Scene {
             .map(|l| l.kernel_levels)
             .max()
             .unwrap_or(0);
-        blur.max(lens).min(5)
+        let mirror = self
+            .mirror_rects
+            .iter()
+            .filter(|m| m.blur_radius.0 > 0.0 || m.blur_radius_end.0 > 0.0)
+            .map(|m| m.kernel_levels)
+            .max()
+            .unwrap_or(0);
+        blur.max(lens).max(mirror).min(5)
     }
 
-    /// Maximum `blur_radius` requested by any `BlurRect` or `LensRect` in
-    /// the scene. For gradient blurs, considers both endpoints (`radius`
-    /// and `radius_end`) — the bigger of the two determines how much
-    /// blurring the Kawase chain must be able to produce. Zero when
-    /// neither primitive kind is present.
+    /// Maximum `blur_radius` requested by any `BlurRect`, `LensRect`, or
+    /// `MirrorRect` in the scene. For gradient blurs, considers both
+    /// endpoints (`radius` and `radius_end`) — the bigger of the two
+    /// determines how much blurring the Kawase chain must be able to
+    /// produce. Zero when no blur-consuming primitive is present.
     pub fn max_blur_radius(&self) -> ScaledPixels {
         let blur = self
             .blur_rects
@@ -207,7 +221,12 @@ impl Scene {
             .iter()
             .map(|l| l.blur_radius.0.max(l.blur_radius_end.0))
             .fold(0.0_f32, f32::max);
-        ScaledPixels(blur.max(lens))
+        let mirror = self
+            .mirror_rects
+            .iter()
+            .map(|m| m.blur_radius.0.max(m.blur_radius_end.0))
+            .fold(0.0_f32, f32::max);
+        ScaledPixels(blur.max(lens).max(mirror))
     }
 
     #[cfg_attr(
@@ -239,6 +258,8 @@ impl Scene {
             blur_rects_iter: self.blur_rects.iter().peekable(),
             lens_rects_start: 0,
             lens_rects_iter: self.lens_rects.iter().peekable(),
+            mirror_rects_start: 0,
+            mirror_rects_iter: self.mirror_rects.iter().peekable(),
         }
     }
 }
@@ -263,6 +284,7 @@ pub(crate) enum PrimitiveKind {
     Surface,
     BlurRect,
     LensRect,
+    MirrorRect,
 }
 
 pub(crate) enum PaintOperation {
@@ -284,6 +306,7 @@ pub enum Primitive {
     Surface(PaintSurface),
     BlurRect(BlurRect),
     LensRect(LensPrimitive),
+    MirrorRect(MirrorRect),
 }
 
 /// A `LensRect` header paired with its per-shape union inputs. Round-trips
@@ -310,6 +333,7 @@ impl Primitive {
             Primitive::Surface(surface) => &surface.bounds,
             Primitive::BlurRect(blur) => &blur.bounds,
             Primitive::LensRect(lens) => &lens.rect.bounds,
+            Primitive::MirrorRect(mirror) => &mirror.bounds,
         }
     }
 
@@ -325,6 +349,7 @@ impl Primitive {
             Primitive::Surface(surface) => &surface.content_mask,
             Primitive::BlurRect(blur) => &blur.content_mask,
             Primitive::LensRect(lens) => &lens.rect.content_mask,
+            Primitive::MirrorRect(mirror) => &mirror.content_mask,
         }
     }
 }
@@ -357,6 +382,8 @@ struct BatchIterator<'a> {
     blur_rects_iter: Peekable<slice::Iter<'a, BlurRect>>,
     lens_rects_start: usize,
     lens_rects_iter: Peekable<slice::Iter<'a, LensRect>>,
+    mirror_rects_start: usize,
+    mirror_rects_iter: Peekable<slice::Iter<'a, MirrorRect>>,
 }
 
 impl<'a> Iterator for BatchIterator<'a> {
@@ -397,6 +424,10 @@ impl<'a> Iterator for BatchIterator<'a> {
             (
                 self.lens_rects_iter.peek().map(|l| l.order),
                 PrimitiveKind::LensRect,
+            ),
+            (
+                self.mirror_rects_iter.peek().map(|m| m.order),
+                PrimitiveKind::MirrorRect,
             ),
         ];
         orders_and_kinds.sort_by_key(|(order, kind)| (order.unwrap_or(u32::MAX), *kind));
@@ -571,6 +602,22 @@ impl<'a> Iterator for BatchIterator<'a> {
                 self.lens_rects_start = lens_rects_end;
                 Some(PrimitiveBatch::LensRects(lens_rects_start..lens_rects_end))
             }
+            PrimitiveKind::MirrorRect => {
+                let mirror_rects_start = self.mirror_rects_start;
+                let mut mirror_rects_end = mirror_rects_start + 1;
+                self.mirror_rects_iter.next();
+                while self
+                    .mirror_rects_iter
+                    .next_if(|mirror| (mirror.order, batch_kind) < max_order_and_kind)
+                    .is_some()
+                {
+                    mirror_rects_end += 1;
+                }
+                self.mirror_rects_start = mirror_rects_end;
+                Some(PrimitiveBatch::MirrorRects(
+                    mirror_rects_start..mirror_rects_end,
+                ))
+            }
         }
     }
 }
@@ -605,6 +652,7 @@ pub enum PrimitiveBatch {
     Surfaces(Range<usize>),
     BlurRects(Range<usize>),
     LensRects(Range<usize>),
+    MirrorRects(Range<usize>),
 }
 
 #[derive(Default, Debug, Copy, Clone)]
@@ -786,6 +834,57 @@ pub struct LensShape {
 }
 
 const _: () = assert!(std::mem::size_of::<LensShape>() == 48);
+
+/// Bit flag enabling a horizontal (left/right) flip in
+/// [`MirrorRect::mirror_axis`].
+pub const MIRROR_AXIS_HORIZONTAL: u32 = 1 << 0;
+/// Bit flag enabling a vertical (top/bottom) flip in
+/// [`MirrorRect::mirror_axis`]. Combine with
+/// [`MIRROR_AXIS_HORIZONTAL`] to produce a 180° rotation.
+pub const MIRROR_AXIS_VERTICAL: u32 = 1 << 1;
+
+/// A rounded rectangle that samples a region of the framebuffer, optionally
+/// flipped across one or both axes, and composites the result back at a
+/// different location. Used for SwiftUI's `backgroundExtensionEffect()` —
+/// extend an image's edge into a decorative out-of-frame mirror, optionally
+/// blurred with the scene's Kawase chain.
+///
+/// Supports the same uniform-or-gradient blur as [`BlurRect`] /
+/// [`LensRect`]. `blur_radius == 0 && blur_radius_end == 0` samples the
+/// un-blurred framebuffer snapshot directly (no blur).
+///
+/// Like `BlurRect` and `LensRect`, each mirror primitive forces a
+/// render-pass break so the framebuffer can be sampled.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+#[expect(missing_docs)]
+pub struct MirrorRect {
+    pub order: DrawOrder,
+    pub kernel_levels: u32,
+    pub bounds: Bounds<ScaledPixels>,
+    pub content_mask: ContentMask<ScaledPixels>,
+    pub corner_radii: Corners<ScaledPixels>,
+    pub source_bounds: Bounds<ScaledPixels>,
+    /// Bitmask of `MIRROR_AXIS_*` flags. `0` disables flipping; the
+    /// primitive then acts as a relocated copy of `source_bounds`.
+    pub mirror_axis: u32,
+    /// `1` clips the mirrored sample against the rounded-rect SDF so
+    /// out-of-corner pixels go transparent. `0` lets the mirrored
+    /// rectangle bleed into the AA band.
+    pub clip_to_destination: u32,
+    pub blur_radius: ScaledPixels,
+    pub blur_radius_end: ScaledPixels,
+    pub gradient_direction: [f32; 2],
+    pub tint: Hsla,
+}
+
+const _: () = assert!(std::mem::size_of::<MirrorRect>() == 112);
+
+impl From<MirrorRect> for Primitive {
+    fn from(mirror: MirrorRect) -> Self {
+        Primitive::MirrorRect(mirror)
+    }
+}
 
 /// The style of a border.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
@@ -1146,7 +1245,10 @@ impl PathVertex<Pixels> {
 
 #[cfg(test)]
 mod tests {
-    use super::{BlurRect, LensPrimitive, LensRect, LensShape, PrimitiveBatch, Quad, Scene};
+    use super::{
+        BlurRect, LensPrimitive, LensRect, LensShape, MIRROR_AXIS_HORIZONTAL, MirrorRect,
+        PrimitiveBatch, Quad, Scene,
+    };
     use crate::{
         Background, BorderStyle, Bounds, ContentMask, Corners, Edges, Hsla, ScaledPixels, point,
         size,
@@ -1427,6 +1529,67 @@ mod tests {
         scene.finish();
 
         assert_eq!(scene.max_blur_radius(), ScaledPixels(24.0));
+    }
+
+    fn make_mirror_rect() -> MirrorRect {
+        MirrorRect {
+            order: 0,
+            kernel_levels: 3,
+            bounds: test_bounds(),
+            content_mask: test_content_mask(),
+            corner_radii: test_corners(),
+            source_bounds: test_bounds(),
+            mirror_axis: MIRROR_AXIS_HORIZONTAL,
+            clip_to_destination: 1,
+            blur_radius: ScaledPixels(0.0),
+            blur_radius_end: ScaledPixels(0.0),
+            gradient_direction: [0.0, 0.0],
+            tint: Hsla {
+                h: 0.0,
+                s: 0.0,
+                l: 0.0,
+                a: 0.0,
+            },
+        }
+    }
+
+    #[test]
+    fn mirror_rect_round_trip() {
+        let mut scene = Scene::default();
+        scene.insert_primitive(make_mirror_rect());
+        scene.finish();
+
+        assert_eq!(scene.mirror_rects.len(), 1);
+
+        let batches: Vec<_> = scene.batches().collect();
+        assert!(
+            batches
+                .iter()
+                .any(|b| matches!(b, PrimitiveBatch::MirrorRects(r) if r.len() == 1)),
+            "expected a MirrorRects batch of size 1, got {:?}",
+            batches
+        );
+    }
+
+    #[test]
+    fn mirror_rect_with_blur_affects_max_blur_radius() {
+        let mut scene = Scene::default();
+        let mut mirror = make_mirror_rect();
+        mirror.blur_radius = ScaledPixels(18.0);
+        mirror.blur_radius_end = ScaledPixels(30.0);
+        scene.insert_primitive(mirror);
+        scene.finish();
+        assert_eq!(scene.max_blur_radius(), ScaledPixels(30.0));
+        assert_eq!(scene.max_blur_kernel_levels(), 3);
+    }
+
+    #[test]
+    fn mirror_rect_without_blur_contributes_zero_kernel() {
+        let mut scene = Scene::default();
+        scene.insert_primitive(make_mirror_rect());
+        scene.finish();
+        // blur_radius == 0 and blur_radius_end == 0: no Kawase chain needed.
+        assert_eq!(scene.max_blur_kernel_levels(), 0);
     }
 
     #[test]

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -821,16 +821,21 @@ impl From<LensPrimitive> for Primitive {
 /// computes a signed distance to each shape, combines them with a smooth-min
 /// weighted by `LensRect::edge_blend_distance`, and refracts against the
 /// resulting field — letting overlapping shapes visually morph into one.
+///
+/// `content_mask` is applied per-shape: fragments outside the mask get a
+/// soft attenuation applied to the shape's contribution (weight → 0), so
+/// clipped shapes dissolve into their neighbors in the smooth-min union
+/// instead of producing a hard seam at the mask edge.
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 #[expect(missing_docs)]
 pub struct LensShape {
     pub bounds: Bounds<ScaledPixels>,
     pub corner_radii: Corners<ScaledPixels>,
-    /// Pads the struct to 48 bytes so its WGSL `array<LensShape>` stride
-    /// (rounded to 8-byte alignment for the nested `Bounds` `vec2<f32>`)
-    /// matches the Rust storage-buffer stride.
-    pub _pad: [f32; 4],
+    /// Per-shape clip rectangle. Fragments outside this rect attenuate
+    /// the shape's SDF-union weight to zero (with a ~1-pixel smoothing
+    /// band) so masked-out regions yield to the remaining shapes.
+    pub content_mask: Bounds<ScaledPixels>,
 }
 
 const _: () = assert!(std::mem::size_of::<LensShape>() == 48);
@@ -1318,7 +1323,7 @@ mod tests {
         LensShape {
             bounds: test_bounds(),
             corner_radii: test_corners(),
-            _pad: [0.0; 4],
+            content_mask: test_content_mask().bounds,
         }
     }
 
@@ -1373,6 +1378,26 @@ mod tests {
             "expected a LensRects batch of size 1, got {:?}",
             batches
         );
+    }
+
+    #[test]
+    fn lens_shape_preserves_content_mask() {
+        let mut scene = Scene::default();
+        let mut lens = make_lens_primitive();
+        let custom_mask = Bounds {
+            origin: point(ScaledPixels(5.0), ScaledPixels(10.0)),
+            size: size(ScaledPixels(77.0), ScaledPixels(33.0)),
+        };
+        lens.shapes = vec![LensShape {
+            bounds: test_bounds(),
+            corner_radii: test_corners(),
+            content_mask: custom_mask,
+        }];
+        scene.insert_primitive(lens);
+        scene.finish();
+
+        assert_eq!(scene.lens_shapes.len(), 1);
+        assert_eq!(scene.lens_shapes[0].content_mask, custom_mask);
     }
 
     #[test]

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -192,17 +192,20 @@ impl Scene {
     }
 
     /// Maximum `blur_radius` requested by any `BlurRect` or `LensRect` in
-    /// the scene. Zero when neither primitive kind is present.
+    /// the scene. For gradient blurs, considers both endpoints (`radius`
+    /// and `radius_end`) — the bigger of the two determines how much
+    /// blurring the Kawase chain must be able to produce. Zero when
+    /// neither primitive kind is present.
     pub fn max_blur_radius(&self) -> ScaledPixels {
         let blur = self
             .blur_rects
             .iter()
-            .map(|b| b.blur_radius.0)
+            .map(|b| b.blur_radius.0.max(b.blur_radius_end.0))
             .fold(0.0_f32, f32::max);
         let lens = self
             .lens_rects
             .iter()
-            .map(|l| l.blur_radius.0)
+            .map(|l| l.blur_radius.0.max(l.blur_radius_end.0))
             .fold(0.0_f32, f32::max);
         ScaledPixels(blur.max(lens))
     }
@@ -665,6 +668,12 @@ impl From<Shadow> for Primitive {
 /// dual-Kawase blur, and composites the result with a tint. Used for
 /// backdrop-blurred materials like Apple's Liquid Glass.
 ///
+/// Supports uniform or linear-gradient blur strength: when
+/// `gradient_direction != [0, 0]`, the fragment shader interpolates
+/// `blur_radius_start -> blur_radius_end` along that axis and mixes between
+/// the un-blurred framebuffer and the maximum-blur output. Used for HIG
+/// scroll-edge fades.
+///
 /// Unlike `Quad` / `Shadow` / etc., a `BlurRect` is not drawn with an
 /// instanced pipeline — each one breaks the current render pass so the
 /// framebuffer can be sampled, then runs its own post-process chain before
@@ -679,12 +688,21 @@ pub struct BlurRect {
     pub bounds: Bounds<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
     pub corner_radii: Corners<ScaledPixels>,
+    /// Starting blur radius (in device pixels). For uniform blur, equals
+    /// `blur_radius_end`. The max of the two is what sizes the Kawase chain.
     pub blur_radius: ScaledPixels,
-    pub pad: f32,
+    /// Ending blur radius (in device pixels) for linear-gradient blur.
+    pub blur_radius_end: ScaledPixels,
+    /// Normalized gradient direction. `[0.0, 0.0]` means uniform blur.
+    pub gradient_direction: [f32; 2],
     pub tint: Hsla,
+    /// Pads the stride to 96 bytes so the WGSL `array<BlurRect>` matches
+    /// the Rust side (8-byte alignment required for the nested `vec2<f32>`
+    /// Bounds).
+    pub _pad_end: [f32; 2],
 }
 
-const _: () = assert!(std::mem::size_of::<BlurRect>() == 80);
+const _: () = assert!(std::mem::size_of::<BlurRect>() == 96);
 
 impl From<BlurRect> for Primitive {
     fn from(blur: BlurRect) -> Self {
@@ -699,6 +717,10 @@ impl From<BlurRect> for Primitive {
 /// merge field has room to settle. Per-shape `corner_radii` and `bounds`
 /// live on separate `LensShape` entries at
 /// `Scene::lens_shapes[shape_offset..shape_offset + shape_count]`.
+///
+/// Supports uniform or linear-gradient blur strength the same way
+/// [`BlurRect`] does: `gradient_direction != [0, 0]` enables a per-pixel
+/// interpolation between `blur_radius..blur_radius_end`.
 ///
 /// The field layout is kept in lockstep with the WGSL / MSL `LensRect`
 /// struct and padded to a 112-byte stride.
@@ -719,18 +741,19 @@ pub struct LensRect {
     /// Smooth-min radius, in pixels, used when merging overlapping shapes
     /// into a single SDF. 0 disables merging (hard min).
     pub edge_blend_distance: ScaledPixels,
-    /// Reserved for future use (Subsystem 2's variable-radius blur takes
-    /// four of the five remaining padding slots below).
-    pub _pad_a: f32,
+    /// Starting blur radius (in device pixels). For uniform blur, equals
+    /// `blur_radius_end`.
     pub blur_radius: ScaledPixels,
+    /// Normalized gradient direction. `[0.0, 0.0]` means uniform blur.
+    pub gradient_direction: [f32; 2],
+    /// Ending blur radius (in device pixels) for linear-gradient blur.
+    pub blur_radius_end: ScaledPixels,
     pub refraction: f32,
     pub depth: f32,
     pub dispersion: f32,
     pub splay: ScaledPixels,
     pub light_angle_radians: f32,
-    pub pad_light: f32,
     pub light_intensity: f32,
-    pub pad: f32,
     pub tint: Hsla,
     // Pads the struct to 112 bytes so its WGSL `array<LensRect>` stride
     // (rounded to 8-byte alignment for the nested `Bounds` `vec2<f32>`)
@@ -1164,13 +1187,15 @@ mod tests {
             content_mask: test_content_mask(),
             corner_radii: test_corners(),
             blur_radius: ScaledPixels(12.0),
-            pad: 0.0,
+            blur_radius_end: ScaledPixels(12.0),
+            gradient_direction: [0.0, 0.0],
             tint: Hsla {
                 h: 0.0,
                 s: 0.0,
                 l: 0.0,
                 a: 0.3,
             },
+            _pad_end: [0.0; 2],
         });
         scene.finish();
 
@@ -1205,16 +1230,15 @@ mod tests {
                 shape_offset: 0,
                 shape_count: 0,
                 edge_blend_distance: ScaledPixels(0.0),
-                _pad_a: 0.0,
                 blur_radius: ScaledPixels(8.0),
+                gradient_direction: [0.0, 0.0],
+                blur_radius_end: ScaledPixels(8.0),
                 refraction: 12.0,
                 depth: 6.0,
                 dispersion: 2.0,
                 splay: ScaledPixels(1.5),
                 light_angle_radians: std::f32::consts::FRAC_PI_4,
-                pad_light: 0.0,
                 light_intensity: 0.2,
-                pad: 0.0,
                 tint: Hsla {
                     h: 0.6,
                     s: 0.2,
@@ -1296,13 +1320,15 @@ mod tests {
             content_mask: test_content_mask(),
             corner_radii: test_corners(),
             blur_radius: ScaledPixels(12.0),
-            pad: 0.0,
+            blur_radius_end: ScaledPixels(12.0),
+            gradient_direction: [0.0, 0.0],
             tint: Hsla {
                 h: 0.0,
                 s: 0.0,
                 l: 0.0,
                 a: 0.3,
             },
+            _pad_end: [0.0; 2],
         }
     }
 

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -38,6 +38,11 @@ pub struct Scene {
     pub surfaces: Vec<PaintSurface>,
     pub blur_rects: Vec<BlurRect>,
     pub lens_rects: Vec<LensRect>,
+    /// Per-shape data for `LensRect`s that represent a multi-shape union.
+    /// Each `LensRect` points at a `shape_offset..shape_offset+shape_count`
+    /// slice of this vec. Shapes are never reordered after insertion, so the
+    /// offsets stored in `lens_rects` survive `finish()`'s sort.
+    pub lens_shapes: Vec<LensShape>,
 }
 
 #[expect(missing_docs)]
@@ -56,6 +61,7 @@ impl Scene {
         self.surfaces.clear();
         self.blur_rects.clear();
         self.lens_rects.clear();
+        self.lens_shapes.clear();
     }
 
     pub fn len(&self) -> usize {
@@ -128,8 +134,11 @@ impl Scene {
                 self.blur_rects.push(*blur);
             }
             Primitive::LensRect(lens) => {
-                lens.order = order;
-                self.lens_rects.push(*lens);
+                lens.rect.order = order;
+                lens.rect.shape_offset = self.lens_shapes.len() as u32;
+                lens.rect.shape_count = lens.shapes.len() as u32;
+                self.lens_shapes.extend_from_slice(&lens.shapes);
+                self.lens_rects.push(lens.rect);
             }
         }
         self.paint_operations
@@ -271,7 +280,17 @@ pub enum Primitive {
     PolychromeSprite(PolychromeSprite),
     Surface(PaintSurface),
     BlurRect(BlurRect),
-    LensRect(LensRect),
+    LensRect(LensPrimitive),
+}
+
+/// A `LensRect` header paired with its per-shape union inputs. Round-trips
+/// through `PaintOperation::Primitive` so `Scene::replay` can repopulate
+/// `Scene::lens_shapes` with fresh offsets.
+#[derive(Clone, Debug)]
+#[expect(missing_docs)]
+pub struct LensPrimitive {
+    pub rect: LensRect,
+    pub shapes: Vec<LensShape>,
 }
 
 #[expect(missing_docs)]
@@ -287,7 +306,7 @@ impl Primitive {
             Primitive::PolychromeSprite(sprite) => &sprite.bounds,
             Primitive::Surface(surface) => &surface.bounds,
             Primitive::BlurRect(blur) => &blur.bounds,
-            Primitive::LensRect(lens) => &lens.bounds,
+            Primitive::LensRect(lens) => &lens.rect.bounds,
         }
     }
 
@@ -302,7 +321,7 @@ impl Primitive {
             Primitive::PolychromeSprite(sprite) => &sprite.content_mask,
             Primitive::Surface(surface) => &surface.content_mask,
             Primitive::BlurRect(blur) => &blur.content_mask,
-            Primitive::LensRect(lens) => &lens.content_mask,
+            Primitive::LensRect(lens) => &lens.rect.content_mask,
         }
     }
 }
@@ -673,10 +692,16 @@ impl From<BlurRect> for Primitive {
     }
 }
 
-/// A rounded rectangle with a full Liquid Glass composite: backdrop blur
-/// plus parabolic refraction, chromatic aberration, and a directional
-/// Fresnel edge highlight. Field layout is kept in lockstep with the WGSL
-/// / MSL `LensRect` struct and padded to a 112-byte stride.
+/// A rounded-rectangle group with a full Liquid Glass composite: backdrop
+/// blur plus parabolic refraction, chromatic aberration, and a directional
+/// Fresnel edge highlight. `bounds` is the union AABB of the shapes this
+/// primitive covers, expanded by `edge_blend_distance` on all sides so the
+/// merge field has room to settle. Per-shape `corner_radii` and `bounds`
+/// live on separate `LensShape` entries at
+/// `Scene::lens_shapes[shape_offset..shape_offset + shape_count]`.
+///
+/// The field layout is kept in lockstep with the WGSL / MSL `LensRect`
+/// struct and padded to a 112-byte stride.
 ///
 /// Same caveat as `BlurRect`: each `LensRect` forces a render-pass break.
 #[derive(Debug, Clone, Copy)]
@@ -687,7 +712,16 @@ pub struct LensRect {
     pub kernel_levels: u32,
     pub bounds: Bounds<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
-    pub corner_radii: Corners<ScaledPixels>,
+    /// Index into `Scene::lens_shapes` of this lens's first shape.
+    pub shape_offset: u32,
+    /// Number of shapes in this lens (1..=`MAX_LENS_SHAPES_PER_GROUP`).
+    pub shape_count: u32,
+    /// Smooth-min radius, in pixels, used when merging overlapping shapes
+    /// into a single SDF. 0 disables merging (hard min).
+    pub edge_blend_distance: ScaledPixels,
+    /// Reserved for future use (Subsystem 2's variable-radius blur takes
+    /// four of the five remaining padding slots below).
+    pub _pad_a: f32,
     pub blur_radius: ScaledPixels,
     pub refraction: f32,
     pub depth: f32,
@@ -706,11 +740,29 @@ pub struct LensRect {
 
 const _: () = assert!(std::mem::size_of::<LensRect>() == 112);
 
-impl From<LensRect> for Primitive {
-    fn from(lens: LensRect) -> Self {
+impl From<LensPrimitive> for Primitive {
+    fn from(lens: LensPrimitive) -> Self {
         Primitive::LensRect(lens)
     }
 }
+
+/// One shape in a multi-shape `LensRect` union. The lens fragment shader
+/// computes a signed distance to each shape, combines them with a smooth-min
+/// weighted by `LensRect::edge_blend_distance`, and refracts against the
+/// resulting field — letting overlapping shapes visually morph into one.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+#[expect(missing_docs)]
+pub struct LensShape {
+    pub bounds: Bounds<ScaledPixels>,
+    pub corner_radii: Corners<ScaledPixels>,
+    /// Pads the struct to 48 bytes so its WGSL `array<LensShape>` stride
+    /// (rounded to 8-byte alignment for the nested `Bounds` `vec2<f32>`)
+    /// matches the Rust storage-buffer stride.
+    pub _pad: [f32; 4],
+}
+
+const _: () = assert!(std::mem::size_of::<LensShape>() == 48);
 
 /// The style of a border.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
@@ -1071,7 +1123,7 @@ impl PathVertex<Pixels> {
 
 #[cfg(test)]
 mod tests {
-    use super::{BlurRect, LensRect, PrimitiveBatch, Quad, Scene};
+    use super::{BlurRect, LensPrimitive, LensRect, LensShape, PrimitiveBatch, Quad, Scene};
     use crate::{
         Background, BorderStyle, Bounds, ContentMask, Corners, Edges, Hsla, ScaledPixels, point,
         size,
@@ -1135,36 +1187,57 @@ mod tests {
         );
     }
 
+    fn test_lens_shape() -> LensShape {
+        LensShape {
+            bounds: test_bounds(),
+            corner_radii: test_corners(),
+            _pad: [0.0; 4],
+        }
+    }
+
+    fn make_lens_primitive() -> LensPrimitive {
+        LensPrimitive {
+            rect: LensRect {
+                order: 0,
+                kernel_levels: 3,
+                bounds: test_bounds(),
+                content_mask: test_content_mask(),
+                shape_offset: 0,
+                shape_count: 0,
+                edge_blend_distance: ScaledPixels(0.0),
+                _pad_a: 0.0,
+                blur_radius: ScaledPixels(8.0),
+                refraction: 12.0,
+                depth: 6.0,
+                dispersion: 2.0,
+                splay: ScaledPixels(1.5),
+                light_angle_radians: std::f32::consts::FRAC_PI_4,
+                pad_light: 0.0,
+                light_intensity: 0.2,
+                pad: 0.0,
+                tint: Hsla {
+                    h: 0.6,
+                    s: 0.2,
+                    l: 0.8,
+                    a: 0.1,
+                },
+                pad2: 0.0,
+            },
+            shapes: vec![test_lens_shape()],
+        }
+    }
+
     #[test]
     fn lens_rect_round_trip() {
         let mut scene = Scene::default();
-        scene.insert_primitive(LensRect {
-            order: 0,
-            kernel_levels: 3,
-            bounds: test_bounds(),
-            content_mask: test_content_mask(),
-            corner_radii: test_corners(),
-            blur_radius: ScaledPixels(8.0),
-            refraction: 12.0,
-            depth: 6.0,
-            dispersion: 2.0,
-            splay: ScaledPixels(1.5),
-            light_angle_radians: std::f32::consts::FRAC_PI_4,
-            pad_light: 0.0,
-            light_intensity: 0.2,
-            pad: 0.0,
-            tint: Hsla {
-                h: 0.6,
-                s: 0.2,
-                l: 0.8,
-                a: 0.1,
-            },
-            pad2: 0.0,
-        });
+        scene.insert_primitive(make_lens_primitive());
         scene.finish();
 
         assert_eq!(scene.lens_rects.len(), 1);
+        assert_eq!(scene.lens_shapes.len(), 1);
         assert!(scene.blur_rects.is_empty());
+        assert_eq!(scene.lens_rects[0].shape_offset, 0);
+        assert_eq!(scene.lens_rects[0].shape_count, 1);
 
         let batches: Vec<_> = scene.batches().collect();
         assert!(
@@ -1174,6 +1247,45 @@ mod tests {
             "expected a LensRects batch of size 1, got {:?}",
             batches
         );
+    }
+
+    #[test]
+    fn lens_rect_multi_shape_roundtrip() {
+        let mut scene = Scene::default();
+        let mut lens = make_lens_primitive();
+        lens.shapes = (0..8).map(|_| test_lens_shape()).collect();
+        scene.insert_primitive(lens);
+        scene.finish();
+
+        assert_eq!(scene.lens_rects.len(), 1);
+        assert_eq!(scene.lens_shapes.len(), 8);
+        assert_eq!(scene.lens_rects[0].shape_offset, 0);
+        assert_eq!(scene.lens_rects[0].shape_count, 8);
+    }
+
+    #[test]
+    fn lens_shapes_survive_lens_rect_sort() {
+        let mut scene = Scene::default();
+        // Insert two lens primitives in reverse draw order; lens_shapes must
+        // still be indexable by the final, sorted lens_rects.
+        for (draw_order, shape_count) in [(5u32, 3usize), (1u32, 2usize)] {
+            let mut lens = make_lens_primitive();
+            lens.rect.order = draw_order;
+            lens.shapes = (0..shape_count).map(|_| test_lens_shape()).collect();
+            scene.insert_primitive(lens);
+        }
+        scene.finish();
+
+        assert_eq!(scene.lens_rects.len(), 2);
+        assert_eq!(scene.lens_shapes.len(), 5);
+        // After sort by order, the lower-order lens (2 shapes) comes first.
+        // Its shape_offset was set at insertion time and must still address
+        // a valid slice of lens_shapes.
+        for lens in &scene.lens_rects {
+            let start = lens.shape_offset as usize;
+            let end = start + lens.shape_count as usize;
+            assert!(end <= scene.lens_shapes.len());
+        }
     }
 
     fn make_blur_rect() -> BlurRect {
@@ -1272,29 +1384,20 @@ mod tests {
         blur.blur_radius = ScaledPixels(8.0);
         scene.insert_primitive(blur);
 
-        scene.insert_primitive(LensRect {
-            order: 0,
-            kernel_levels: 3,
-            bounds: test_bounds(),
-            content_mask: test_content_mask(),
-            corner_radii: test_corners(),
-            blur_radius: ScaledPixels(24.0),
-            refraction: 12.0,
-            depth: 6.0,
-            dispersion: 0.0,
-            splay: ScaledPixels(1.5),
-            light_angle_radians: 0.0,
-            pad_light: 0.0,
-            light_intensity: 0.0,
-            pad: 0.0,
-            tint: Hsla {
-                h: 0.0,
-                s: 0.0,
-                l: 0.0,
-                a: 0.0,
-            },
-            pad2: 0.0,
-        });
+        let mut lens = make_lens_primitive();
+        lens.rect.blur_radius = ScaledPixels(24.0);
+        lens.rect.dispersion = 0.0;
+        lens.rect.light_intensity = 0.0;
+        lens.rect.light_angle_radians = 0.0;
+        lens.rect.refraction = 12.0;
+        lens.rect.depth = 6.0;
+        lens.rect.tint = Hsla {
+            h: 0.0,
+            s: 0.0,
+            l: 0.0,
+            a: 0.0,
+        };
+        scene.insert_primitive(lens);
         scene.finish();
 
         assert_eq!(scene.max_blur_radius(), ScaledPixels(24.0));

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -6,8 +6,9 @@ use crate::{
     Capslock, Context, Corners, CursorStyle, Decorations, DevicePixels, DispatchActionListener,
     DispatchNodeId, DispatchTree, DisplayId, Edges, Effect, Entity, EntityId, EventEmitter,
     FileDropEvent, FontId, Global, GlobalElementId, GlyphId, GpuSpecs, Hsla, InputHandler, IsZero,
-    KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke, KeystrokeEvent, LayoutId, LensRect,
-    LineLayoutIndex, Modifiers, ModifiersChangedEvent, MonochromeSprite, MouseButton, MouseEvent,
+    KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke, KeystrokeEvent, LayoutId,
+    LensPrimitive, LensRect, LensShape, LineLayoutIndex, Modifiers, ModifiersChangedEvent,
+    MonochromeSprite, MouseButton, MouseEvent,
     MouseMoveEvent, MouseUpEvent, Path, Pixels, PlatformAtlas, PlatformDisplay, PlatformInput,
     PlatformInputHandler, PlatformWindow, Point, PolychromeSprite, Priority, PromptButton,
     PromptLevel, Quad, Radians, Render, RenderGlyphParams, RenderImage, RenderImageParams,
@@ -3432,6 +3433,35 @@ impl Window {
         corner_radii: Corners<Pixels>,
         effect: LensEffect,
     ) {
+        self.paint_lens_rect_union(
+            [LensShapeSpec {
+                bounds,
+                corner_radii,
+            }],
+            px(0.0),
+            effect,
+        );
+    }
+
+    /// Paint a Liquid Glass composite over the union of multiple rounded
+    /// rectangles. Shapes within `edge_blend_distance` of each other morph
+    /// into a single continuous lens via a smooth-minimum of their signed
+    /// distance fields — the GPU-side equivalent of SwiftUI's
+    /// `GlassEffectContainer(spacing:)`.
+    ///
+    /// `edge_blend_distance` of 0 disables merging: each shape contributes
+    /// its own refraction but they remain visually distinct where they
+    /// overlap. Accepts 1..=`MAX_LENS_SHAPES_PER_GROUP` shapes; violations
+    /// trip a `debug_assert!`.
+    ///
+    /// Same render-pass-break caveat as `paint_blur_rect` — keep the number
+    /// of lens rects per frame small.
+    pub fn paint_lens_rect_union(
+        &mut self,
+        shapes: impl IntoIterator<Item = LensShapeSpec>,
+        edge_blend_distance: Pixels,
+        effect: LensEffect,
+    ) {
         self.invalidator.debug_assert_paint();
         debug_assert!(
             effect.light_angle.0.is_finite(),
@@ -3447,23 +3477,66 @@ impl Window {
         let scale_factor = self.scale_factor();
         let content_mask = self.content_mask();
         let opacity = self.element_opacity();
-        self.next_frame.scene.insert_primitive(LensRect {
-            order: 0,
-            kernel_levels: effect.kernel_levels.clamp(1, 5),
-            bounds: bounds.scale(scale_factor),
-            content_mask: content_mask.scale(scale_factor),
-            corner_radii: corner_radii.scale(scale_factor),
-            blur_radius: effect.radius.scale(scale_factor),
-            refraction: effect.refraction * 100.0,
-            depth: effect.depth * 100.0,
-            dispersion: effect.dispersion * 100.0,
-            splay: effect.splay.scale(scale_factor),
-            light_angle_radians: effect.light_angle.0,
-            pad_light: 0.0,
-            light_intensity: effect.light_intensity,
-            pad: 0.0,
-            tint: effect.tint.opacity(opacity),
-            pad2: 0.0,
+
+        let mut specs: Vec<LensShapeSpec> = shapes.into_iter().collect();
+        debug_assert!(
+            !specs.is_empty(),
+            "paint_lens_rect_union requires at least one shape"
+        );
+        debug_assert!(
+            specs.len() <= MAX_LENS_SHAPES_PER_GROUP,
+            "paint_lens_rect_union accepts at most {MAX_LENS_SHAPES_PER_GROUP} shapes, got {}",
+            specs.len()
+        );
+        if specs.is_empty() {
+            return;
+        }
+        specs.truncate(MAX_LENS_SHAPES_PER_GROUP);
+
+        let mut union = specs[0].bounds;
+        for spec in specs.iter().skip(1) {
+            union = union.union(&spec.bounds);
+        }
+        let blend = edge_blend_distance.max(px(0.0));
+        let padded_origin = point(union.origin.x - blend, union.origin.y - blend);
+        let padded_size = size(union.size.width + blend * 2.0, union.size.height + blend * 2.0);
+        let padded_bounds = Bounds {
+            origin: padded_origin,
+            size: padded_size,
+        };
+
+        let scaled_shapes: Vec<LensShape> = specs
+            .into_iter()
+            .map(|spec| LensShape {
+                bounds: spec.bounds.scale(scale_factor),
+                corner_radii: spec.corner_radii.scale(scale_factor),
+                _pad: [0.0; 4],
+            })
+            .collect();
+
+        self.next_frame.scene.insert_primitive(LensPrimitive {
+            rect: LensRect {
+                order: 0,
+                kernel_levels: effect.kernel_levels.clamp(1, 5),
+                bounds: padded_bounds.scale(scale_factor),
+                content_mask: content_mask.scale(scale_factor),
+                shape_offset: 0,
+                shape_count: 0,
+                edge_blend_distance: blend.scale(scale_factor),
+                _pad_a: 0.0,
+                blur_radius: effect.radius.scale(scale_factor),
+                refraction: effect.refraction * 100.0,
+                depth: effect.depth * 100.0,
+                dispersion: effect.dispersion * 100.0,
+                splay: effect.splay.scale(scale_factor),
+                light_angle_radians: effect.light_angle.0,
+                pad_light: 0.0,
+                light_intensity: effect.light_intensity,
+                pad: 0.0,
+                tint: effect.tint.opacity(opacity),
+                pad2: 0.0,
+            },
+            shapes: scaled_shapes,
         });
     }
 
@@ -6080,4 +6153,19 @@ impl LensEffect {
             ..Default::default()
         }
     }
+}
+
+/// Maximum number of shapes in a single [`Window::paint_lens_rect_union`]
+/// call. Kept small so the per-fragment smooth-min loop stays cheap and the
+/// per-primitive GPU shape buffer is bounded.
+pub const MAX_LENS_SHAPES_PER_GROUP: usize = 8;
+
+/// A single rounded-rectangle shape inside a multi-shape lens group. Passed
+/// to [`Window::paint_lens_rect_union`].
+#[derive(Clone, Copy, Debug)]
+pub struct LensShapeSpec {
+    /// Bounds of this shape in window pixels.
+    pub bounds: Bounds<Pixels>,
+    /// Per-corner radii of this shape in window pixels.
+    pub corner_radii: Corners<Pixels>,
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3413,8 +3413,10 @@ impl Window {
             content_mask: content_mask.scale(scale_factor),
             corner_radii: corner_radii.scale(scale_factor),
             blur_radius: effect.radius.scale(scale_factor),
-            pad: 0.0,
+            blur_radius_end: effect.radius_end.scale(scale_factor),
+            gradient_direction: effect.gradient_direction,
             tint: effect.tint.opacity(opacity),
+            _pad_end: [0.0; 2],
         });
     }
 
@@ -3523,16 +3525,15 @@ impl Window {
                 shape_offset: 0,
                 shape_count: 0,
                 edge_blend_distance: blend.scale(scale_factor),
-                _pad_a: 0.0,
                 blur_radius: effect.radius.scale(scale_factor),
+                gradient_direction: effect.gradient_direction,
+                blur_radius_end: effect.radius_end.scale(scale_factor),
                 refraction: effect.refraction * 100.0,
                 depth: effect.depth * 100.0,
                 dispersion: effect.dispersion * 100.0,
                 splay: effect.splay.scale(scale_factor),
                 light_angle_radians: effect.light_angle.0,
-                pad_light: 0.0,
                 light_intensity: effect.light_intensity,
-                pad: 0.0,
                 tint: effect.tint.opacity(opacity),
                 pad2: 0.0,
             },
@@ -6050,12 +6051,49 @@ pub fn outline(
     }
 }
 
+/// Direction along which a linear-gradient blur fades. Horizontal (leading →
+/// trailing) or Vertical (top → bottom). Used by the `_gradient` builders on
+/// [`BlurEffect`] / [`LensEffect`] when the consumer wants a simple
+/// axis-aligned fade (HIG scroll-edge blur). For diagonal fades, use
+/// [`BlurEffect::with_gradient_direction`] directly.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BlurAxis {
+    /// Left-to-right (+x) fade.
+    Horizontal,
+    /// Top-to-bottom (+y) fade.
+    Vertical,
+}
+
+impl BlurAxis {
+    fn direction(self) -> [f32; 2] {
+        match self {
+            BlurAxis::Horizontal => [1.0, 0.0],
+            BlurAxis::Vertical => [0.0, 1.0],
+        }
+    }
+}
+
 /// A dual-Kawase backdrop blur with tint, applied to a rounded rectangle.
 /// Passed to [`Window::paint_blur_rect`].
+///
+/// Supports either a uniform blur (`radius_end == radius`, no gradient) or a
+/// linear-gradient blur along `gradient_direction` where the per-pixel
+/// strength interpolates from `radius` at the leading edge of the rect to
+/// `radius_end` at the trailing edge. The gradient variant is a
+/// `mix(unblurred, max-blurred, t)` approximation — visually plausible for
+/// HIG scroll-edge fades but not a true Gaussian per-pixel blur.
 #[derive(Clone, Copy, Debug)]
 pub struct BlurEffect {
-    /// Gaussian-equivalent blur radius, in window pixels.
+    /// Gaussian-equivalent blur radius at the start of the gradient (or the
+    /// uniform radius if `gradient_direction` is zero), in window pixels.
     pub radius: Pixels,
+    /// Blur radius at the end of the gradient. Equal to `radius` for a
+    /// uniform blur; differs to fade the blur strength along
+    /// `gradient_direction`.
+    pub radius_end: Pixels,
+    /// Normalized 2D axis the gradient runs along. `[0.0, 0.0]` disables the
+    /// gradient (uniform `radius`).
+    pub gradient_direction: [f32; 2],
     /// Number of Kawase downsample/upsample passes. Higher = wider blur,
     /// lower = sharper. Clamped to 1..=5 by the renderer. Typical: 3.
     ///
@@ -6072,6 +6110,8 @@ impl Default for BlurEffect {
     fn default() -> Self {
         Self {
             radius: px(20.0),
+            radius_end: px(20.0),
+            gradient_direction: [0.0, 0.0],
             kernel_levels: 3,
             tint: transparent_black(),
         }
@@ -6079,13 +6119,32 @@ impl Default for BlurEffect {
 }
 
 impl BlurEffect {
-    /// Construct a blur with HIG defaults (3 Kawase levels, no tint) at the
-    /// given radius.
+    /// Construct a uniform blur with HIG defaults (3 Kawase levels, no tint)
+    /// at the given radius.
     pub fn new(radius: Pixels) -> Self {
         Self {
             radius,
+            radius_end: radius,
             ..Default::default()
         }
+    }
+
+    /// Construct a linear-gradient blur that fades from `from` to `to` along
+    /// the given [`BlurAxis`].
+    pub fn linear_gradient(from: Pixels, to: Pixels, axis: BlurAxis) -> Self {
+        Self {
+            radius: from,
+            radius_end: to,
+            gradient_direction: axis.direction(),
+            ..Default::default()
+        }
+    }
+
+    /// Override the gradient direction with an arbitrary 2D vector. The
+    /// shader normalizes the input; callers should pass a non-zero vector.
+    pub fn with_gradient_direction(mut self, direction: [f32; 2]) -> Self {
+        self.gradient_direction = direction;
+        self
     }
 }
 
@@ -6097,8 +6156,14 @@ impl BlurEffect {
 /// light angle -45°, light intensity 0.67.
 #[derive(Clone, Copy, Debug)]
 pub struct LensEffect {
-    /// Backdrop-blur radius, in window pixels.
+    /// Backdrop-blur radius (start of the gradient, or the uniform radius),
+    /// in window pixels.
     pub radius: Pixels,
+    /// Backdrop-blur radius at the end of the gradient, in window pixels.
+    /// Equal to `radius` for uniform blur.
+    pub radius_end: Pixels,
+    /// Normalized gradient direction. `[0.0, 0.0]` means uniform blur.
+    pub gradient_direction: [f32; 2],
     /// Number of Kawase downsample/upsample passes. Higher = wider blur,
     /// lower = sharper. Clamped to 1..=5 by the renderer. Typical: 3.
     ///
@@ -6131,6 +6196,8 @@ impl Default for LensEffect {
     fn default() -> Self {
         Self {
             radius: px(20.0),
+            radius_end: px(20.0),
+            gradient_direction: [0.0, 0.0],
             kernel_levels: 3,
             refraction: 1.0,
             depth: 0.16,
@@ -6144,14 +6211,33 @@ impl Default for LensEffect {
 }
 
 impl LensEffect {
-    /// Construct a lens with HIG defaults (3 Kawase levels, full refraction,
-    /// no dispersion, -45° light at 0.67 intensity, no tint) at the given
-    /// blur radius.
+    /// Construct a uniform lens with HIG defaults (3 Kawase levels, full
+    /// refraction, no dispersion, -45° light at 0.67 intensity, no tint) at
+    /// the given blur radius.
     pub fn new(radius: Pixels) -> Self {
         Self {
             radius,
+            radius_end: radius,
             ..Default::default()
         }
+    }
+
+    /// Construct a linear-gradient lens that fades the blur strength from
+    /// `from` to `to` along the given [`BlurAxis`]. Other lens parameters
+    /// keep their HIG defaults.
+    pub fn linear_gradient(from: Pixels, to: Pixels, axis: BlurAxis) -> Self {
+        Self {
+            radius: from,
+            radius_end: to,
+            gradient_direction: axis.direction(),
+            ..Default::default()
+        }
+    }
+
+    /// Override the gradient direction with an arbitrary 2D vector.
+    pub fn with_gradient_direction(mut self, direction: [f32; 2]) -> Self {
+        self.gradient_direction = direction;
+        self
     }
 }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -7,8 +7,9 @@ use crate::{
     DispatchNodeId, DispatchTree, DisplayId, Edges, Effect, Entity, EntityId, EventEmitter,
     FileDropEvent, FontId, Global, GlobalElementId, GlyphId, GpuSpecs, Hsla, InputHandler, IsZero,
     KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke, KeystrokeEvent, LayoutId,
-    LensPrimitive, LensRect, LensShape, LineLayoutIndex, Modifiers, ModifiersChangedEvent,
-    MonochromeSprite, MouseButton, MouseEvent,
+    LensPrimitive, LensRect, LensShape, LineLayoutIndex, MIRROR_AXIS_HORIZONTAL,
+    MIRROR_AXIS_VERTICAL, MirrorRect, Modifiers, ModifiersChangedEvent, MonochromeSprite,
+    MouseButton, MouseEvent,
     MouseMoveEvent, MouseUpEvent, Path, Pixels, PlatformAtlas, PlatformDisplay, PlatformInput,
     PlatformInputHandler, PlatformWindow, Point, PolychromeSprite, Priority, PromptButton,
     PromptLevel, Quad, Radians, Render, RenderGlyphParams, RenderImage, RenderImageParams,
@@ -3541,6 +3542,62 @@ impl Window {
         });
     }
 
+    /// Paint a mirrored slice of the current frame into `destination`. The
+    /// rectangle `source` is read from the framebuffer snapshot, optionally
+    /// flipped horizontally / vertically per `effect.axis`, and composited
+    /// at `destination` with an optional rounded-rect clip and tint.
+    ///
+    /// Used to extend an element beyond its own frame — SwiftUI's
+    /// `backgroundExtensionEffect()` is the direct analogue.
+    ///
+    /// Like `paint_blur_rect` and `paint_lens_rect`, each mirror rect
+    /// forces a render-pass break so the framebuffer can be sampled.
+    pub fn paint_mirror_rect(
+        &mut self,
+        source: Bounds<Pixels>,
+        destination: Bounds<Pixels>,
+        corner_radii: Corners<Pixels>,
+        effect: MirrorEffect,
+    ) {
+        self.invalidator.debug_assert_paint();
+
+        let scale_factor = self.scale_factor();
+        let content_mask = self.content_mask();
+        let opacity = self.element_opacity();
+
+        let (blur_radius, blur_radius_end, gradient_direction, kernel_levels) =
+            if let Some(blur) = effect.blur {
+                (
+                    blur.radius.scale(scale_factor),
+                    blur.radius_end.scale(scale_factor),
+                    blur.gradient_direction,
+                    blur.kernel_levels.clamp(1, 5),
+                )
+            } else {
+                (
+                    ScaledPixels(0.0),
+                    ScaledPixels(0.0),
+                    [0.0, 0.0],
+                    1,
+                )
+            };
+
+        self.next_frame.scene.insert_primitive(MirrorRect {
+            order: 0,
+            kernel_levels,
+            bounds: destination.scale(scale_factor),
+            content_mask: content_mask.scale(scale_factor),
+            corner_radii: corner_radii.scale(scale_factor),
+            source_bounds: source.scale(scale_factor),
+            mirror_axis: effect.axis.flags(),
+            clip_to_destination: if effect.clip_to_destination { 1 } else { 0 },
+            blur_radius,
+            blur_radius_end,
+            gradient_direction,
+            tint: effect.tint.opacity(opacity),
+        });
+    }
+
     /// Paint the given `Path` into the scene for the next frame at the current z-index.
     ///
     /// This method should only be called as part of the paint phase of element drawing.
@@ -6254,4 +6311,73 @@ pub struct LensShapeSpec {
     pub bounds: Bounds<Pixels>,
     /// Per-corner radii of this shape in window pixels.
     pub corner_radii: Corners<Pixels>,
+}
+
+/// How [`Window::paint_mirror_rect`] flips the sampled source region before
+/// compositing at the destination.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MirrorAxis {
+    /// Mirror left/right (flip around the vertical axis).
+    Horizontal,
+    /// Mirror top/bottom (flip around the horizontal axis).
+    Vertical,
+    /// Flip both axes — equivalent to a 180° rotation.
+    Both,
+    /// No flip; `paint_mirror_rect` becomes a translated copy of the
+    /// source region.
+    None,
+}
+
+impl MirrorAxis {
+    fn flags(self) -> u32 {
+        match self {
+            MirrorAxis::Horizontal => MIRROR_AXIS_HORIZONTAL,
+            MirrorAxis::Vertical => MIRROR_AXIS_VERTICAL,
+            MirrorAxis::Both => MIRROR_AXIS_HORIZONTAL | MIRROR_AXIS_VERTICAL,
+            MirrorAxis::None => 0,
+        }
+    }
+}
+
+/// Configuration for [`Window::paint_mirror_rect`].
+#[derive(Clone, Copy, Debug)]
+pub struct MirrorEffect {
+    /// How to flip the sampled source region.
+    pub axis: MirrorAxis,
+    /// When `true`, the mirrored sample is masked against the destination's
+    /// rounded-rect SDF so out-of-corner pixels go transparent.
+    pub clip_to_destination: bool,
+    /// Optional backdrop blur applied to the mirrored source. When
+    /// `None`, the un-blurred framebuffer snapshot is sampled directly.
+    pub blur: Option<BlurEffect>,
+    /// Color overlay applied after mirroring.
+    pub tint: Hsla,
+}
+
+impl Default for MirrorEffect {
+    fn default() -> Self {
+        Self {
+            axis: MirrorAxis::Horizontal,
+            clip_to_destination: true,
+            blur: None,
+            tint: transparent_black(),
+        }
+    }
+}
+
+impl MirrorEffect {
+    /// Construct a mirror effect with the given flip axis, clip-to-dest
+    /// enabled, no blur, and no tint.
+    pub fn new(axis: MirrorAxis) -> Self {
+        Self {
+            axis,
+            ..Default::default()
+        }
+    }
+
+    /// Override the blur to apply to the mirrored source.
+    pub fn with_blur(mut self, blur: BlurEffect) -> Self {
+        self.blur = Some(blur);
+        self
+    }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3437,10 +3437,7 @@ impl Window {
         effect: LensEffect,
     ) {
         self.paint_lens_rect_union(
-            [LensShapeSpec {
-                bounds,
-                corner_radii,
-            }],
+            [LensShapeSpec::new(bounds, corner_radii)],
             px(0.0),
             effect,
         );
@@ -3508,12 +3505,23 @@ impl Window {
             size: padded_size,
         };
 
+        // Each shape gets its own content_mask; if the caller didn't
+        // supply one, fall back to the element's content mask. Per-shape
+        // masks are intersected with the element's mask so callers can't
+        // bypass the element clip.
+        let element_mask_bounds = content_mask.bounds;
         let scaled_shapes: Vec<LensShape> = specs
             .into_iter()
-            .map(|spec| LensShape {
-                bounds: spec.bounds.scale(scale_factor),
-                corner_radii: spec.corner_radii.scale(scale_factor),
-                _pad: [0.0; 4],
+            .map(|spec| {
+                let shape_mask = spec
+                    .content_mask
+                    .map(|m| m.intersect(&element_mask_bounds))
+                    .unwrap_or(element_mask_bounds);
+                LensShape {
+                    bounds: spec.bounds.scale(scale_factor),
+                    corner_radii: spec.corner_radii.scale(scale_factor),
+                    content_mask: shape_mask.scale(scale_factor),
+                }
             })
             .collect();
 
@@ -6311,6 +6319,30 @@ pub struct LensShapeSpec {
     pub bounds: Bounds<Pixels>,
     /// Per-corner radii of this shape in window pixels.
     pub corner_radii: Corners<Pixels>,
+    /// Optional per-shape clip. `None` inherits the element's
+    /// `content_mask`. When set, fragments outside this rect softly
+    /// attenuate this shape's contribution to the smooth-min union —
+    /// adjacent shapes in the same group keep rendering normally.
+    pub content_mask: Option<Bounds<Pixels>>,
+}
+
+impl LensShapeSpec {
+    /// Construct a shape spec with no per-shape `content_mask`, inheriting
+    /// the element's clip at paint time.
+    pub fn new(bounds: Bounds<Pixels>, corner_radii: Corners<Pixels>) -> Self {
+        Self {
+            bounds,
+            corner_radii,
+            content_mask: None,
+        }
+    }
+
+    /// Chain a per-shape `content_mask` onto this spec. The mask is
+    /// intersected with the element's own `content_mask` at paint time.
+    pub fn with_content_mask(mut self, content_mask: Bounds<Pixels>) -> Self {
+        self.content_mask = Some(content_mask);
+        self
+    }
 }
 
 /// How [`Window::paint_mirror_rect`] flips the sampled source region before

--- a/crates/gpui_macos/build.rs
+++ b/crates/gpui_macos/build.rs
@@ -64,6 +64,7 @@ mod macos_build {
             "TransformationMatrix".into(),
             "BlurRect".into(),
             "LensRect".into(),
+            "LensShape".into(),
             "BlurIoInputIndex".into(),
             "BlurRectInputIndex".into(),
             "LensRectInputIndex".into(),

--- a/crates/gpui_macos/build.rs
+++ b/crates/gpui_macos/build.rs
@@ -65,10 +65,12 @@ mod macos_build {
             "BlurRect".into(),
             "LensRect".into(),
             "LensShape".into(),
+            "MirrorRect".into(),
             "SceneBlurParams".into(),
             "BlurIoInputIndex".into(),
             "BlurRectInputIndex".into(),
             "LensRectInputIndex".into(),
+            "MirrorRectInputIndex".into(),
         ]);
         config.no_includes = true;
         config.enumeration.prefix_with_name = true;

--- a/crates/gpui_macos/build.rs
+++ b/crates/gpui_macos/build.rs
@@ -65,6 +65,7 @@ mod macos_build {
             "BlurRect".into(),
             "LensRect".into(),
             "LensShape".into(),
+            "SceneBlurParams".into(),
             "BlurIoInputIndex".into(),
             "BlurRectInputIndex".into(),
             "LensRectInputIndex".into(),

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -148,6 +148,11 @@ pub(crate) struct MetalRenderer {
     /// half-sized. `BlurEffect::kernel_levels` selects the depth used per
     /// frame (1..=5).
     blur_chain_textures: [Option<metal::Texture>; BLUR_CHAIN_LEVELS],
+    /// Un-blurred copy of the framebuffer, preserved across the Kawase
+    /// chain so variable-radius blur / lens primitives can mix between
+    /// the blurred and un-blurred sources per pixel. Allocated alongside
+    /// `blur_chain_textures[0]`.
+    framebuffer_snapshot_texture: Option<metal::Texture>,
 }
 
 /// Maximum blur chain depth (`kernel_levels` is clamped to this).
@@ -450,6 +455,7 @@ impl MetalRenderer {
             lens_rect_pipeline_state,
             blur_sampler,
             blur_chain_textures: Default::default(),
+            framebuffer_snapshot_texture: None,
         }
     }
 
@@ -548,10 +554,23 @@ impl MetalRenderer {
                 );
                 self.blur_chain_textures[level] = Some(self.device.new_texture(&descriptor));
             }
+
+            let width = (size.width.0 as u64).max(1);
+            let height = (size.height.0 as u64).max(1);
+            let descriptor = metal::TextureDescriptor::new();
+            descriptor.set_width(width);
+            descriptor.set_height(height);
+            descriptor.set_pixel_format(metal::MTLPixelFormat::BGRA8Unorm);
+            descriptor.set_storage_mode(metal::MTLStorageMode::Private);
+            descriptor.set_usage(
+                metal::MTLTextureUsage::RenderTarget | metal::MTLTextureUsage::ShaderRead,
+            );
+            self.framebuffer_snapshot_texture = Some(self.device.new_texture(&descriptor));
         } else {
             for slot in &mut self.blur_chain_textures {
                 *slot = None;
             }
+            self.framebuffer_snapshot_texture = None;
         }
     }
 
@@ -881,8 +900,13 @@ impl MetalRenderer {
         let mut instance_offset = 0;
 
         let blur_kernel_levels = scene.max_blur_kernel_levels();
+        let scene_max_blur_radius = scene.max_blur_radius().0;
         let blur_offset_multiplier =
-            (scene.max_blur_radius().0 / BLUR_REFERENCE_RADIUS_PX).clamp(0.1, 4.0);
+            (scene_max_blur_radius / BLUR_REFERENCE_RADIUS_PX).clamp(0.1, 4.0);
+        let scene_blur_params = SceneBlurParams {
+            max_blur_radius: scene_max_blur_radius,
+            _pad: [0.0; 3],
+        };
         // Tracks whether the Kawase chain already reflects the drawable
         // contents since the last non-blur batch. Reset to `false` at
         // frame start and whenever any other primitive writes to the
@@ -1017,6 +1041,7 @@ impl MetalRenderer {
                         if did_snapshot {
                             self.draw_blur_rects(
                                 rects,
+                                scene_blur_params,
                                 instance_buffer,
                                 &mut instance_offset,
                                 viewport_size,
@@ -1060,6 +1085,7 @@ impl MetalRenderer {
                             self.draw_lens_rects(
                                 rects,
                                 &scene.lens_shapes,
+                                scene_blur_params,
                                 instance_buffer,
                                 &mut instance_offset,
                                 viewport_size,
@@ -1427,18 +1453,33 @@ impl MetalRenderer {
         let snapshot = self.blur_chain_textures[0]
             .as_ref()
             .expect("chain level 0 checked above");
+        let Some(ref framebuffer_snapshot) = self.framebuffer_snapshot_texture else {
+            return false;
+        };
 
         let blit = command_buffer.new_blit_command_encoder();
+        let full_size = metal::MTLSize {
+            width: texture.width(),
+            height: texture.height(),
+            depth: 1,
+        };
         blit.copy_from_texture(
             texture,
             0,
             0,
             metal::MTLOrigin { x: 0, y: 0, z: 0 },
-            metal::MTLSize {
-                width: texture.width(),
-                height: texture.height(),
-                depth: 1,
-            },
+            full_size,
+            framebuffer_snapshot,
+            0,
+            0,
+            metal::MTLOrigin { x: 0, y: 0, z: 0 },
+        );
+        blit.copy_from_texture(
+            texture,
+            0,
+            0,
+            metal::MTLOrigin { x: 0, y: 0, z: 0 },
+            full_size,
             snapshot,
             0,
             0,
@@ -1527,6 +1568,7 @@ impl MetalRenderer {
     fn draw_blur_rects(
         &self,
         rects: &[BlurRect],
+        scene_blur_params: SceneBlurParams,
         instance_buffer: &mut InstanceBuffer,
         instance_offset: &mut usize,
         viewport_size: Size<DevicePixels>,
@@ -1536,6 +1578,9 @@ impl MetalRenderer {
             return true;
         }
         let Some(ref snapshot) = self.blur_chain_textures[0] else {
+            return false;
+        };
+        let Some(ref unblurred) = self.framebuffer_snapshot_texture else {
             return false;
         };
         align_offset(instance_offset);
@@ -1566,8 +1611,15 @@ impl MetalRenderer {
             mem::size_of_val(&viewport_size) as u64,
             &viewport_size as *const Size<DevicePixels> as *const _,
         );
+        command_encoder.set_fragment_bytes(
+            BlurRectInputIndex::SceneBlurParams as u64,
+            mem::size_of::<SceneBlurParams>() as u64,
+            &scene_blur_params as *const SceneBlurParams as *const _,
+        );
         command_encoder
             .set_fragment_texture(BlurRectInputIndex::BlurTexture as u64, Some(snapshot));
+        command_encoder
+            .set_fragment_texture(BlurRectInputIndex::UnblurredTexture as u64, Some(unblurred));
         command_encoder.set_fragment_sampler_state(
             BlurRectInputIndex::BlurSampler as u64,
             Some(&self.blur_sampler),
@@ -1598,6 +1650,7 @@ impl MetalRenderer {
         &self,
         rects: &[LensRect],
         shapes: &[LensShape],
+        scene_blur_params: SceneBlurParams,
         instance_buffer: &mut InstanceBuffer,
         instance_offset: &mut usize,
         viewport_size: Size<DevicePixels>,
@@ -1612,6 +1665,9 @@ impl MetalRenderer {
             return false;
         }
         let Some(ref snapshot) = self.blur_chain_textures[0] else {
+            return false;
+        };
+        let Some(ref unblurred) = self.framebuffer_snapshot_texture else {
             return false;
         };
         align_offset(instance_offset);
@@ -1676,8 +1732,17 @@ impl MetalRenderer {
             mem::size_of_val(&viewport_size) as u64,
             &viewport_size as *const Size<DevicePixels> as *const _,
         );
+        command_encoder.set_fragment_bytes(
+            LensRectInputIndex::SceneBlurParams as u64,
+            mem::size_of::<SceneBlurParams>() as u64,
+            &scene_blur_params as *const SceneBlurParams as *const _,
+        );
         command_encoder
             .set_fragment_texture(LensRectInputIndex::BlurTexture as u64, Some(snapshot));
+        command_encoder.set_fragment_texture(
+            LensRectInputIndex::UnblurredTexture as u64,
+            Some(unblurred),
+        );
         command_encoder.set_fragment_sampler_state(
             LensRectInputIndex::BlurSampler as u64,
             Some(&self.blur_sampler),
@@ -2231,6 +2296,8 @@ enum BlurRectInputIndex {
     ViewportSize = 2,
     BlurTexture = 3,
     BlurSampler = 4,
+    UnblurredTexture = 5,
+    SceneBlurParams = 6,
 }
 
 #[repr(C)]
@@ -2241,6 +2308,21 @@ enum LensRectInputIndex {
     BlurTexture = 3,
     BlurSampler = 4,
     Shapes = 5,
+    UnblurredTexture = 6,
+    SceneBlurParams = 7,
+}
+
+/// Scene-wide blur parameters that the gradient-blur shaders use to
+/// normalize per-pixel strength. Written once per frame and bound to both
+/// `blur_rect` and `lens_rect` pipelines.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct SceneBlurParams {
+    /// Maximum `blur_radius` anywhere in the scene (see
+    /// `Scene::max_blur_radius`). Used by the shader to scale per-pixel
+    /// gradient strength into a [0, 1] mix factor.
+    max_blur_radius: f32,
+    _pad: [f32; 3],
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -147,13 +147,18 @@ pub(crate) struct MetalRenderer {
     /// Dual-Kawase scratch chain. `blur_chain_textures[0]` is surface-sized
     /// and receives the framebuffer snapshot; each subsequent level is
     /// half-sized. `BlurEffect::kernel_levels` selects the depth used per
-    /// frame (1..=5).
+    /// frame (1..=5). The upsample phase overwrites `chain[0..N-1]`, so
+    /// fragment shaders sample `blur_pyramid_texture` for intermediate
+    /// blur radii, not the chain.
     blur_chain_textures: [Option<metal::Texture>; BLUR_CHAIN_LEVELS],
-    /// Un-blurred copy of the framebuffer, preserved across the Kawase
-    /// chain so variable-radius blur / lens primitives can mix between
-    /// the blurred and un-blurred sources per pixel. Allocated alongside
-    /// `blur_chain_textures[0]`.
-    framebuffer_snapshot_texture: Option<metal::Texture>,
+    /// Preserved downsample pyramid: a single mipmapped texture where mip
+    /// 0 is the un-blurred framebuffer snapshot and each subsequent mip is
+    /// the Kawase-downsample result of the previous level. Written once
+    /// per frame after the Kawase downsample loop (before upsample would
+    /// overwrite the chain). Fragment shaders sample this with
+    /// `textureSampleLevel` at fractional LOD to produce a per-pixel
+    /// variable-radius blur.
+    blur_pyramid_texture: Option<metal::Texture>,
 }
 
 /// Maximum blur chain depth (`kernel_levels` is clamped to this).
@@ -424,6 +429,9 @@ impl MetalRenderer {
             let desc = metal::SamplerDescriptor::new();
             desc.set_min_filter(metal::MTLSamplerMinMagFilter::Linear);
             desc.set_mag_filter(metal::MTLSamplerMinMagFilter::Linear);
+            // Trilinear filtering between pyramid mip levels is what makes
+            // the per-pixel variable-radius blur smooth.
+            desc.set_mip_filter(metal::MTLSamplerMipFilter::Linear);
             desc.set_address_mode_s(metal::MTLSamplerAddressMode::ClampToEdge);
             desc.set_address_mode_t(metal::MTLSamplerAddressMode::ClampToEdge);
             device.new_sampler(&desc)
@@ -465,7 +473,7 @@ impl MetalRenderer {
             mirror_rect_pipeline_state,
             blur_sampler,
             blur_chain_textures: Default::default(),
-            framebuffer_snapshot_texture: None,
+            blur_pyramid_texture: None,
         }
     }
 
@@ -571,16 +579,15 @@ impl MetalRenderer {
             descriptor.set_width(width);
             descriptor.set_height(height);
             descriptor.set_pixel_format(metal::MTLPixelFormat::BGRA8Unorm);
+            descriptor.set_mipmap_level_count(BLUR_CHAIN_LEVELS as u64);
             descriptor.set_storage_mode(metal::MTLStorageMode::Private);
-            descriptor.set_usage(
-                metal::MTLTextureUsage::RenderTarget | metal::MTLTextureUsage::ShaderRead,
-            );
-            self.framebuffer_snapshot_texture = Some(self.device.new_texture(&descriptor));
+            descriptor.set_usage(metal::MTLTextureUsage::ShaderRead);
+            self.blur_pyramid_texture = Some(self.device.new_texture(&descriptor));
         } else {
             for slot in &mut self.blur_chain_textures {
                 *slot = None;
             }
-            self.framebuffer_snapshot_texture = None;
+            self.blur_pyramid_texture = None;
         }
     }
 
@@ -915,7 +922,8 @@ impl MetalRenderer {
             (scene_max_blur_radius / BLUR_REFERENCE_RADIUS_PX).clamp(0.1, 4.0);
         let scene_blur_params = SceneBlurParams {
             max_blur_radius: scene_max_blur_radius,
-            _pad: [0.0; 3],
+            kernel_levels: blur_kernel_levels as f32,
+            _pad: [0.0; 2],
         };
         // Tracks whether the Kawase chain already reflects the drawable
         // contents since the last non-blur batch. Reset to `false` at
@@ -1513,7 +1521,7 @@ impl MetalRenderer {
         let snapshot = self.blur_chain_textures[0]
             .as_ref()
             .expect("chain level 0 checked above");
-        let Some(ref framebuffer_snapshot) = self.framebuffer_snapshot_texture else {
+        let Some(ref pyramid) = self.blur_pyramid_texture else {
             return false;
         };
 
@@ -1523,13 +1531,15 @@ impl MetalRenderer {
             height: texture.height(),
             depth: 1,
         };
+        // Mip 0 of the pyramid is the un-blurred framebuffer; the Kawase
+        // chain runs in parallel on `blur_chain_textures`.
         blit.copy_from_texture(
             texture,
             0,
             0,
             metal::MTLOrigin { x: 0, y: 0, z: 0 },
             full_size,
-            framebuffer_snapshot,
+            pyramid,
             0,
             0,
             metal::MTLOrigin { x: 0, y: 0, z: 0 },
@@ -1568,6 +1578,35 @@ impl MetalRenderer {
                 },
             );
         }
+
+        // Preserve the downsample chain into pyramid mip levels before the
+        // upsample loop overwrites `chain[0..N-1]`. Each `chain[i]` is the
+        // /2^i-sized result of `i` Kawase downsample passes, which maps to
+        // pyramid mip level `i`.
+        let preserve_blit = command_buffer.new_blit_command_encoder();
+        for i in 1..=kernel_levels {
+            let src = self.blur_chain_textures[i]
+                .as_ref()
+                .expect("chain level checked above");
+            let width = ((viewport_size.width.0 as u64) >> i).max(1);
+            let height = ((viewport_size.height.0 as u64) >> i).max(1);
+            preserve_blit.copy_from_texture(
+                src,
+                0,
+                0,
+                metal::MTLOrigin { x: 0, y: 0, z: 0 },
+                metal::MTLSize {
+                    width,
+                    height,
+                    depth: 1,
+                },
+                pyramid,
+                0,
+                i as u64,
+                metal::MTLOrigin { x: 0, y: 0, z: 0 },
+            );
+        }
+        preserve_blit.end_encoding();
 
         for step in 0..kernel_levels {
             let src_level = kernel_levels - step;
@@ -1637,10 +1676,7 @@ impl MetalRenderer {
         if rects.is_empty() {
             return true;
         }
-        let Some(ref snapshot) = self.blur_chain_textures[0] else {
-            return false;
-        };
-        let Some(ref unblurred) = self.framebuffer_snapshot_texture else {
+        let Some(ref pyramid) = self.blur_pyramid_texture else {
             return false;
         };
         align_offset(instance_offset);
@@ -1677,9 +1713,7 @@ impl MetalRenderer {
             &scene_blur_params as *const SceneBlurParams as *const _,
         );
         command_encoder
-            .set_fragment_texture(BlurRectInputIndex::BlurTexture as u64, Some(snapshot));
-        command_encoder
-            .set_fragment_texture(BlurRectInputIndex::UnblurredTexture as u64, Some(unblurred));
+            .set_fragment_texture(BlurRectInputIndex::BlurPyramid as u64, Some(pyramid));
         command_encoder.set_fragment_sampler_state(
             BlurRectInputIndex::BlurSampler as u64,
             Some(&self.blur_sampler),
@@ -1724,10 +1758,7 @@ impl MetalRenderer {
         if shapes.is_empty() {
             return false;
         }
-        let Some(ref snapshot) = self.blur_chain_textures[0] else {
-            return false;
-        };
-        let Some(ref unblurred) = self.framebuffer_snapshot_texture else {
+        let Some(ref pyramid) = self.blur_pyramid_texture else {
             return false;
         };
         align_offset(instance_offset);
@@ -1798,11 +1829,7 @@ impl MetalRenderer {
             &scene_blur_params as *const SceneBlurParams as *const _,
         );
         command_encoder
-            .set_fragment_texture(LensRectInputIndex::BlurTexture as u64, Some(snapshot));
-        command_encoder.set_fragment_texture(
-            LensRectInputIndex::UnblurredTexture as u64,
-            Some(unblurred),
-        );
+            .set_fragment_texture(LensRectInputIndex::BlurPyramid as u64, Some(pyramid));
         command_encoder.set_fragment_sampler_state(
             LensRectInputIndex::BlurSampler as u64,
             Some(&self.blur_sampler),
@@ -1830,10 +1857,7 @@ impl MetalRenderer {
         if rects.is_empty() {
             return true;
         }
-        let Some(ref snapshot) = self.blur_chain_textures[0] else {
-            return false;
-        };
-        let Some(ref unblurred) = self.framebuffer_snapshot_texture else {
+        let Some(ref pyramid) = self.blur_pyramid_texture else {
             return false;
         };
         align_offset(instance_offset);
@@ -1870,11 +1894,7 @@ impl MetalRenderer {
             &scene_blur_params as *const SceneBlurParams as *const _,
         );
         command_encoder
-            .set_fragment_texture(MirrorRectInputIndex::BlurTexture as u64, Some(snapshot));
-        command_encoder.set_fragment_texture(
-            MirrorRectInputIndex::UnblurredTexture as u64,
-            Some(unblurred),
-        );
+            .set_fragment_texture(MirrorRectInputIndex::BlurPyramid as u64, Some(pyramid));
         command_encoder.set_fragment_sampler_state(
             MirrorRectInputIndex::BlurSampler as u64,
             Some(&self.blur_sampler),
@@ -2436,10 +2456,12 @@ enum BlurRectInputIndex {
     Vertices = 0,
     Rects = 1,
     ViewportSize = 2,
-    BlurTexture = 3,
+    /// Mipmapped pyramid: mip 0 is un-blurred, each subsequent mip is a
+    /// Kawase downsample step. The fragment shader picks a fractional
+    /// LOD based on per-pixel target blur radius.
+    BlurPyramid = 3,
     BlurSampler = 4,
-    UnblurredTexture = 5,
-    SceneBlurParams = 6,
+    SceneBlurParams = 5,
 }
 
 #[repr(C)]
@@ -2447,11 +2469,10 @@ enum LensRectInputIndex {
     Vertices = 0,
     Rects = 1,
     ViewportSize = 2,
-    BlurTexture = 3,
+    BlurPyramid = 3,
     BlurSampler = 4,
     Shapes = 5,
-    UnblurredTexture = 6,
-    SceneBlurParams = 7,
+    SceneBlurParams = 6,
 }
 
 #[repr(C)]
@@ -2459,23 +2480,26 @@ enum MirrorRectInputIndex {
     Vertices = 0,
     Rects = 1,
     ViewportSize = 2,
-    BlurTexture = 3,
+    BlurPyramid = 3,
     BlurSampler = 4,
-    UnblurredTexture = 5,
-    SceneBlurParams = 6,
+    SceneBlurParams = 5,
 }
 
 /// Scene-wide blur parameters that the gradient-blur shaders use to
-/// normalize per-pixel strength. Written once per frame and bound to both
-/// `blur_rect` and `lens_rect` pipelines.
+/// compute a per-pixel mip level into the preserved downsample pyramid.
+/// Written once per frame and bound to every blur-consuming pipeline.
 #[repr(C)]
 #[derive(Clone, Copy)]
 struct SceneBlurParams {
     /// Maximum `blur_radius` anywhere in the scene (see
-    /// `Scene::max_blur_radius`). Used by the shader to scale per-pixel
-    /// gradient strength into a [0, 1] mix factor.
+    /// `Scene::max_blur_radius`). The per-pixel `target_radius / max`
+    /// ratio becomes the `strength` input to the log2 mip-level formula.
     max_blur_radius: f32,
-    _pad: [f32; 3],
+    /// Number of Kawase downsample passes actually run this frame, as an
+    /// `f32` for the shader's `log2(strength)` clamping math. Matches
+    /// `Scene::max_blur_kernel_levels`.
+    kernel_levels: f32,
+    _pad: [f32; 2],
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -7,7 +7,7 @@ use cocoa::{
     quartzcore::AutoresizingMask,
 };
 use gpui::{
-    AtlasTextureId, Background, BlurRect, Bounds, ContentMask, DevicePixels, LensRect,
+    AtlasTextureId, Background, BlurRect, Bounds, ContentMask, DevicePixels, LensRect, LensShape,
     MonochromeSprite, PaintSurface, Path, Point, PolychromeSprite, PrimitiveBatch, Quad,
     ScaledPixels, Scene, Shadow, Size, Surface, Underline, point, size,
 };
@@ -1059,6 +1059,7 @@ impl MetalRenderer {
                         if did_snapshot {
                             self.draw_lens_rects(
                                 rects,
+                                &scene.lens_shapes,
                                 instance_buffer,
                                 &mut instance_offset,
                                 viewport_size,
@@ -1596,6 +1597,7 @@ impl MetalRenderer {
     fn draw_lens_rects(
         &self,
         rects: &[LensRect],
+        shapes: &[LensShape],
         instance_buffer: &mut InstanceBuffer,
         instance_offset: &mut usize,
         viewport_size: Size<DevicePixels>,
@@ -1604,10 +1606,39 @@ impl MetalRenderer {
         if rects.is_empty() {
             return true;
         }
+        // Shapes cannot be empty if any rect references them; fail rather
+        // than bind a zero-length buffer (Metal doesn't accept that).
+        if shapes.is_empty() {
+            return false;
+        }
         let Some(ref snapshot) = self.blur_chain_textures[0] else {
             return false;
         };
         align_offset(instance_offset);
+        let rects_offset = *instance_offset;
+        let rects_bytes = mem::size_of_val(rects);
+        let after_rects = rects_offset + rects_bytes;
+        if after_rects > instance_buffer.size {
+            return false;
+        }
+        unsafe {
+            let dst =
+                (instance_buffer.metal_buffer.contents() as *mut u8).add(rects_offset);
+            ptr::copy_nonoverlapping(rects.as_ptr() as *const u8, dst, rects_bytes);
+        }
+
+        let mut shapes_offset = after_rects;
+        align_offset(&mut shapes_offset);
+        let shapes_bytes = mem::size_of_val(shapes);
+        let after_shapes = shapes_offset + shapes_bytes;
+        if after_shapes > instance_buffer.size {
+            return false;
+        }
+        unsafe {
+            let dst =
+                (instance_buffer.metal_buffer.contents() as *mut u8).add(shapes_offset);
+            ptr::copy_nonoverlapping(shapes.as_ptr() as *const u8, dst, shapes_bytes);
+        }
 
         command_encoder.set_render_pipeline_state(&self.lens_rect_pipeline_state);
         command_encoder.set_vertex_buffer(
@@ -1618,12 +1649,22 @@ impl MetalRenderer {
         command_encoder.set_vertex_buffer(
             LensRectInputIndex::Rects as u64,
             Some(&instance_buffer.metal_buffer),
-            *instance_offset as u64,
+            rects_offset as u64,
         );
         command_encoder.set_fragment_buffer(
             LensRectInputIndex::Rects as u64,
             Some(&instance_buffer.metal_buffer),
-            *instance_offset as u64,
+            rects_offset as u64,
+        );
+        command_encoder.set_vertex_buffer(
+            LensRectInputIndex::Shapes as u64,
+            Some(&instance_buffer.metal_buffer),
+            shapes_offset as u64,
+        );
+        command_encoder.set_fragment_buffer(
+            LensRectInputIndex::Shapes as u64,
+            Some(&instance_buffer.metal_buffer),
+            shapes_offset as u64,
         );
         command_encoder.set_vertex_bytes(
             LensRectInputIndex::ViewportSize as u64,
@@ -1642,24 +1683,13 @@ impl MetalRenderer {
             Some(&self.blur_sampler),
         );
 
-        let bytes_len = mem::size_of_val(rects);
-        let next_offset = *instance_offset + bytes_len;
-        if next_offset > instance_buffer.size {
-            return false;
-        }
-        let buffer_contents =
-            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
-        unsafe {
-            ptr::copy_nonoverlapping(rects.as_ptr() as *const u8, buffer_contents, bytes_len);
-        }
-
         command_encoder.draw_primitives_instanced(
             metal::MTLPrimitiveType::Triangle,
             0,
             6,
             rects.len() as u64,
         );
-        *instance_offset = next_offset;
+        *instance_offset = after_shapes;
         true
     }
 
@@ -2210,6 +2240,7 @@ enum LensRectInputIndex {
     ViewportSize = 2,
     BlurTexture = 3,
     BlurSampler = 4,
+    Shapes = 5,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -8,8 +8,8 @@ use cocoa::{
 };
 use gpui::{
     AtlasTextureId, Background, BlurRect, Bounds, ContentMask, DevicePixels, LensRect, LensShape,
-    MonochromeSprite, PaintSurface, Path, Point, PolychromeSprite, PrimitiveBatch, Quad,
-    ScaledPixels, Scene, Shadow, Size, Surface, Underline, point, size,
+    MirrorRect, MonochromeSprite, PaintSurface, Path, Point, PolychromeSprite, PrimitiveBatch,
+    Quad, ScaledPixels, Scene, Shadow, Size, Surface, Underline, point, size,
 };
 #[cfg(any(test, feature = "test-support"))]
 use image::RgbaImage;
@@ -142,6 +142,7 @@ pub(crate) struct MetalRenderer {
     blur_upsample_pipeline_state: metal::RenderPipelineState,
     blur_rect_pipeline_state: metal::RenderPipelineState,
     lens_rect_pipeline_state: metal::RenderPipelineState,
+    mirror_rect_pipeline_state: metal::RenderPipelineState,
     blur_sampler: metal::SamplerState,
     /// Dual-Kawase scratch chain. `blur_chain_textures[0]` is surface-sized
     /// and receives the framebuffer snapshot; each subsequent level is
@@ -410,6 +411,14 @@ impl MetalRenderer {
             "lens_rect_fragment",
             MTLPixelFormat::BGRA8Unorm,
         );
+        let mirror_rect_pipeline_state = build_pipeline_state(
+            &device,
+            &library,
+            "mirror_rect",
+            "mirror_rect_vertex",
+            "mirror_rect_fragment",
+            MTLPixelFormat::BGRA8Unorm,
+        );
 
         let blur_sampler = {
             let desc = metal::SamplerDescriptor::new();
@@ -453,6 +462,7 @@ impl MetalRenderer {
             blur_upsample_pipeline_state,
             blur_rect_pipeline_state,
             lens_rect_pipeline_state,
+            mirror_rect_pipeline_state,
             blur_sampler,
             blur_chain_textures: Default::default(),
             framebuffer_snapshot_texture: None,
@@ -926,7 +936,9 @@ impl MetalRenderer {
         for batch in scene.batches() {
             let is_blur_batch = matches!(
                 batch,
-                PrimitiveBatch::BlurRects(_) | PrimitiveBatch::LensRects(_)
+                PrimitiveBatch::BlurRects(_)
+                    | PrimitiveBatch::LensRects(_)
+                    | PrimitiveBatch::MirrorRects(_)
             );
             let ok = match batch {
                 PrimitiveBatch::Shadows(range) => self.draw_shadows(
@@ -1096,11 +1108,58 @@ impl MetalRenderer {
                         }
                     }
                 }
+                PrimitiveBatch::MirrorRects(range) => {
+                    let rects = &scene.mirror_rects[range];
+                    if rects.is_empty() || !self.frame_sampling_enabled {
+                        true
+                    } else {
+                        command_encoder.end_encoding();
+                        // Mirror always needs the un-blurred snapshot;
+                        // also run the Kawase chain so blur-enabled mirror
+                        // rects have a source to mix against.
+                        let did_snapshot = if blur_snapshot_valid {
+                            true
+                        } else {
+                            let levels = blur_kernel_levels.max(1);
+                            let ok = self.snapshot_and_blur_frame(
+                                texture,
+                                viewport_size,
+                                levels,
+                                blur_offset_multiplier,
+                                command_buffer,
+                            );
+                            if ok {
+                                blur_snapshot_valid = true;
+                            }
+                            ok
+                        };
+                        command_encoder = new_command_encoder_for_texture(
+                            command_buffer,
+                            texture,
+                            viewport_size,
+                            |color_attachment| {
+                                color_attachment.set_load_action(metal::MTLLoadAction::Load);
+                            },
+                        );
+                        if did_snapshot {
+                            self.draw_mirror_rects(
+                                rects,
+                                scene_blur_params,
+                                instance_buffer,
+                                &mut instance_offset,
+                                viewport_size,
+                                command_encoder,
+                            )
+                        } else {
+                            true
+                        }
+                    }
+                }
             };
             if !ok {
                 command_encoder.end_encoding();
                 anyhow::bail!(
-                    "scene too large: {} paths, {} shadows, {} quads, {} underlines, {} mono, {} poly, {} surfaces, {} blur rects, {} lens rects",
+                    "scene too large: {} paths, {} shadows, {} quads, {} underlines, {} mono, {} poly, {} surfaces, {} blur rects, {} lens rects, {} mirror rects",
                     scene.paths.len(),
                     scene.shadows.len(),
                     scene.quads.len(),
@@ -1110,6 +1169,7 @@ impl MetalRenderer {
                     scene.surfaces.len(),
                     scene.blur_rects.len(),
                     scene.lens_rects.len(),
+                    scene.mirror_rects.len(),
                 );
             }
             if !is_blur_batch {
@@ -1758,6 +1818,88 @@ impl MetalRenderer {
         true
     }
 
+    fn draw_mirror_rects(
+        &self,
+        rects: &[MirrorRect],
+        scene_blur_params: SceneBlurParams,
+        instance_buffer: &mut InstanceBuffer,
+        instance_offset: &mut usize,
+        viewport_size: Size<DevicePixels>,
+        command_encoder: &metal::RenderCommandEncoderRef,
+    ) -> bool {
+        if rects.is_empty() {
+            return true;
+        }
+        let Some(ref snapshot) = self.blur_chain_textures[0] else {
+            return false;
+        };
+        let Some(ref unblurred) = self.framebuffer_snapshot_texture else {
+            return false;
+        };
+        align_offset(instance_offset);
+
+        command_encoder.set_render_pipeline_state(&self.mirror_rect_pipeline_state);
+        command_encoder.set_vertex_buffer(
+            MirrorRectInputIndex::Vertices as u64,
+            Some(&self.unit_vertices),
+            0,
+        );
+        command_encoder.set_vertex_buffer(
+            MirrorRectInputIndex::Rects as u64,
+            Some(&instance_buffer.metal_buffer),
+            *instance_offset as u64,
+        );
+        command_encoder.set_fragment_buffer(
+            MirrorRectInputIndex::Rects as u64,
+            Some(&instance_buffer.metal_buffer),
+            *instance_offset as u64,
+        );
+        command_encoder.set_vertex_bytes(
+            MirrorRectInputIndex::ViewportSize as u64,
+            mem::size_of_val(&viewport_size) as u64,
+            &viewport_size as *const Size<DevicePixels> as *const _,
+        );
+        command_encoder.set_fragment_bytes(
+            MirrorRectInputIndex::ViewportSize as u64,
+            mem::size_of_val(&viewport_size) as u64,
+            &viewport_size as *const Size<DevicePixels> as *const _,
+        );
+        command_encoder.set_fragment_bytes(
+            MirrorRectInputIndex::SceneBlurParams as u64,
+            mem::size_of::<SceneBlurParams>() as u64,
+            &scene_blur_params as *const SceneBlurParams as *const _,
+        );
+        command_encoder
+            .set_fragment_texture(MirrorRectInputIndex::BlurTexture as u64, Some(snapshot));
+        command_encoder.set_fragment_texture(
+            MirrorRectInputIndex::UnblurredTexture as u64,
+            Some(unblurred),
+        );
+        command_encoder.set_fragment_sampler_state(
+            MirrorRectInputIndex::BlurSampler as u64,
+            Some(&self.blur_sampler),
+        );
+
+        let bytes_len = mem::size_of_val(rects);
+        let next_offset = *instance_offset + bytes_len;
+        if next_offset > instance_buffer.size {
+            return false;
+        }
+        unsafe {
+            let dst = (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset);
+            ptr::copy_nonoverlapping(rects.as_ptr() as *const u8, dst, bytes_len);
+        }
+
+        command_encoder.draw_primitives_instanced(
+            metal::MTLPrimitiveType::Triangle,
+            0,
+            6,
+            rects.len() as u64,
+        );
+        *instance_offset = next_offset;
+        true
+    }
+
     fn draw_underlines(
         &self,
         underlines: &[Underline],
@@ -2312,6 +2454,17 @@ enum LensRectInputIndex {
     SceneBlurParams = 7,
 }
 
+#[repr(C)]
+enum MirrorRectInputIndex {
+    Vertices = 0,
+    Rects = 1,
+    ViewportSize = 2,
+    BlurTexture = 3,
+    BlurSampler = 4,
+    UnblurredTexture = 5,
+    SceneBlurParams = 6,
+}
+
 /// Scene-wide blur parameters that the gradient-blur shaders use to
 /// normalize per-pixel strength. Written once per frame and bound to both
 /// `blur_rect` and `lens_rect` pipelines.
@@ -2392,5 +2545,6 @@ mod tests {
         let _ = renderer.blur_upsample_pipeline_state.as_ptr();
         let _ = renderer.blur_rect_pipeline_state.as_ptr();
         let _ = renderer.lens_rect_pipeline_state.as_ptr();
+        let _ = renderer.mirror_rect_pipeline_state.as_ptr();
     }
 }

--- a/crates/gpui_macos/src/shaders.metal
+++ b/crates/gpui_macos/src/shaders.metal
@@ -1394,6 +1394,12 @@ fragment float4 blur_rect_fragment(
 }
 
 // --- LensRect: Liquid Glass composite (refraction + CA + Fresnel) ---
+//
+// Multi-shape lens: the fragment loops over
+// `rect.shape_offset..shape_offset + shape_count` in the `shapes` storage
+// buffer, computing a per-shape SDF + parabolic refraction direction, then
+// smooth-min-blends them by `rect.edge_blend_distance` so overlapping shapes
+// morph into one continuous lens.
 
 struct LensRectVarying {
   uint rect_id [[flat]];
@@ -1415,7 +1421,8 @@ vertex LensRectVarying lens_rect_vertex(
   uint rect_id [[instance_id]],
   constant float2 *unit_vertices [[buffer(LensRectInputIndex_Vertices)]],
   constant LensRect *rects [[buffer(LensRectInputIndex_Rects)]],
-  constant Size_DevicePixels *viewport_size [[buffer(LensRectInputIndex_ViewportSize)]]
+  constant Size_DevicePixels *viewport_size [[buffer(LensRectInputIndex_ViewportSize)]],
+  constant LensShape *shapes [[buffer(LensRectInputIndex_Shapes)]]
 ) {
   float2 unit_vertex = unit_vertices[unit_vertex_id];
   LensRect rect = rects[rect_id];
@@ -1423,11 +1430,16 @@ vertex LensRectVarying lens_rect_vertex(
   out.position = to_device_position(unit_vertex, rect.bounds, viewport_size);
   out.rect_id = rect_id;
   out.light_dir = float2(cos(rect.light_angle_radians), sin(rect.light_angle_radians));
+  // Use the first shape's corner radii as the edge-band reference. Shapes
+  // in a union typically share a radius; if they don't, the visible
+  // difference in the Fresnel band width is minor compared to the other
+  // shader outputs.
+  LensShape shape0 = shapes[rect.shape_offset];
   float corner_avg = 0.25 * (
-    rect.corner_radii.top_left
-    + rect.corner_radii.top_right
-    + rect.corner_radii.bottom_right
-    + rect.corner_radii.bottom_left
+    shape0.corner_radii.top_left
+    + shape0.corner_radii.top_right
+    + shape0.corner_radii.bottom_right
+    + shape0.corner_radii.bottom_left
   );
   float splay_px = max(rect.splay, 1.0);
   out.edge_band = max(corner_avg * 0.5, splay_px);
@@ -1444,38 +1456,107 @@ fragment float4 lens_rect_fragment(
   constant LensRect *rects [[buffer(LensRectInputIndex_Rects)]],
   constant Size_DevicePixels *viewport_size [[buffer(LensRectInputIndex_ViewportSize)]],
   texture2d<float> blur_input [[texture(LensRectInputIndex_BlurTexture)]],
-  sampler blur_sampler [[sampler(LensRectInputIndex_BlurSampler)]]
+  sampler blur_sampler [[sampler(LensRectInputIndex_BlurSampler)]],
+  constant LensShape *shapes [[buffer(LensRectInputIndex_Shapes)]]
 ) {
   LensRect rect = rects[input.rect_id];
   float2 viewport_f = float2((float)viewport_size->width, (float)viewport_size->height);
 
-  float sdf = quad_sdf(input.position.xy, rect.bounds, rect.corner_radii);
+  float2 frag_pos = input.position.xy;
+  uint shape_count = rect.shape_count;
+  if (shape_count == 0u) {
+    discard_fragment();
+  }
+  float blend_k = max(rect.edge_blend_distance, 0.0);
+  bool blend_shapes = blend_k > 0.0 && shape_count > 1u;
+
+  // Pass 1: accumulate per-shape SDFs; pick softmin/hardmin weights and
+  // tracked union SDF.
+  float per_shape_sdf[8];
+  float2 per_shape_dir[8];
+  float per_shape_norm_dist[8];
+  float min_sdf = 1e20;
+  for (uint i = 0u; i < shape_count; ++i) {
+    LensShape s = shapes[rect.shape_offset + i];
+    float d = quad_sdf(frag_pos, s.bounds, s.corner_radii);
+    per_shape_sdf[i] = d;
+    min_sdf = min(min_sdf, d);
+
+    float2 origin = float2(s.bounds.origin.x, s.bounds.origin.y);
+    float2 size = float2(s.bounds.size.width, s.bounds.size.height);
+    float2 center = origin + size * 0.5;
+    float2 half_size = size * 0.5;
+    float2 local_pos = frag_pos - center;
+    float local_len = length(local_pos);
+    per_shape_dir[i] = local_len > 0.001 ? local_pos / max(local_len, 0.0001) : float2(0.0, 0.0);
+    float2 safe_half = max(half_size, float2(1.0, 1.0));
+    per_shape_norm_dist[i] = clamp(length(local_pos / safe_half), 0.0, 1.0);
+  }
+
+  float union_sdf;
+  float weights[8];
+  float total_weight = 0.0;
+  if (blend_shapes) {
+    // Exponential smooth-minimum (polynomial order 8). Each weight is
+    // `exp(-d_i / k)`, normalized so they sum to 1. As `k -> 0` the weight
+    // on the minimum shape approaches 1 — identical to hard union.
+    float min_d = min_sdf;
+    for (uint i = 0u; i < shape_count; ++i) {
+      float w = exp(-(per_shape_sdf[i] - min_d) / blend_k);
+      weights[i] = w;
+      total_weight += w;
+    }
+    // Softmin value: -k * log(Σ exp(-d_i / k)), shifted by min_d to avoid
+    // overflow. Yields the smooth-min distance used for AA and Fresnel.
+    union_sdf = min_d - blend_k * log(max(total_weight, 1e-6));
+    // Normalize weights.
+    float inv_total = 1.0 / max(total_weight, 1e-6);
+    for (uint i = 0u; i < shape_count; ++i) {
+      weights[i] *= inv_total;
+    }
+  } else {
+    // Single shape or hard union: pick the min-SDF shape deterministically.
+    uint winner = 0u;
+    float min_d = per_shape_sdf[0];
+    for (uint i = 1u; i < shape_count; ++i) {
+      if (per_shape_sdf[i] < min_d) {
+        min_d = per_shape_sdf[i];
+        winner = i;
+      }
+    }
+    union_sdf = min_d;
+    for (uint i = 0u; i < shape_count; ++i) {
+      weights[i] = (i == winner) ? 1.0 : 0.0;
+    }
+  }
+
   const float antialias_threshold = 0.5;
-  float aa = saturate(antialias_threshold - sdf);
+  float aa = saturate(antialias_threshold - union_sdf);
   if (aa <= 0.0) {
     discard_fragment();
   }
 
-  float2 origin = float2(rect.bounds.origin.x, rect.bounds.origin.y);
-  float2 size = float2(rect.bounds.size.width, rect.bounds.size.height);
-  float2 center = origin + size * 0.5;
-  float2 half_size = size * 0.5;
-  float2 local_pos = input.position.xy - center;
-  float local_len = length(local_pos);
-  float2 direction = local_len > 0.001 ? local_pos / max(local_len, 0.0001) : float2(0.0, 0.0);
-  float2 safe_half = max(half_size, float2(1.0, 1.0));
-  float normalized_dist = clamp(length(local_pos / safe_half), 0.0, 1.0);
-
+  // Pass 2: weighted refraction offset. The per-shape parabolic distortion
+  // (`(1 - r^2) * direction * refraction / 2`) is softmin-weighted so fields
+  // from merging shapes blend instead of clipping.
   float depth_scale = clamp(rect.depth * 0.01, 0.0, 1.0);
-  float distortion = (1.0 - normalized_dist * normalized_dist) * (1.0 + depth_scale);
-  float2 offset_px = distortion * direction * rect.refraction * 0.5;
-  float2 base_uv = input.position.xy / viewport_f;
+  float2 offset_px = float2(0.0, 0.0);
+  float weighted_norm_dist = 0.0;
+  float2 weighted_dir = float2(0.0, 0.0);
+  for (uint i = 0u; i < shape_count; ++i) {
+    float nd = per_shape_norm_dist[i];
+    float distortion = (1.0 - nd * nd) * (1.0 + depth_scale);
+    offset_px += weights[i] * (distortion * per_shape_dir[i] * rect.refraction * 0.5);
+    weighted_norm_dist += weights[i] * nd;
+    weighted_dir += weights[i] * per_shape_dir[i];
+  }
+  float2 base_uv = frag_pos / viewport_f;
   float2 refracted_uv = base_uv - offset_px / viewport_f;
 
   float4 color;
   if (rect.dispersion > 0.0) {
-    float ca_shift = normalized_dist * rect.dispersion;
-    float2 ca_dir = direction / viewport_f;
+    float ca_shift = weighted_norm_dist * rect.dispersion;
+    float2 ca_dir = weighted_dir / viewport_f;
     color.r = blur_input.sample(blur_sampler, refracted_uv - ca_dir * ca_shift).r;
     color.g = blur_input.sample(blur_sampler, refracted_uv).g;
     color.b = blur_input.sample(blur_sampler, refracted_uv + ca_dir * ca_shift).b;
@@ -1488,9 +1569,12 @@ fragment float4 lens_rect_fragment(
   color = float4(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
 
   if (rect.light_intensity > 0.0) {
-    float edge_dist = fabs(sdf);
+    float edge_dist = fabs(union_sdf);
     float edge_falloff = smoothstep(input.edge_band, 0.0, edge_dist);
-    float facing = local_len > 0.001 ? clamp(dot(direction, input.light_dir), 0.0, 1.0) : 1.0;
+    float weighted_len = length(weighted_dir);
+    float facing = weighted_len > 0.001
+      ? clamp(dot(weighted_dir / weighted_len, input.light_dir), 0.0, 1.0)
+      : 1.0;
     float edge_glow = edge_falloff * facing * rect.light_intensity;
     color = color + float4(edge_glow, edge_glow, edge_glow, 0.0);
   }

--- a/crates/gpui_macos/src/shaders.metal
+++ b/crates/gpui_macos/src/shaders.metal
@@ -1373,61 +1373,69 @@ vertex BlurRectVarying blur_rect_vertex(
   return out;
 }
 
-// Compute the per-pixel mix factor between the un-blurred and max-blurred
-// sources for a linear-gradient blur. Returns 1.0 (full blur) when the
-// gradient is disabled (`gradient_direction == 0`).
-//
-// This is a `mix(unblurred, max-blurred, t)` approximation. It's visually
-// plausible for HIG scroll-edge fades but not a true per-pixel Gaussian.
-// Mid-range `t` values diverge from a true variable-radius blur; the
-// documented follow-up (mip-pyramid sampling of preserved downsample
-// intermediates) is out of scope for this change.
-float gradient_blur_strength(
+// Compute the per-pixel target blur radius for a linear-gradient blur.
+// Uniform-blur paths (gradient_direction == 0) return `radius_start`.
+float gradient_target_radius(
     float2 frag_pos,
     Bounds_ScaledPixels bounds,
     float radius_start,
     float radius_end,
-    float2 gradient_direction,
-    float scene_max_radius
+    float2 gradient_direction
 ) {
-  if (scene_max_radius <= 0.0) {
-    return 0.0;
-  }
   float dir_len2 = dot(gradient_direction, gradient_direction);
   if (dir_len2 < 1e-6) {
-    return clamp(radius_start / scene_max_radius, 0.0, 1.0);
+    return radius_start;
   }
   float2 local = frag_pos - float2(bounds.origin.x, bounds.origin.y);
   float2 size_v = float2(bounds.size.width, bounds.size.height);
   float extent = max(dot(size_v, gradient_direction), 1.0);
   float t = clamp(dot(local, gradient_direction) / extent, 0.0, 1.0);
-  float target = mix(radius_start, radius_end, t);
-  return clamp(target / scene_max_radius, 0.0, 1.0);
+  return mix(radius_start, radius_end, t);
+}
+
+// Sample the preserved Kawase downsample pyramid at a per-pixel blur
+// radius. Mip level 0 is the un-blurred framebuffer; each subsequent mip
+// is a /2-sized Kawase downsample of the previous, so the effective
+// Gaussian sigma roughly doubles per level. Choosing
+// `level = kernel_levels + log2(strength)` matches this exponential
+// spacing — doubling the target radius bumps level by 1 — and trilinear
+// filtering between mips produces a smooth per-pixel variable-radius
+// blur.
+float4 sample_blur_pyramid(
+    texture2d<float> pyramid,
+    sampler pyramid_sampler,
+    float2 uv,
+    float target_radius,
+    constant SceneBlurParams *scene_blur
+) {
+  if (scene_blur->max_blur_radius <= 0.0) {
+    return pyramid.sample(pyramid_sampler, uv, level(0.0));
+  }
+  float strength = clamp(target_radius / scene_blur->max_blur_radius, 0.0, 1.0);
+  float level_f = scene_blur->kernel_levels + log2(max(strength, 1e-6));
+  level_f = clamp(level_f, 0.0, scene_blur->kernel_levels);
+  return pyramid.sample(pyramid_sampler, uv, level(level_f));
 }
 
 fragment float4 blur_rect_fragment(
   BlurRectFragmentInput input [[stage_in]],
   constant BlurRect *rects [[buffer(BlurRectInputIndex_Rects)]],
   constant Size_DevicePixels *viewport_size [[buffer(BlurRectInputIndex_ViewportSize)]],
-  texture2d<float> blur_input [[texture(BlurRectInputIndex_BlurTexture)]],
+  texture2d<float> blur_pyramid [[texture(BlurRectInputIndex_BlurPyramid)]],
   sampler blur_sampler [[sampler(BlurRectInputIndex_BlurSampler)]],
-  texture2d<float> unblurred_input [[texture(BlurRectInputIndex_UnblurredTexture)]],
   constant SceneBlurParams *scene_blur [[buffer(BlurRectInputIndex_SceneBlurParams)]]
 ) {
   BlurRect rect = rects[input.rect_id];
   float2 viewport_f = float2((float)viewport_size->width, (float)viewport_size->height);
   float2 fb_uv = input.position.xy / viewport_f;
-  float strength = gradient_blur_strength(
+  float target_radius = gradient_target_radius(
     input.position.xy,
     rect.bounds,
     rect.blur_radius,
     rect.blur_radius_end,
-    float2(rect.gradient_direction[0], rect.gradient_direction[1]),
-    scene_blur->max_blur_radius
+    float2(rect.gradient_direction[0], rect.gradient_direction[1])
   );
-  float4 blurred = blur_input.sample(blur_sampler, fb_uv);
-  float4 sharp = unblurred_input.sample(blur_sampler, fb_uv);
-  float4 color = mix(sharp, blurred, strength);
+  float4 color = sample_blur_pyramid(blur_pyramid, blur_sampler, fb_uv, target_radius, scene_blur);
   float4 tint_rgba = hsla_to_rgba(rect.tint);
   color = float4(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
 
@@ -1499,10 +1507,9 @@ fragment float4 lens_rect_fragment(
   LensRectFragmentInput input [[stage_in]],
   constant LensRect *rects [[buffer(LensRectInputIndex_Rects)]],
   constant Size_DevicePixels *viewport_size [[buffer(LensRectInputIndex_ViewportSize)]],
-  texture2d<float> blur_input [[texture(LensRectInputIndex_BlurTexture)]],
+  texture2d<float> blur_pyramid [[texture(LensRectInputIndex_BlurPyramid)]],
   sampler blur_sampler [[sampler(LensRectInputIndex_BlurSampler)]],
   constant LensShape *shapes [[buffer(LensRectInputIndex_Shapes)]],
-  texture2d<float> unblurred_input [[texture(LensRectInputIndex_UnblurredTexture)]],
   constant SceneBlurParams *scene_blur [[buffer(LensRectInputIndex_SceneBlurParams)]]
 ) {
   LensRect rect = rects[input.rect_id];
@@ -1598,13 +1605,12 @@ fragment float4 lens_rect_fragment(
   }
   float2 base_uv = frag_pos / viewport_f;
   float2 refracted_uv = base_uv - offset_px / viewport_f;
-  float strength = gradient_blur_strength(
+  float target_radius = gradient_target_radius(
     frag_pos,
     rect.bounds,
     rect.blur_radius,
     rect.blur_radius_end,
-    float2(rect.gradient_direction[0], rect.gradient_direction[1]),
-    scene_blur->max_blur_radius
+    float2(rect.gradient_direction[0], rect.gradient_direction[1])
   );
 
   float4 color;
@@ -1613,25 +1619,11 @@ fragment float4 lens_rect_fragment(
     float2 ca_dir = weighted_dir / viewport_f;
     float2 uv_r = refracted_uv - ca_dir * ca_shift;
     float2 uv_b = refracted_uv + ca_dir * ca_shift;
-    color.r = mix(
-      unblurred_input.sample(blur_sampler, uv_r).r,
-      blur_input.sample(blur_sampler, uv_r).r,
-      strength
-    );
-    color.g = mix(
-      unblurred_input.sample(blur_sampler, refracted_uv).g,
-      blur_input.sample(blur_sampler, refracted_uv).g,
-      strength
-    );
-    color.b = mix(
-      unblurred_input.sample(blur_sampler, uv_b).b,
-      blur_input.sample(blur_sampler, uv_b).b,
-      strength
-    );
+    color.r = sample_blur_pyramid(blur_pyramid, blur_sampler, uv_r, target_radius, scene_blur).r;
+    color.g = sample_blur_pyramid(blur_pyramid, blur_sampler, refracted_uv, target_radius, scene_blur).g;
+    color.b = sample_blur_pyramid(blur_pyramid, blur_sampler, uv_b, target_radius, scene_blur).b;
   } else {
-    float4 blurred = blur_input.sample(blur_sampler, refracted_uv);
-    float4 sharp = unblurred_input.sample(blur_sampler, refracted_uv);
-    color = mix(sharp, blurred, strength);
+    color = sample_blur_pyramid(blur_pyramid, blur_sampler, refracted_uv, target_radius, scene_blur);
   }
   color.a = 1.0;
 
@@ -1694,9 +1686,8 @@ fragment float4 mirror_rect_fragment(
   MirrorRectFragmentInput input [[stage_in]],
   constant MirrorRect *rects [[buffer(MirrorRectInputIndex_Rects)]],
   constant Size_DevicePixels *viewport_size [[buffer(MirrorRectInputIndex_ViewportSize)]],
-  texture2d<float> blur_input [[texture(MirrorRectInputIndex_BlurTexture)]],
+  texture2d<float> blur_pyramid [[texture(MirrorRectInputIndex_BlurPyramid)]],
   sampler blur_sampler [[sampler(MirrorRectInputIndex_BlurSampler)]],
-  texture2d<float> unblurred_input [[texture(MirrorRectInputIndex_UnblurredTexture)]],
   constant SceneBlurParams *scene_blur [[buffer(MirrorRectInputIndex_SceneBlurParams)]]
 ) {
   MirrorRect rect = rects[input.rect_id];
@@ -1725,17 +1716,14 @@ fragment float4 mirror_rect_fragment(
     return float4(0.0);
   }
 
-  float strength = gradient_blur_strength(
+  float target_radius = gradient_target_radius(
     input.position.xy,
     rect.bounds,
     rect.blur_radius,
     rect.blur_radius_end,
-    float2(rect.gradient_direction[0], rect.gradient_direction[1]),
-    scene_blur->max_blur_radius
+    float2(rect.gradient_direction[0], rect.gradient_direction[1])
   );
-  float4 blurred = blur_input.sample(blur_sampler, src_uv);
-  float4 sharp = unblurred_input.sample(blur_sampler, src_uv);
-  float4 color = mix(sharp, blurred, strength);
+  float4 color = sample_blur_pyramid(blur_pyramid, blur_sampler, src_uv, target_radius, scene_blur);
 
   float4 tint_rgba = hsla_to_rgba(rect.tint);
   color = float4(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);

--- a/crates/gpui_macos/src/shaders.metal
+++ b/crates/gpui_macos/src/shaders.metal
@@ -1651,3 +1651,101 @@ fragment float4 lens_rect_fragment(
 
   return float4(color.rgb, color.a * aa);
 }
+
+// --- MirrorRect: sampled+flipped framebuffer region ---
+//
+// Samples `source_bounds` from either the un-blurred or Kawase-blurred
+// snapshot (gradient blur supported the same way `BlurRect` / `LensRect`
+// do), applies the horizontal/vertical flips encoded in `mirror_axis`,
+// composites into `bounds` with a rounded-rect SDF clip and tint.
+
+struct MirrorRectVarying {
+  uint rect_id [[flat]];
+  float4 position [[position]];
+  float clip_distance [[clip_distance]][4];
+};
+
+struct MirrorRectFragmentInput {
+  uint rect_id [[flat]];
+  float4 position [[position]];
+};
+
+vertex MirrorRectVarying mirror_rect_vertex(
+  uint unit_vertex_id [[vertex_id]],
+  uint rect_id [[instance_id]],
+  constant float2 *unit_vertices [[buffer(MirrorRectInputIndex_Vertices)]],
+  constant MirrorRect *rects [[buffer(MirrorRectInputIndex_Rects)]],
+  constant Size_DevicePixels *viewport_size [[buffer(MirrorRectInputIndex_ViewportSize)]]
+) {
+  float2 unit_vertex = unit_vertices[unit_vertex_id];
+  MirrorRect rect = rects[rect_id];
+  MirrorRectVarying out;
+  out.position = to_device_position(unit_vertex, rect.bounds, viewport_size);
+  out.rect_id = rect_id;
+  float4 clip = distance_from_clip_rect(unit_vertex, rect.bounds, rect.content_mask.bounds);
+  out.clip_distance[0] = clip.x;
+  out.clip_distance[1] = clip.y;
+  out.clip_distance[2] = clip.z;
+  out.clip_distance[3] = clip.w;
+  return out;
+}
+
+fragment float4 mirror_rect_fragment(
+  MirrorRectFragmentInput input [[stage_in]],
+  constant MirrorRect *rects [[buffer(MirrorRectInputIndex_Rects)]],
+  constant Size_DevicePixels *viewport_size [[buffer(MirrorRectInputIndex_ViewportSize)]],
+  texture2d<float> blur_input [[texture(MirrorRectInputIndex_BlurTexture)]],
+  sampler blur_sampler [[sampler(MirrorRectInputIndex_BlurSampler)]],
+  texture2d<float> unblurred_input [[texture(MirrorRectInputIndex_UnblurredTexture)]],
+  constant SceneBlurParams *scene_blur [[buffer(MirrorRectInputIndex_SceneBlurParams)]]
+) {
+  MirrorRect rect = rects[input.rect_id];
+  float2 viewport_f = float2((float)viewport_size->width, (float)viewport_size->height);
+
+  // Normalized position within the destination rect.
+  float2 dest_origin = float2(rect.bounds.origin.x, rect.bounds.origin.y);
+  float2 dest_size = max(float2(rect.bounds.size.width, rect.bounds.size.height), float2(1.0));
+  float2 u = clamp((input.position.xy - dest_origin) / dest_size, 0.0, 1.0);
+
+  // Flip per axis. MIRROR_AXIS_HORIZONTAL = bit 0, VERTICAL = bit 1.
+  if ((rect.mirror_axis & 1u) != 0u) {
+    u.x = 1.0 - u.x;
+  }
+  if ((rect.mirror_axis & 2u) != 0u) {
+    u.y = 1.0 - u.y;
+  }
+
+  // Map back to source rect, then to viewport UV.
+  float2 src_origin = float2(rect.source_bounds.origin.x, rect.source_bounds.origin.y);
+  float2 src_size = float2(rect.source_bounds.size.width, rect.source_bounds.size.height);
+  float2 src_pos = src_origin + u * src_size;
+  float2 src_uv = src_pos / viewport_f;
+  // Reject out-of-viewport samples to transparent.
+  if (src_uv.x < 0.0 || src_uv.x > 1.0 || src_uv.y < 0.0 || src_uv.y > 1.0) {
+    return float4(0.0);
+  }
+
+  float strength = gradient_blur_strength(
+    input.position.xy,
+    rect.bounds,
+    rect.blur_radius,
+    rect.blur_radius_end,
+    float2(rect.gradient_direction[0], rect.gradient_direction[1]),
+    scene_blur->max_blur_radius
+  );
+  float4 blurred = blur_input.sample(blur_sampler, src_uv);
+  float4 sharp = unblurred_input.sample(blur_sampler, src_uv);
+  float4 color = mix(sharp, blurred, strength);
+
+  float4 tint_rgba = hsla_to_rgba(rect.tint);
+  color = float4(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
+
+  float alpha = color.a;
+  if (rect.clip_to_destination != 0u) {
+    float sdf = quad_sdf(input.position.xy, rect.bounds, rect.corner_radii);
+    const float antialias_threshold = 0.5;
+    float aa = saturate(antialias_threshold - sdf);
+    alpha = color.a * aa;
+  }
+  return float4(color.rgb, alpha);
+}

--- a/crates/gpui_macos/src/shaders.metal
+++ b/crates/gpui_macos/src/shaders.metal
@@ -1523,9 +1523,13 @@ fragment float4 lens_rect_fragment(
   float blend_k = max(rect.edge_blend_distance, 0.0);
   bool blend_shapes = blend_k > 0.0 && shape_count > 1u;
 
-  // Pass 1: accumulate per-shape SDFs; pick softmin/hardmin weights and
-  // tracked union SDF.
+  // Pass 1: accumulate per-shape SDFs plus a soft per-shape mask
+  // attenuation (0 outside the shape's own `content_mask`, 1 inside,
+  // with a ~1-pixel feather).
+  const float antialias_threshold = 0.5;
+  Corners_ScaledPixels zero_corners = {0.0, 0.0, 0.0, 0.0};
   float per_shape_sdf[8];
+  float per_shape_mask_attn[8];
   float2 per_shape_dir[8];
   float per_shape_norm_dist[8];
   float min_sdf = 1e20;
@@ -1534,6 +1538,9 @@ fragment float4 lens_rect_fragment(
     float d = quad_sdf(frag_pos, s.bounds, s.corner_radii);
     per_shape_sdf[i] = d;
     min_sdf = min(min_sdf, d);
+
+    float mask_sdf = quad_sdf(frag_pos, s.content_mask, zero_corners);
+    per_shape_mask_attn[i] = saturate(antialias_threshold - mask_sdf);
 
     float2 origin = float2(s.bounds.origin.x, s.bounds.origin.y);
     float2 size = float2(s.bounds.size.width, s.bounds.size.height);
@@ -1548,25 +1555,38 @@ fragment float4 lens_rect_fragment(
 
   float union_sdf;
   float weights[8];
-  float total_weight = 0.0;
+  // Scales the final fragment alpha to fade at per-shape mask boundaries.
+  // 1 when every shape is fully inside its own mask (or no mask in play);
+  // smoothly decreases as shapes' mask edges cross the fragment.
+  float coverage_factor;
   if (blend_shapes) {
-    // Exponential smooth-minimum (polynomial order 8). Each weight is
-    // `exp(-d_i / k)`, normalized so they sum to 1. As `k -> 0` the weight
-    // on the minimum shape approaches 1 — identical to hard union.
+    // Exponential smooth-minimum. Each shape contributes a weight
+    // `mask_attn[i] * exp(-(d_i - min_d) / k)` — masked-out shapes are
+    // pulled toward zero weight, so their neighbors dominate the
+    // refraction / Fresnel blend naturally.
     float min_d = min_sdf;
+    float total_pre = 0.0;
+    float total_masked = 0.0;
     for (uint i = 0u; i < shape_count; ++i) {
-      float w = exp(-(per_shape_sdf[i] - min_d) / blend_k);
-      weights[i] = w;
-      total_weight += w;
+      float pre = exp(-(per_shape_sdf[i] - min_d) / blend_k);
+      float masked = per_shape_mask_attn[i] * pre;
+      weights[i] = masked;
+      total_pre += pre;
+      total_masked += masked;
+    }
+    if (total_masked < 1e-6) {
+      discard_fragment();
     }
     // Softmin value: -k * log(Σ exp(-d_i / k)), shifted by min_d to avoid
-    // overflow. Yields the smooth-min distance used for AA and Fresnel.
-    union_sdf = min_d - blend_k * log(max(total_weight, 1e-6));
-    // Normalize weights.
-    float inv_total = 1.0 / max(total_weight, 1e-6);
+    // overflow. Unmasked sum preserves the geometric union outline even
+    // when one shape is masked out — we only attenuate the alpha and
+    // refraction weights, not the shape boundary itself.
+    union_sdf = min_d - blend_k * log(max(total_pre, 1e-6));
+    float inv_masked = 1.0 / max(total_masked, 1e-6);
     for (uint i = 0u; i < shape_count; ++i) {
-      weights[i] *= inv_total;
+      weights[i] *= inv_masked;
     }
+    coverage_factor = clamp(total_masked / max(total_pre, 1e-6), 0.0, 1.0);
   } else {
     // Single shape or hard union: pick the min-SDF shape deterministically.
     uint winner = 0u;
@@ -1581,10 +1601,13 @@ fragment float4 lens_rect_fragment(
     for (uint i = 0u; i < shape_count; ++i) {
       weights[i] = (i == winner) ? 1.0 : 0.0;
     }
+    coverage_factor = per_shape_mask_attn[winner];
+    if (coverage_factor < 1e-3) {
+      discard_fragment();
+    }
   }
 
-  const float antialias_threshold = 0.5;
-  float aa = saturate(antialias_threshold - union_sdf);
+  float aa = saturate(antialias_threshold - union_sdf) * coverage_factor;
   if (aa <= 0.0) {
     discard_fragment();
   }

--- a/crates/gpui_macos/src/shaders.metal
+++ b/crates/gpui_macos/src/shaders.metal
@@ -1373,17 +1373,61 @@ vertex BlurRectVarying blur_rect_vertex(
   return out;
 }
 
+// Compute the per-pixel mix factor between the un-blurred and max-blurred
+// sources for a linear-gradient blur. Returns 1.0 (full blur) when the
+// gradient is disabled (`gradient_direction == 0`).
+//
+// This is a `mix(unblurred, max-blurred, t)` approximation. It's visually
+// plausible for HIG scroll-edge fades but not a true per-pixel Gaussian.
+// Mid-range `t` values diverge from a true variable-radius blur; the
+// documented follow-up (mip-pyramid sampling of preserved downsample
+// intermediates) is out of scope for this change.
+float gradient_blur_strength(
+    float2 frag_pos,
+    Bounds_ScaledPixels bounds,
+    float radius_start,
+    float radius_end,
+    float2 gradient_direction,
+    float scene_max_radius
+) {
+  if (scene_max_radius <= 0.0) {
+    return 0.0;
+  }
+  float dir_len2 = dot(gradient_direction, gradient_direction);
+  if (dir_len2 < 1e-6) {
+    return clamp(radius_start / scene_max_radius, 0.0, 1.0);
+  }
+  float2 local = frag_pos - float2(bounds.origin.x, bounds.origin.y);
+  float2 size_v = float2(bounds.size.width, bounds.size.height);
+  float extent = max(dot(size_v, gradient_direction), 1.0);
+  float t = clamp(dot(local, gradient_direction) / extent, 0.0, 1.0);
+  float target = mix(radius_start, radius_end, t);
+  return clamp(target / scene_max_radius, 0.0, 1.0);
+}
+
 fragment float4 blur_rect_fragment(
   BlurRectFragmentInput input [[stage_in]],
   constant BlurRect *rects [[buffer(BlurRectInputIndex_Rects)]],
   constant Size_DevicePixels *viewport_size [[buffer(BlurRectInputIndex_ViewportSize)]],
   texture2d<float> blur_input [[texture(BlurRectInputIndex_BlurTexture)]],
-  sampler blur_sampler [[sampler(BlurRectInputIndex_BlurSampler)]]
+  sampler blur_sampler [[sampler(BlurRectInputIndex_BlurSampler)]],
+  texture2d<float> unblurred_input [[texture(BlurRectInputIndex_UnblurredTexture)]],
+  constant SceneBlurParams *scene_blur [[buffer(BlurRectInputIndex_SceneBlurParams)]]
 ) {
   BlurRect rect = rects[input.rect_id];
   float2 viewport_f = float2((float)viewport_size->width, (float)viewport_size->height);
   float2 fb_uv = input.position.xy / viewport_f;
-  float4 color = blur_input.sample(blur_sampler, fb_uv);
+  float strength = gradient_blur_strength(
+    input.position.xy,
+    rect.bounds,
+    rect.blur_radius,
+    rect.blur_radius_end,
+    float2(rect.gradient_direction[0], rect.gradient_direction[1]),
+    scene_blur->max_blur_radius
+  );
+  float4 blurred = blur_input.sample(blur_sampler, fb_uv);
+  float4 sharp = unblurred_input.sample(blur_sampler, fb_uv);
+  float4 color = mix(sharp, blurred, strength);
   float4 tint_rgba = hsla_to_rgba(rect.tint);
   color = float4(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
 
@@ -1457,7 +1501,9 @@ fragment float4 lens_rect_fragment(
   constant Size_DevicePixels *viewport_size [[buffer(LensRectInputIndex_ViewportSize)]],
   texture2d<float> blur_input [[texture(LensRectInputIndex_BlurTexture)]],
   sampler blur_sampler [[sampler(LensRectInputIndex_BlurSampler)]],
-  constant LensShape *shapes [[buffer(LensRectInputIndex_Shapes)]]
+  constant LensShape *shapes [[buffer(LensRectInputIndex_Shapes)]],
+  texture2d<float> unblurred_input [[texture(LensRectInputIndex_UnblurredTexture)]],
+  constant SceneBlurParams *scene_blur [[buffer(LensRectInputIndex_SceneBlurParams)]]
 ) {
   LensRect rect = rects[input.rect_id];
   float2 viewport_f = float2((float)viewport_size->width, (float)viewport_size->height);
@@ -1552,16 +1598,40 @@ fragment float4 lens_rect_fragment(
   }
   float2 base_uv = frag_pos / viewport_f;
   float2 refracted_uv = base_uv - offset_px / viewport_f;
+  float strength = gradient_blur_strength(
+    frag_pos,
+    rect.bounds,
+    rect.blur_radius,
+    rect.blur_radius_end,
+    float2(rect.gradient_direction[0], rect.gradient_direction[1]),
+    scene_blur->max_blur_radius
+  );
 
   float4 color;
   if (rect.dispersion > 0.0) {
     float ca_shift = weighted_norm_dist * rect.dispersion;
     float2 ca_dir = weighted_dir / viewport_f;
-    color.r = blur_input.sample(blur_sampler, refracted_uv - ca_dir * ca_shift).r;
-    color.g = blur_input.sample(blur_sampler, refracted_uv).g;
-    color.b = blur_input.sample(blur_sampler, refracted_uv + ca_dir * ca_shift).b;
+    float2 uv_r = refracted_uv - ca_dir * ca_shift;
+    float2 uv_b = refracted_uv + ca_dir * ca_shift;
+    color.r = mix(
+      unblurred_input.sample(blur_sampler, uv_r).r,
+      blur_input.sample(blur_sampler, uv_r).r,
+      strength
+    );
+    color.g = mix(
+      unblurred_input.sample(blur_sampler, refracted_uv).g,
+      blur_input.sample(blur_sampler, refracted_uv).g,
+      strength
+    );
+    color.b = mix(
+      unblurred_input.sample(blur_sampler, uv_b).b,
+      blur_input.sample(blur_sampler, uv_b).b,
+      strength
+    );
   } else {
-    color = blur_input.sample(blur_sampler, refracted_uv);
+    float4 blurred = blur_input.sample(blur_sampler, refracted_uv);
+    float4 sharp = unblurred_input.sample(blur_sampler, refracted_uv);
+    color = mix(sharp, blurred, strength);
   }
   color.a = 1.0;
 

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -1396,12 +1396,11 @@ struct SceneBlurParams {
 struct LensShape {
     bounds: Bounds,
     corner_radii: Corners,
-    // Pads the stride to 48 bytes so the WGSL `array<LensShape>` matches
-    // the Rust side.
-    _pad0: f32,
-    _pad1: f32,
-    _pad2: f32,
-    _pad3: f32,
+    // Per-shape clip rectangle. Fragments outside this attenuate the
+    // shape's contribution to the SDF union instead of hard-clipping, so
+    // adjacent shapes in the same lens group don't develop a seam at the
+    // mask edge.
+    content_mask: Bounds,
 }
 
 struct MirrorRect {
@@ -1566,7 +1565,10 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
     let blend_k = max(rect.edge_blend_distance, 0.0);
     let blend_shapes = blend_k > 0.0 && shape_count > 1u;
 
+    let antialias_threshold = 0.5;
+    let zero_corners = Corners(0.0, 0.0, 0.0, 0.0);
     var per_shape_sdf: array<f32, 8>;
+    var per_shape_mask_attn: array<f32, 8>;
     var per_shape_dir: array<vec2<f32>, 8>;
     var per_shape_norm_dist: array<f32, 8>;
     var min_sdf: f32 = 1e20;
@@ -1575,6 +1577,9 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
         let d = quad_sdf(input.position.xy, s.bounds, s.corner_radii);
         per_shape_sdf[i] = d;
         min_sdf = min(min_sdf, d);
+
+        let mask_sdf = quad_sdf(input.position.xy, s.content_mask, zero_corners);
+        per_shape_mask_attn[i] = saturate(antialias_threshold - mask_sdf);
 
         let center = s.bounds.origin + s.bounds.size * 0.5;
         let half_size = s.bounds.size * 0.5;
@@ -1591,18 +1596,26 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
 
     var union_sdf: f32;
     var weights: array<f32, 8>;
+    var coverage_factor: f32;
     if (blend_shapes) {
-        var total_weight: f32 = 0.0;
+        var total_pre: f32 = 0.0;
+        var total_masked: f32 = 0.0;
         for (var i: u32 = 0u; i < shape_count; i = i + 1u) {
-            let w = exp(-(per_shape_sdf[i] - min_sdf) / blend_k);
-            weights[i] = w;
-            total_weight = total_weight + w;
+            let pre = exp(-(per_shape_sdf[i] - min_sdf) / blend_k);
+            let masked = per_shape_mask_attn[i] * pre;
+            weights[i] = masked;
+            total_pre = total_pre + pre;
+            total_masked = total_masked + masked;
         }
-        union_sdf = min_sdf - blend_k * log(max(total_weight, 1e-6));
-        let inv_total = 1.0 / max(total_weight, 1e-6);
+        if (total_masked < 1e-6) {
+            return vec4<f32>(0.0);
+        }
+        union_sdf = min_sdf - blend_k * log(max(total_pre, 1e-6));
+        let inv_masked = 1.0 / max(total_masked, 1e-6);
         for (var i: u32 = 0u; i < shape_count; i = i + 1u) {
-            weights[i] = weights[i] * inv_total;
+            weights[i] = weights[i] * inv_masked;
         }
+        coverage_factor = clamp(total_masked / max(total_pre, 1e-6), 0.0, 1.0);
     } else {
         var winner: u32 = 0u;
         var min_d: f32 = per_shape_sdf[0];
@@ -1616,10 +1629,13 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
         for (var i: u32 = 0u; i < shape_count; i = i + 1u) {
             weights[i] = select(0.0, 1.0, i == winner);
         }
+        coverage_factor = per_shape_mask_attn[winner];
+        if (coverage_factor < 1e-3) {
+            return vec4<f32>(0.0);
+        }
     }
 
-    let antialias_threshold = 0.5;
-    let aa = saturate(antialias_threshold - union_sdf);
+    let aa = saturate(antialias_threshold - union_sdf) * coverage_factor;
     if (aa <= 0.0) {
         return vec4<f32>(0.0);
     }

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -1357,8 +1357,11 @@ struct BlurRect {
     content_mask: Bounds,
     corner_radii: Corners,
     blur_radius: f32,
-    pad: f32,
+    blur_radius_end: f32,
+    gradient_direction: vec2<f32>,
     tint: Hsla,
+    // Aligns the struct stride to 96 bytes (matching the Rust side).
+    _pad_end: vec2<f32>,
 }
 
 struct LensRect {
@@ -1369,19 +1372,25 @@ struct LensRect {
     shape_offset: u32,
     shape_count: u32,
     edge_blend_distance: f32,
-    _pad_a: f32,
     blur_radius: f32,
+    gradient_direction: vec2<f32>,
+    blur_radius_end: f32,
     refraction: f32,
     depth: f32,
     dispersion: f32,
     splay: f32,
     light_angle_radians: f32,
-    pad_light: f32,
     light_intensity: f32,
-    pad: f32,
     tint: Hsla,
     // Aligns the struct stride to 112 bytes (matching the Rust side).
     pad2: f32,
+}
+
+struct SceneBlurParams {
+    max_blur_radius: f32,
+    _pad0: f32,
+    _pad1: f32,
+    _pad2: f32,
 }
 
 struct LensShape {
@@ -1400,6 +1409,8 @@ struct LensShape {
 @group(1) @binding(2) var t_blur_input: texture_2d<f32>;
 @group(1) @binding(3) var s_blur_input: sampler;
 @group(1) @binding(4) var<storage, read> b_lens_shapes: array<LensShape>;
+@group(1) @binding(5) var t_unblurred_input: texture_2d<f32>;
+@group(1) @binding(6) var<uniform> scene_blur: SceneBlurParams;
 
 // --- BlurRect: rounded rect that samples the blurred framebuffer ---
 
@@ -1423,6 +1434,30 @@ fn vs_blur_rect(
     return out;
 }
 
+// Compute per-pixel blur-strength mix factor for linear-gradient blur. See
+// the Metal implementation for notes on the mix-approximation caveat.
+fn gradient_blur_strength(
+    frag_pos: vec2<f32>,
+    bounds: Bounds,
+    radius_start: f32,
+    radius_end: f32,
+    gradient_direction: vec2<f32>,
+    scene_max_radius: f32,
+) -> f32 {
+    if (scene_max_radius <= 0.0) {
+        return 0.0;
+    }
+    let dir_len2 = dot(gradient_direction, gradient_direction);
+    if (dir_len2 < 1e-6) {
+        return clamp(radius_start / scene_max_radius, 0.0, 1.0);
+    }
+    let local = frag_pos - bounds.origin;
+    let extent = max(dot(bounds.size, gradient_direction), 1.0);
+    let t = clamp(dot(local, gradient_direction) / extent, 0.0, 1.0);
+    let target_radius = mix(radius_start, radius_end, t);
+    return clamp(target_radius / scene_max_radius, 0.0, 1.0);
+}
+
 @fragment
 fn fs_blur_rect(input: BlurRectVarying) -> @location(0) vec4<f32> {
     if (any(input.clip_distances < vec4<f32>(0.0))) {
@@ -1430,7 +1465,17 @@ fn fs_blur_rect(input: BlurRectVarying) -> @location(0) vec4<f32> {
     }
     let rect = b_blur_rects[input.rect_id];
     let fb_uv = input.position.xy / globals.viewport_size;
-    var color = textureSample(t_blur_input, s_blur_input, fb_uv);
+    let blurred = textureSample(t_blur_input, s_blur_input, fb_uv);
+    let sharp = textureSample(t_unblurred_input, s_blur_input, fb_uv);
+    let strength = gradient_blur_strength(
+        input.position.xy,
+        rect.bounds,
+        rect.blur_radius,
+        rect.blur_radius_end,
+        rect.gradient_direction,
+        scene_blur.max_blur_radius,
+    );
+    var color = mix(sharp, blurred, strength);
     let tint_rgba = hsla_to_rgba(rect.tint);
     color = vec4<f32>(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
 
@@ -1568,16 +1613,40 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
     }
     let base_uv = input.position.xy / globals.viewport_size;
     let refracted_uv = base_uv - offset_px / globals.viewport_size;
+    let strength = gradient_blur_strength(
+        input.position.xy,
+        rect.bounds,
+        rect.blur_radius,
+        rect.blur_radius_end,
+        rect.gradient_direction,
+        scene_blur.max_blur_radius,
+    );
 
     var color: vec4<f32>;
     if (rect.dispersion > 0.0) {
         let ca_shift = weighted_norm_dist * rect.dispersion;
         let ca_dir = weighted_dir / globals.viewport_size;
-        color.r = textureSample(t_blur_input, s_blur_input, refracted_uv - ca_dir * ca_shift).r;
-        color.g = textureSample(t_blur_input, s_blur_input, refracted_uv).g;
-        color.b = textureSample(t_blur_input, s_blur_input, refracted_uv + ca_dir * ca_shift).b;
+        let uv_r = refracted_uv - ca_dir * ca_shift;
+        let uv_b = refracted_uv + ca_dir * ca_shift;
+        color.r = mix(
+            textureSample(t_unblurred_input, s_blur_input, uv_r).r,
+            textureSample(t_blur_input, s_blur_input, uv_r).r,
+            strength,
+        );
+        color.g = mix(
+            textureSample(t_unblurred_input, s_blur_input, refracted_uv).g,
+            textureSample(t_blur_input, s_blur_input, refracted_uv).g,
+            strength,
+        );
+        color.b = mix(
+            textureSample(t_unblurred_input, s_blur_input, uv_b).b,
+            textureSample(t_blur_input, s_blur_input, uv_b).b,
+            strength,
+        );
     } else {
-        color = textureSample(t_blur_input, s_blur_input, refracted_uv);
+        let blurred = textureSample(t_blur_input, s_blur_input, refracted_uv);
+        let sharp = textureSample(t_unblurred_input, s_blur_input, refracted_uv);
+        color = mix(sharp, blurred, strength);
     }
     color.a = 1.0;
 

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -1388,9 +1388,9 @@ struct LensRect {
 
 struct SceneBlurParams {
     max_blur_radius: f32,
+    kernel_levels: f32,
     _pad0: f32,
     _pad1: f32,
-    _pad2: f32,
 }
 
 struct LensShape {
@@ -1421,10 +1421,12 @@ struct MirrorRect {
 
 @group(1) @binding(0) var<storage, read> b_blur_rects: array<BlurRect>;
 @group(1) @binding(1) var<storage, read> b_lens_rects: array<LensRect>;
-@group(1) @binding(2) var t_blur_input: texture_2d<f32>;
+// Mipmapped pyramid: mip 0 = un-blurred framebuffer snapshot, each
+// subsequent mip = Kawase downsample result of the previous level.
+// Fragment shaders pick fractional LOD via `textureSampleLevel`.
+@group(1) @binding(2) var t_blur_pyramid: texture_2d<f32>;
 @group(1) @binding(3) var s_blur_input: sampler;
 @group(1) @binding(4) var<storage, read> b_lens_shapes: array<LensShape>;
-@group(1) @binding(5) var t_unblurred_input: texture_2d<f32>;
 @group(1) @binding(6) var<uniform> scene_blur: SceneBlurParams;
 @group(1) @binding(7) var<storage, read> b_mirror_rects: array<MirrorRect>;
 
@@ -1450,28 +1452,37 @@ fn vs_blur_rect(
     return out;
 }
 
-// Compute per-pixel blur-strength mix factor for linear-gradient blur. See
-// the Metal implementation for notes on the mix-approximation caveat.
-fn gradient_blur_strength(
+// Compute the per-pixel target blur radius for a linear-gradient blur.
+// Uniform-blur paths (gradient_direction == 0) return `radius_start`.
+fn gradient_target_radius(
     frag_pos: vec2<f32>,
     bounds: Bounds,
     radius_start: f32,
     radius_end: f32,
     gradient_direction: vec2<f32>,
-    scene_max_radius: f32,
 ) -> f32 {
-    if (scene_max_radius <= 0.0) {
-        return 0.0;
-    }
     let dir_len2 = dot(gradient_direction, gradient_direction);
     if (dir_len2 < 1e-6) {
-        return clamp(radius_start / scene_max_radius, 0.0, 1.0);
+        return radius_start;
     }
     let local = frag_pos - bounds.origin;
     let extent = max(dot(bounds.size, gradient_direction), 1.0);
     let t = clamp(dot(local, gradient_direction) / extent, 0.0, 1.0);
-    let target_radius = mix(radius_start, radius_end, t);
-    return clamp(target_radius / scene_max_radius, 0.0, 1.0);
+    return mix(radius_start, radius_end, t);
+}
+
+// Sample the preserved Kawase downsample pyramid at a per-pixel blur
+// radius. Mip 0 is un-blurred; each subsequent mip doubles the effective
+// Gaussian sigma, so `level = kernel_levels + log2(strength)` with
+// trilinear filtering produces a smooth per-pixel variable-radius blur.
+fn sample_blur_pyramid(uv: vec2<f32>, target_radius: f32) -> vec4<f32> {
+    if (scene_blur.max_blur_radius <= 0.0) {
+        return textureSampleLevel(t_blur_pyramid, s_blur_input, uv, 0.0);
+    }
+    let strength = clamp(target_radius / scene_blur.max_blur_radius, 0.0, 1.0);
+    let raw_level = scene_blur.kernel_levels + log2(max(strength, 1e-6));
+    let level = clamp(raw_level, 0.0, scene_blur.kernel_levels);
+    return textureSampleLevel(t_blur_pyramid, s_blur_input, uv, level);
 }
 
 @fragment
@@ -1481,17 +1492,14 @@ fn fs_blur_rect(input: BlurRectVarying) -> @location(0) vec4<f32> {
     }
     let rect = b_blur_rects[input.rect_id];
     let fb_uv = input.position.xy / globals.viewport_size;
-    let blurred = textureSample(t_blur_input, s_blur_input, fb_uv);
-    let sharp = textureSample(t_unblurred_input, s_blur_input, fb_uv);
-    let strength = gradient_blur_strength(
+    let target_radius = gradient_target_radius(
         input.position.xy,
         rect.bounds,
         rect.blur_radius,
         rect.blur_radius_end,
         rect.gradient_direction,
-        scene_blur.max_blur_radius,
     );
-    var color = mix(sharp, blurred, strength);
+    var color = sample_blur_pyramid(fb_uv, target_radius);
     let tint_rgba = hsla_to_rgba(rect.tint);
     color = vec4<f32>(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
 
@@ -1629,13 +1637,12 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
     }
     let base_uv = input.position.xy / globals.viewport_size;
     let refracted_uv = base_uv - offset_px / globals.viewport_size;
-    let strength = gradient_blur_strength(
+    let target_radius = gradient_target_radius(
         input.position.xy,
         rect.bounds,
         rect.blur_radius,
         rect.blur_radius_end,
         rect.gradient_direction,
-        scene_blur.max_blur_radius,
     );
 
     var color: vec4<f32>;
@@ -1644,25 +1651,11 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
         let ca_dir = weighted_dir / globals.viewport_size;
         let uv_r = refracted_uv - ca_dir * ca_shift;
         let uv_b = refracted_uv + ca_dir * ca_shift;
-        color.r = mix(
-            textureSample(t_unblurred_input, s_blur_input, uv_r).r,
-            textureSample(t_blur_input, s_blur_input, uv_r).r,
-            strength,
-        );
-        color.g = mix(
-            textureSample(t_unblurred_input, s_blur_input, refracted_uv).g,
-            textureSample(t_blur_input, s_blur_input, refracted_uv).g,
-            strength,
-        );
-        color.b = mix(
-            textureSample(t_unblurred_input, s_blur_input, uv_b).b,
-            textureSample(t_blur_input, s_blur_input, uv_b).b,
-            strength,
-        );
+        color.r = sample_blur_pyramid(uv_r, target_radius).r;
+        color.g = sample_blur_pyramid(refracted_uv, target_radius).g;
+        color.b = sample_blur_pyramid(uv_b, target_radius).b;
     } else {
-        let blurred = textureSample(t_blur_input, s_blur_input, refracted_uv);
-        let sharp = textureSample(t_unblurred_input, s_blur_input, refracted_uv);
-        color = mix(sharp, blurred, strength);
+        color = sample_blur_pyramid(refracted_uv, target_radius);
     }
     color.a = 1.0;
 
@@ -1731,17 +1724,14 @@ fn fs_mirror_rect(input: MirrorRectVarying) -> @location(0) vec4<f32> {
         return vec4<f32>(0.0);
     }
 
-    let strength = gradient_blur_strength(
+    let target_radius = gradient_target_radius(
         input.position.xy,
         rect.bounds,
         rect.blur_radius,
         rect.blur_radius_end,
         rect.gradient_direction,
-        scene_blur.max_blur_radius,
     );
-    let blurred = textureSample(t_blur_input, s_blur_input, src_uv);
-    let sharp = textureSample(t_unblurred_input, s_blur_input, src_uv);
-    var color = mix(sharp, blurred, strength);
+    var color = sample_blur_pyramid(src_uv, target_radius);
 
     let tint_rgba = hsla_to_rgba(rect.tint);
     color = vec4<f32>(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -1404,6 +1404,21 @@ struct LensShape {
     _pad3: f32,
 }
 
+struct MirrorRect {
+    order: u32,
+    kernel_levels: u32,
+    bounds: Bounds,
+    content_mask: Bounds,
+    corner_radii: Corners,
+    source_bounds: Bounds,
+    mirror_axis: u32,
+    clip_to_destination: u32,
+    blur_radius: f32,
+    blur_radius_end: f32,
+    gradient_direction: vec2<f32>,
+    tint: Hsla,
+}
+
 @group(1) @binding(0) var<storage, read> b_blur_rects: array<BlurRect>;
 @group(1) @binding(1) var<storage, read> b_lens_rects: array<LensRect>;
 @group(1) @binding(2) var t_blur_input: texture_2d<f32>;
@@ -1411,6 +1426,7 @@ struct LensShape {
 @group(1) @binding(4) var<storage, read> b_lens_shapes: array<LensShape>;
 @group(1) @binding(5) var t_unblurred_input: texture_2d<f32>;
 @group(1) @binding(6) var<uniform> scene_blur: SceneBlurParams;
+@group(1) @binding(7) var<storage, read> b_mirror_rects: array<MirrorRect>;
 
 // --- BlurRect: rounded rect that samples the blurred framebuffer ---
 
@@ -1667,4 +1683,75 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
     }
 
     return blend_color(color, aa);
+}
+
+// --- MirrorRect: sampled+flipped framebuffer region ---
+
+struct MirrorRectVarying {
+    @builtin(position) position: vec4<f32>,
+    @location(0) @interpolate(flat) rect_id: u32,
+    @location(1) clip_distances: vec4<f32>,
+}
+
+@vertex
+fn vs_mirror_rect(
+    @builtin(vertex_index) vertex_id: u32,
+    @builtin(instance_index) instance_id: u32,
+) -> MirrorRectVarying {
+    let unit_vertex = vec2<f32>(f32(vertex_id & 1u), 0.5 * f32(vertex_id & 2u));
+    let rect = b_mirror_rects[instance_id];
+    var out = MirrorRectVarying();
+    out.position = to_device_position(unit_vertex, rect.bounds);
+    out.rect_id = instance_id;
+    out.clip_distances = distance_from_clip_rect(unit_vertex, rect.bounds, rect.content_mask);
+    return out;
+}
+
+@fragment
+fn fs_mirror_rect(input: MirrorRectVarying) -> @location(0) vec4<f32> {
+    if (any(input.clip_distances < vec4<f32>(0.0))) {
+        return vec4<f32>(0.0);
+    }
+    let rect = b_mirror_rects[input.rect_id];
+
+    let dest_origin = rect.bounds.origin;
+    let dest_size = max(rect.bounds.size, vec2<f32>(1.0));
+    var u = clamp((input.position.xy - dest_origin) / dest_size, vec2<f32>(0.0), vec2<f32>(1.0));
+
+    if ((rect.mirror_axis & 1u) != 0u) {
+        u.x = 1.0 - u.x;
+    }
+    if ((rect.mirror_axis & 2u) != 0u) {
+        u.y = 1.0 - u.y;
+    }
+
+    let src_pos = rect.source_bounds.origin + u * rect.source_bounds.size;
+    let src_uv = src_pos / globals.viewport_size;
+    if (src_uv.x < 0.0 || src_uv.x > 1.0 || src_uv.y < 0.0 || src_uv.y > 1.0) {
+        return vec4<f32>(0.0);
+    }
+
+    let strength = gradient_blur_strength(
+        input.position.xy,
+        rect.bounds,
+        rect.blur_radius,
+        rect.blur_radius_end,
+        rect.gradient_direction,
+        scene_blur.max_blur_radius,
+    );
+    let blurred = textureSample(t_blur_input, s_blur_input, src_uv);
+    let sharp = textureSample(t_unblurred_input, s_blur_input, src_uv);
+    var color = mix(sharp, blurred, strength);
+
+    let tint_rgba = hsla_to_rgba(rect.tint);
+    color = vec4<f32>(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
+
+    var alpha = color.a;
+    if (rect.clip_to_destination != 0u) {
+        let sdf = quad_sdf(input.position.xy, rect.bounds, rect.corner_radii);
+        let antialias_threshold = 0.5;
+        let aa = saturate(antialias_threshold - sdf);
+        alpha = color.a * aa;
+    }
+    return vec4<f32>(color.rgb, alpha);
 }

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -1366,7 +1366,10 @@ struct LensRect {
     kernel_levels: u32,
     bounds: Bounds,
     content_mask: Bounds,
-    corner_radii: Corners,
+    shape_offset: u32,
+    shape_count: u32,
+    edge_blend_distance: f32,
+    _pad_a: f32,
     blur_radius: f32,
     refraction: f32,
     depth: f32,
@@ -1381,10 +1384,22 @@ struct LensRect {
     pad2: f32,
 }
 
+struct LensShape {
+    bounds: Bounds,
+    corner_radii: Corners,
+    // Pads the stride to 48 bytes so the WGSL `array<LensShape>` matches
+    // the Rust side.
+    _pad0: f32,
+    _pad1: f32,
+    _pad2: f32,
+    _pad3: f32,
+}
+
 @group(1) @binding(0) var<storage, read> b_blur_rects: array<BlurRect>;
 @group(1) @binding(1) var<storage, read> b_lens_rects: array<LensRect>;
 @group(1) @binding(2) var t_blur_input: texture_2d<f32>;
 @group(1) @binding(3) var s_blur_input: sampler;
+@group(1) @binding(4) var<storage, read> b_lens_shapes: array<LensShape>;
 
 // --- BlurRect: rounded rect that samples the blurred framebuffer ---
 
@@ -1450,16 +1465,24 @@ fn vs_lens_rect(
         cos(rect.light_angle_radians),
         sin(rect.light_angle_radians),
     );
+    // Use the first shape's corner radii as the Fresnel edge-band reference;
+    // the difference when shapes differ is minor relative to the other
+    // shader outputs.
+    let shape0 = b_lens_shapes[rect.shape_offset];
     let corner_avg = 0.25 * (
-        rect.corner_radii.top_left
-        + rect.corner_radii.top_right
-        + rect.corner_radii.bottom_right
-        + rect.corner_radii.bottom_left
+        shape0.corner_radii.top_left
+        + shape0.corner_radii.top_right
+        + shape0.corner_radii.bottom_right
+        + shape0.corner_radii.bottom_left
     );
     let splay_px = max(rect.splay, 1.0);
     out.edge_band = max(corner_avg * 0.5, splay_px);
     return out;
 }
+
+// Max shapes per LensRect. Matches `MAX_LENS_SHAPES_PER_GROUP` in window.rs;
+// sized to keep the per-fragment loops cheap.
+const MAX_LENS_SHAPES: u32 = 8u;
 
 @fragment
 fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
@@ -1467,36 +1490,89 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
         return vec4<f32>(0.0);
     }
     let rect = b_lens_rects[input.rect_id];
+    let shape_count = min(rect.shape_count, MAX_LENS_SHAPES);
+    if (shape_count == 0u) {
+        return vec4<f32>(0.0);
+    }
+    let blend_k = max(rect.edge_blend_distance, 0.0);
+    let blend_shapes = blend_k > 0.0 && shape_count > 1u;
 
-    let sdf = quad_sdf(input.position.xy, rect.bounds, rect.corner_radii);
+    var per_shape_sdf: array<f32, 8>;
+    var per_shape_dir: array<vec2<f32>, 8>;
+    var per_shape_norm_dist: array<f32, 8>;
+    var min_sdf: f32 = 1e20;
+    for (var i: u32 = 0u; i < shape_count; i = i + 1u) {
+        let s = b_lens_shapes[rect.shape_offset + i];
+        let d = quad_sdf(input.position.xy, s.bounds, s.corner_radii);
+        per_shape_sdf[i] = d;
+        min_sdf = min(min_sdf, d);
+
+        let center = s.bounds.origin + s.bounds.size * 0.5;
+        let half_size = s.bounds.size * 0.5;
+        let local_pos = input.position.xy - center;
+        let local_len = length(local_pos);
+        per_shape_dir[i] = select(
+            vec2<f32>(0.0, 0.0),
+            local_pos / max(local_len, 0.0001),
+            local_len > 0.001,
+        );
+        let safe_half = max(half_size, vec2<f32>(1.0, 1.0));
+        per_shape_norm_dist[i] = clamp(length(local_pos / safe_half), 0.0, 1.0);
+    }
+
+    var union_sdf: f32;
+    var weights: array<f32, 8>;
+    if (blend_shapes) {
+        var total_weight: f32 = 0.0;
+        for (var i: u32 = 0u; i < shape_count; i = i + 1u) {
+            let w = exp(-(per_shape_sdf[i] - min_sdf) / blend_k);
+            weights[i] = w;
+            total_weight = total_weight + w;
+        }
+        union_sdf = min_sdf - blend_k * log(max(total_weight, 1e-6));
+        let inv_total = 1.0 / max(total_weight, 1e-6);
+        for (var i: u32 = 0u; i < shape_count; i = i + 1u) {
+            weights[i] = weights[i] * inv_total;
+        }
+    } else {
+        var winner: u32 = 0u;
+        var min_d: f32 = per_shape_sdf[0];
+        for (var i: u32 = 1u; i < shape_count; i = i + 1u) {
+            if (per_shape_sdf[i] < min_d) {
+                min_d = per_shape_sdf[i];
+                winner = i;
+            }
+        }
+        union_sdf = min_d;
+        for (var i: u32 = 0u; i < shape_count; i = i + 1u) {
+            weights[i] = select(0.0, 1.0, i == winner);
+        }
+    }
+
     let antialias_threshold = 0.5;
-    let aa = saturate(antialias_threshold - sdf);
+    let aa = saturate(antialias_threshold - union_sdf);
     if (aa <= 0.0) {
         return vec4<f32>(0.0);
     }
 
-    let center = rect.bounds.origin + rect.bounds.size * 0.5;
-    let half_size = rect.bounds.size * 0.5;
-    let local_pos = input.position.xy - center;
-    let local_len = length(local_pos);
-    let direction = select(
-        vec2<f32>(0.0, 0.0),
-        local_pos / max(local_len, 0.0001),
-        local_len > 0.001,
-    );
-    let safe_half = max(half_size, vec2<f32>(1.0, 1.0));
-    let normalized_dist = clamp(length(local_pos / safe_half), 0.0, 1.0);
-
     let depth_scale = clamp(rect.depth * 0.01, 0.0, 1.0);
-    let distortion = (1.0 - normalized_dist * normalized_dist) * (1.0 + depth_scale);
-    let offset_px = distortion * direction * rect.refraction * 0.5;
+    var offset_px = vec2<f32>(0.0, 0.0);
+    var weighted_norm_dist: f32 = 0.0;
+    var weighted_dir = vec2<f32>(0.0, 0.0);
+    for (var i: u32 = 0u; i < shape_count; i = i + 1u) {
+        let nd = per_shape_norm_dist[i];
+        let distortion = (1.0 - nd * nd) * (1.0 + depth_scale);
+        offset_px = offset_px + weights[i] * (distortion * per_shape_dir[i] * rect.refraction * 0.5);
+        weighted_norm_dist = weighted_norm_dist + weights[i] * nd;
+        weighted_dir = weighted_dir + weights[i] * per_shape_dir[i];
+    }
     let base_uv = input.position.xy / globals.viewport_size;
     let refracted_uv = base_uv - offset_px / globals.viewport_size;
 
     var color: vec4<f32>;
     if (rect.dispersion > 0.0) {
-        let ca_shift = normalized_dist * rect.dispersion;
-        let ca_dir = direction / globals.viewport_size;
+        let ca_shift = weighted_norm_dist * rect.dispersion;
+        let ca_dir = weighted_dir / globals.viewport_size;
         color.r = textureSample(t_blur_input, s_blur_input, refracted_uv - ca_dir * ca_shift).r;
         color.g = textureSample(t_blur_input, s_blur_input, refracted_uv).g;
         color.b = textureSample(t_blur_input, s_blur_input, refracted_uv + ca_dir * ca_shift).b;
@@ -1509,12 +1585,13 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
     color = vec4<f32>(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
 
     if (rect.light_intensity > 0.0) {
-        let edge_dist = abs(sdf);
+        let edge_dist = abs(union_sdf);
         let edge_falloff = smoothstep(input.edge_band, 0.0, edge_dist);
+        let weighted_len = length(weighted_dir);
         let facing = select(
             1.0,
-            clamp(dot(direction, input.light_dir), 0.0, 1.0),
-            local_len > 0.001,
+            clamp(dot(weighted_dir / weighted_len, input.light_dir), 0.0, 1.0),
+            weighted_len > 0.001,
         );
         let edge_glow = edge_falloff * facing * rect.light_intensity;
         color = color + vec4<f32>(edge_glow, edge_glow, edge_glow, 0.0);

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -61,6 +61,16 @@ struct BlurParams {
     pad: f32,
 }
 
+/// Scene-wide blur parameters used by the gradient-blur shaders to
+/// normalize per-pixel strength into a [0, 1] mix factor. Written once per
+/// frame and bound to both `blur_rect` and `lens_rect` pipelines.
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct SceneBlurParams {
+    max_blur_radius: f32,
+    _pad: [f32; 3],
+}
+
 #[derive(Clone, Debug)]
 #[repr(C)]
 struct PathSprite {
@@ -140,6 +150,11 @@ struct WgpuResources {
     /// frame (1..=5).
     blur_chain_textures: [Option<wgpu::Texture>; BLUR_CHAIN_LEVELS],
     blur_chain_views: [Option<wgpu::TextureView>; BLUR_CHAIN_LEVELS],
+    /// Un-blurred copy of the framebuffer, preserved across the Kawase
+    /// chain so variable-radius blur / lens primitives can mix between
+    /// the blurred and un-blurred sources per pixel.
+    framebuffer_snapshot_texture: Option<wgpu::Texture>,
+    framebuffer_snapshot_view: Option<wgpu::TextureView>,
     /// Bind groups pre-built for downsample/upsample passes. Downsample
     /// pass `i` samples level `i` and writes level `i + 1`; upsample pass
     /// `i` samples level `i + 1` and writes level `i`.
@@ -155,6 +170,8 @@ struct WgpuResources {
     /// equal to `size_of::<BlurParams>()` rounded up to
     /// `min_uniform_buffer_offset_alignment`.
     blur_params_slot_stride: u64,
+    /// Scene-wide gradient-blur params; written once per frame.
+    scene_blur_params_buffer: wgpu::Buffer,
 }
 
 impl WgpuResources {
@@ -169,6 +186,8 @@ impl WgpuResources {
         for slot in &mut self.blur_chain_views {
             *slot = None;
         }
+        self.framebuffer_snapshot_texture = None;
+        self.framebuffer_snapshot_view = None;
         for slot in &mut self.blur_down_bind_groups {
             *slot = None;
         }
@@ -467,6 +486,13 @@ impl WgpuRenderer {
             mapped_at_creation: false,
         });
 
+        let scene_blur_params_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("scene_blur_params_buffer"),
+            size: std::mem::size_of::<SceneBlurParams>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
         let globals_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("globals_buffer"),
             size: gamma_offset + gamma_size,
@@ -558,11 +584,14 @@ impl WgpuRenderer {
             path_msaa_view: None,
             blur_chain_textures: Default::default(),
             blur_chain_views: Default::default(),
+            framebuffer_snapshot_texture: None,
+            framebuffer_snapshot_view: None,
             blur_down_bind_groups: Default::default(),
             blur_up_bind_groups: Default::default(),
             blur_sampler,
             blur_params_buffer,
             blur_params_slot_stride,
+            scene_blur_params_buffer,
         };
 
         Ok(Self {
@@ -741,6 +770,26 @@ impl WgpuRenderer {
             ],
         });
 
+        let unblurred_texture_entry = wgpu::BindGroupLayoutEntry {
+            binding: 5,
+            visibility: wgpu::ShaderStages::FRAGMENT,
+            ty: wgpu::BindingType::Texture {
+                sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                view_dimension: wgpu::TextureViewDimension::D2,
+                multisampled: false,
+            },
+            count: None,
+        };
+        let scene_blur_params_entry = wgpu::BindGroupLayoutEntry {
+            binding: 6,
+            visibility: wgpu::ShaderStages::FRAGMENT,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Uniform,
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        };
         let blur_rect = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             label: Some("blur_rect_layout"),
             entries: &[
@@ -761,6 +810,8 @@ impl WgpuRenderer {
                     ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                     count: None,
                 },
+                unblurred_texture_entry,
+                scene_blur_params_entry,
             ],
         });
 
@@ -785,6 +836,8 @@ impl WgpuRenderer {
                     count: None,
                 },
                 storage_buffer_entry(4),
+                unblurred_texture_entry,
+                scene_blur_params_entry,
             ],
         });
 
@@ -1342,6 +1395,27 @@ impl WgpuRenderer {
             resources.blur_chain_views[level] = Some(view);
         }
 
+        // Un-blurred framebuffer snapshot, surface-sized. Shares the chain's
+        // color format so sampling between it and `blur_chain_textures[0]`
+        // produces consistent results.
+        let snapshot_texture = resources.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("framebuffer_snapshot"),
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: chain_format,
+            usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        let snapshot_view = snapshot_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        resources.framebuffer_snapshot_texture = Some(snapshot_texture);
+        resources.framebuffer_snapshot_view = Some(snapshot_view);
+
         // Pre-build every bind group for the passes the chain can host.
         // Each pass reads one level and writes the adjacent level; the
         // bind-group inputs (source view + sampler + params buffer) are
@@ -1569,6 +1643,18 @@ impl WgpuRenderer {
         let blur_kernel_levels = scene.max_blur_kernel_levels();
         let blur_radius = scene.max_blur_radius().0;
         let blur_offset_multiplier = (blur_radius / BLUR_REFERENCE_RADIUS_PX).clamp(0.1, 4.0);
+        {
+            let params = SceneBlurParams {
+                max_blur_radius: blur_radius,
+                _pad: [0.0; 3],
+            };
+            let resources = self.resources();
+            resources.queue.write_buffer(
+                &resources.scene_blur_params_buffer,
+                0,
+                bytemuck::bytes_of(&params),
+            );
+        }
 
         loop {
             let mut instance_offset: u64 = 0;
@@ -2084,6 +2170,11 @@ impl WgpuRenderer {
             .queue
             .write_buffer(&resources.blur_params_buffer, 0, &slot_bytes);
 
+        let copy_extent = wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        };
         encoder.copy_texture_to_texture(
             wgpu::TexelCopyTextureInfo {
                 texture: frame_texture,
@@ -2099,12 +2190,25 @@ impl WgpuRenderer {
                 origin: wgpu::Origin3d::ZERO,
                 aspect: wgpu::TextureAspect::All,
             },
-            wgpu::Extent3d {
-                width,
-                height,
-                depth_or_array_layers: 1,
-            },
+            copy_extent,
         );
+        if let Some(snapshot) = resources.framebuffer_snapshot_texture.as_ref() {
+            encoder.copy_texture_to_texture(
+                wgpu::TexelCopyTextureInfo {
+                    texture: frame_texture,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                wgpu::TexelCopyTextureInfo {
+                    texture: snapshot,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                copy_extent,
+            );
+        }
 
         for i in 0..kernel_levels {
             let dst_view = resources.blur_chain_views[i + 1]
@@ -2181,6 +2285,9 @@ impl WgpuRenderer {
         let Some(snapshot_view) = resources.blur_chain_views[0].as_ref() else {
             return true;
         };
+        let Some(unblurred_view) = resources.framebuffer_snapshot_view.as_ref() else {
+            return true;
+        };
         let bind_group = resources
             .device
             .create_bind_group(&wgpu::BindGroupDescriptor {
@@ -2198,6 +2305,14 @@ impl WgpuRenderer {
                     wgpu::BindGroupEntry {
                         binding: 3,
                         resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 5,
+                        resource: wgpu::BindingResource::TextureView(unblurred_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 6,
+                        resource: resources.scene_blur_params_buffer.as_entire_binding(),
                     },
                 ],
             });
@@ -2237,6 +2352,9 @@ impl WgpuRenderer {
         let Some(snapshot_view) = resources.blur_chain_views[0].as_ref() else {
             return true;
         };
+        let Some(unblurred_view) = resources.framebuffer_snapshot_view.as_ref() else {
+            return true;
+        };
         let bind_group = resources
             .device
             .create_bind_group(&wgpu::BindGroupDescriptor {
@@ -2258,6 +2376,14 @@ impl WgpuRenderer {
                     wgpu::BindGroupEntry {
                         binding: 4,
                         resource: self.instance_binding(shapes_offset, shapes_size),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 5,
+                        resource: wgpu::BindingResource::TextureView(unblurred_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 6,
+                        resource: resources.scene_blur_params_buffer.as_entire_binding(),
                     },
                 ],
             });

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -2,8 +2,8 @@ use crate::{CompositorGpuHint, WgpuAtlas, WgpuContext};
 use bytemuck::{Pod, Zeroable};
 use gpui::{
     AtlasTextureId, Background, BlurRect, Bounds, DevicePixels, GpuSpecs, LensRect, LensShape,
-    MonochromeSprite, Path, Point, PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene,
-    Shadow, Size, SubpixelSprite, Underline, get_gamma_correction_ratios,
+    MirrorRect, MonochromeSprite, Path, Point, PolychromeSprite, PrimitiveBatch, Quad,
+    ScaledPixels, Scene, Shadow, Size, SubpixelSprite, Underline, get_gamma_correction_ratios,
 };
 use log::warn;
 #[cfg(not(target_family = "wasm"))]
@@ -113,6 +113,7 @@ struct WgpuPipelines {
     blur_upsample: wgpu::RenderPipeline,
     blur_rect: wgpu::RenderPipeline,
     lens_rect: wgpu::RenderPipeline,
+    mirror_rect: wgpu::RenderPipeline,
 }
 
 struct WgpuBindGroupLayouts {
@@ -123,6 +124,7 @@ struct WgpuBindGroupLayouts {
     blur_io: wgpu::BindGroupLayout,
     blur_rect: wgpu::BindGroupLayout,
     lens_rect: wgpu::BindGroupLayout,
+    mirror_rect: wgpu::BindGroupLayout,
 }
 
 /// Shared GPU context reference, used to coordinate device recovery across multiple windows.
@@ -841,6 +843,31 @@ impl WgpuRenderer {
             ],
         });
 
+        let mirror_rect = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("mirror_rect_layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 3,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+                unblurred_texture_entry,
+                scene_blur_params_entry,
+                storage_buffer_entry(7),
+            ],
+        });
+
         WgpuBindGroupLayouts {
             globals,
             instances,
@@ -849,6 +876,7 @@ impl WgpuRenderer {
             blur_io,
             blur_rect,
             lens_rect,
+            mirror_rect,
         }
     }
 
@@ -1190,6 +1218,17 @@ impl WgpuRenderer {
             &layouts.globals,
             &layouts.lens_rect,
             wgpu::PrimitiveTopology::TriangleStrip,
+            &[Some(color_target.clone())],
+            1,
+            &shader_module,
+        );
+        let mirror_rect = create_pipeline(
+            "mirror_rect",
+            "vs_mirror_rect",
+            "fs_mirror_rect",
+            &layouts.globals,
+            &layouts.mirror_rect,
+            wgpu::PrimitiveTopology::TriangleStrip,
             &[Some(color_target)],
             1,
             &shader_module,
@@ -1209,6 +1248,7 @@ impl WgpuRenderer {
             blur_upsample,
             blur_rect,
             lens_rect,
+            mirror_rect,
         }
     }
 
@@ -1691,7 +1731,9 @@ impl WgpuRenderer {
                 for batch in scene.batches() {
                     let is_blur_batch = matches!(
                         batch,
-                        PrimitiveBatch::BlurRects(_) | PrimitiveBatch::LensRects(_)
+                        PrimitiveBatch::BlurRects(_)
+                            | PrimitiveBatch::LensRects(_)
+                            | PrimitiveBatch::MirrorRects(_)
                     );
                     let ok = match batch {
                         PrimitiveBatch::Quads(range) => {
@@ -1861,6 +1903,51 @@ impl WgpuRenderer {
                                     &mut instance_offset,
                                     &mut pass,
                                 )
+                            } else {
+                                true
+                            }
+                        }
+                        PrimitiveBatch::MirrorRects(range) => {
+                            let rects = &scene.mirror_rects[range];
+                            if rects.is_empty() {
+                                continue;
+                            }
+
+                            drop(pass);
+
+                            let levels = blur_kernel_levels.max(1);
+                            let did_snapshot = if blur_snapshot_valid {
+                                true
+                            } else {
+                                let ok = self.snapshot_and_blur_frame(
+                                    &mut encoder,
+                                    &frame.texture,
+                                    levels,
+                                    blur_offset_multiplier,
+                                );
+                                if ok {
+                                    blur_snapshot_valid = true;
+                                }
+                                ok
+                            };
+
+                            pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                                label: Some("main_pass_continued_mirror"),
+                                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                                    view: &frame_view,
+                                    resolve_target: None,
+                                    ops: wgpu::Operations {
+                                        load: wgpu::LoadOp::Load,
+                                        store: wgpu::StoreOp::Store,
+                                    },
+                                    depth_slice: None,
+                                })],
+                                depth_stencil_attachment: None,
+                                ..Default::default()
+                            });
+
+                            if did_snapshot {
+                                self.draw_mirror_rects(rects, &mut instance_offset, &mut pass)
                             } else {
                                 true
                             }
@@ -2394,6 +2481,61 @@ impl WgpuRenderer {
         true
     }
 
+    fn draw_mirror_rects(
+        &self,
+        rects: &[MirrorRect],
+        instance_offset: &mut u64,
+        pass: &mut wgpu::RenderPass<'_>,
+    ) -> bool {
+        if rects.is_empty() {
+            return true;
+        }
+        let data = unsafe { Self::instance_bytes(rects) };
+        let Some((offset, size)) = self.write_to_instance_buffer(instance_offset, data) else {
+            return false;
+        };
+        let resources = self.resources();
+        let Some(snapshot_view) = resources.blur_chain_views[0].as_ref() else {
+            return true;
+        };
+        let Some(unblurred_view) = resources.framebuffer_snapshot_view.as_ref() else {
+            return true;
+        };
+        let bind_group = resources
+            .device
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("mirror_rect_bind_group"),
+                layout: &resources.bind_group_layouts.mirror_rect,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: wgpu::BindingResource::TextureView(snapshot_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 3,
+                        resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 5,
+                        resource: wgpu::BindingResource::TextureView(unblurred_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 6,
+                        resource: resources.scene_blur_params_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 7,
+                        resource: self.instance_binding(offset, size),
+                    },
+                ],
+            });
+        pass.set_pipeline(&resources.pipelines.mirror_rect);
+        pass.set_bind_group(0, &resources.globals_bind_group, &[]);
+        pass.set_bind_group(1, &bind_group, &[]);
+        pass.draw(0..4, 0..rects.len() as u32);
+        true
+    }
+
     fn draw_paths_from_intermediate(
         &self,
         paths: &[Path<ScaledPixels>],
@@ -2893,5 +3035,6 @@ mod tests {
         let _ = &pipelines.blur_upsample;
         let _ = &pipelines.blur_rect;
         let _ = &pipelines.lens_rect;
+        let _ = &pipelines.mirror_rect;
     }
 }

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -1,7 +1,7 @@
 use crate::{CompositorGpuHint, WgpuAtlas, WgpuContext};
 use bytemuck::{Pod, Zeroable};
 use gpui::{
-    AtlasTextureId, Background, BlurRect, Bounds, DevicePixels, GpuSpecs, LensRect,
+    AtlasTextureId, Background, BlurRect, Bounds, DevicePixels, GpuSpecs, LensRect, LensShape,
     MonochromeSprite, Path, Point, PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene,
     Shadow, Size, SubpixelSprite, Underline, get_gamma_correction_ratios,
 };
@@ -784,6 +784,7 @@ impl WgpuRenderer {
                     ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                     count: None,
                 },
+                storage_buffer_entry(4),
             ],
         });
 
@@ -1768,7 +1769,12 @@ impl WgpuRenderer {
                             });
 
                             if did_snapshot {
-                                self.draw_lens_rects(rects, &mut instance_offset, &mut pass)
+                                self.draw_lens_rects(
+                                    rects,
+                                    &scene.lens_shapes,
+                                    &mut instance_offset,
+                                    &mut pass,
+                                )
                             } else {
                                 true
                             }
@@ -2205,14 +2211,26 @@ impl WgpuRenderer {
     fn draw_lens_rects(
         &self,
         rects: &[LensRect],
+        shapes: &[LensShape],
         instance_offset: &mut u64,
         pass: &mut wgpu::RenderPass<'_>,
     ) -> bool {
         if rects.is_empty() {
             return true;
         }
-        let data = unsafe { Self::instance_bytes(rects) };
-        let Some((offset, size)) = self.write_to_instance_buffer(instance_offset, data) else {
+        if shapes.is_empty() {
+            return false;
+        }
+        let rects_data = unsafe { Self::instance_bytes(rects) };
+        let Some((rects_offset, rects_size)) =
+            self.write_to_instance_buffer(instance_offset, rects_data)
+        else {
+            return false;
+        };
+        let shapes_data = unsafe { Self::instance_bytes(shapes) };
+        let Some((shapes_offset, shapes_size)) =
+            self.write_to_instance_buffer(instance_offset, shapes_data)
+        else {
             return false;
         };
         let resources = self.resources();
@@ -2227,7 +2245,7 @@ impl WgpuRenderer {
                 entries: &[
                     wgpu::BindGroupEntry {
                         binding: 1,
-                        resource: self.instance_binding(offset, size),
+                        resource: self.instance_binding(rects_offset, rects_size),
                     },
                     wgpu::BindGroupEntry {
                         binding: 2,
@@ -2236,6 +2254,10 @@ impl WgpuRenderer {
                     wgpu::BindGroupEntry {
                         binding: 3,
                         resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 4,
+                        resource: self.instance_binding(shapes_offset, shapes_size),
                     },
                 ],
             });

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -62,13 +62,19 @@ struct BlurParams {
 }
 
 /// Scene-wide blur parameters used by the gradient-blur shaders to
-/// normalize per-pixel strength into a [0, 1] mix factor. Written once per
-/// frame and bound to both `blur_rect` and `lens_rect` pipelines.
+/// compute a per-pixel mip level into the preserved downsample pyramid.
+/// Written once per frame and bound to every blur-consuming pipeline.
 #[repr(C)]
 #[derive(Clone, Copy, Pod, Zeroable)]
 struct SceneBlurParams {
+    /// Maximum `blur_radius` anywhere in the scene (see
+    /// `Scene::max_blur_radius`). The per-pixel `target_radius / max`
+    /// ratio becomes the `strength` input to the log2 mip-level formula.
     max_blur_radius: f32,
-    _pad: [f32; 3],
+    /// Number of Kawase downsample passes actually run this frame, as an
+    /// `f32` for the shader's `log2(strength)` clamping math.
+    kernel_levels: f32,
+    _pad: [f32; 2],
 }
 
 #[derive(Clone, Debug)]
@@ -152,11 +158,13 @@ struct WgpuResources {
     /// frame (1..=5).
     blur_chain_textures: [Option<wgpu::Texture>; BLUR_CHAIN_LEVELS],
     blur_chain_views: [Option<wgpu::TextureView>; BLUR_CHAIN_LEVELS],
-    /// Un-blurred copy of the framebuffer, preserved across the Kawase
-    /// chain so variable-radius blur / lens primitives can mix between
-    /// the blurred and un-blurred sources per pixel.
-    framebuffer_snapshot_texture: Option<wgpu::Texture>,
-    framebuffer_snapshot_view: Option<wgpu::TextureView>,
+    /// Preserved downsample pyramid: a single mipmapped texture where mip
+    /// 0 is the un-blurred framebuffer snapshot and each subsequent mip
+    /// holds the Kawase-downsample result of the previous level. Fragment
+    /// shaders sample this with `textureSampleLevel` at fractional LOD to
+    /// produce a per-pixel variable-radius blur.
+    blur_pyramid_texture: Option<wgpu::Texture>,
+    blur_pyramid_view: Option<wgpu::TextureView>,
     /// Bind groups pre-built for downsample/upsample passes. Downsample
     /// pass `i` samples level `i` and writes level `i + 1`; upsample pass
     /// `i` samples level `i + 1` and writes level `i`.
@@ -188,8 +196,8 @@ impl WgpuResources {
         for slot in &mut self.blur_chain_views {
             *slot = None;
         }
-        self.framebuffer_snapshot_texture = None;
-        self.framebuffer_snapshot_view = None;
+        self.blur_pyramid_texture = None;
+        self.blur_pyramid_view = None;
         for slot in &mut self.blur_down_bind_groups {
             *slot = None;
         }
@@ -469,7 +477,9 @@ impl WgpuRenderer {
             address_mode_w: wgpu::AddressMode::ClampToEdge,
             mag_filter: wgpu::FilterMode::Linear,
             min_filter: wgpu::FilterMode::Linear,
-            mipmap_filter: wgpu::MipmapFilterMode::Nearest,
+            // Trilinear filtering between pyramid mip levels gives the
+            // per-pixel variable-radius blur its smooth gradient.
+            mipmap_filter: wgpu::MipmapFilterMode::Linear,
             ..Default::default()
         });
 
@@ -586,8 +596,8 @@ impl WgpuRenderer {
             path_msaa_view: None,
             blur_chain_textures: Default::default(),
             blur_chain_views: Default::default(),
-            framebuffer_snapshot_texture: None,
-            framebuffer_snapshot_view: None,
+            blur_pyramid_texture: None,
+            blur_pyramid_view: None,
             blur_down_bind_groups: Default::default(),
             blur_up_bind_groups: Default::default(),
             blur_sampler,
@@ -772,16 +782,6 @@ impl WgpuRenderer {
             ],
         });
 
-        let unblurred_texture_entry = wgpu::BindGroupLayoutEntry {
-            binding: 5,
-            visibility: wgpu::ShaderStages::FRAGMENT,
-            ty: wgpu::BindingType::Texture {
-                sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                view_dimension: wgpu::TextureViewDimension::D2,
-                multisampled: false,
-            },
-            count: None,
-        };
         let scene_blur_params_entry = wgpu::BindGroupLayoutEntry {
             binding: 6,
             visibility: wgpu::ShaderStages::FRAGMENT,
@@ -812,7 +812,6 @@ impl WgpuRenderer {
                     ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                     count: None,
                 },
-                unblurred_texture_entry,
                 scene_blur_params_entry,
             ],
         });
@@ -838,7 +837,6 @@ impl WgpuRenderer {
                     count: None,
                 },
                 storage_buffer_entry(4),
-                unblurred_texture_entry,
                 scene_blur_params_entry,
             ],
         });
@@ -862,7 +860,6 @@ impl WgpuRenderer {
                     ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                     count: None,
                 },
-                unblurred_texture_entry,
                 scene_blur_params_entry,
                 storage_buffer_entry(7),
             ],
@@ -1435,26 +1432,33 @@ impl WgpuRenderer {
             resources.blur_chain_views[level] = Some(view);
         }
 
-        // Un-blurred framebuffer snapshot, surface-sized. Shares the chain's
-        // color format so sampling between it and `blur_chain_textures[0]`
-        // produces consistent results.
-        let snapshot_texture = resources.device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("framebuffer_snapshot"),
+        // Preserved downsample pyramid. Mip 0 holds the un-blurred
+        // framebuffer snapshot; each subsequent mip is the Kawase
+        // downsample result of the previous level. A single mipmapped
+        // texture plus trilinear sampling lets the fragment shader pick a
+        // fractional LOD per pixel, producing a smooth variable-radius
+        // blur. Clamp the mip count to what the surface size actually
+        // supports: a 16x16 surface can only host 5 mips, not 6.
+        let min_dim = width.min(height).max(1);
+        let max_mips = 32 - min_dim.leading_zeros();
+        let pyramid_mip_count = (BLUR_CHAIN_LEVELS as u32).min(max_mips);
+        let pyramid_texture = resources.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("blur_pyramid"),
             size: wgpu::Extent3d {
                 width,
                 height,
                 depth_or_array_layers: 1,
             },
-            mip_level_count: 1,
+            mip_level_count: pyramid_mip_count,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: chain_format,
             usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
             view_formats: &[],
         });
-        let snapshot_view = snapshot_texture.create_view(&wgpu::TextureViewDescriptor::default());
-        resources.framebuffer_snapshot_texture = Some(snapshot_texture);
-        resources.framebuffer_snapshot_view = Some(snapshot_view);
+        let pyramid_view = pyramid_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        resources.blur_pyramid_texture = Some(pyramid_texture);
+        resources.blur_pyramid_view = Some(pyramid_view);
 
         // Pre-build every bind group for the passes the chain can host.
         // Each pass reads one level and writes the adjacent level; the
@@ -1686,7 +1690,8 @@ impl WgpuRenderer {
         {
             let params = SceneBlurParams {
                 max_blur_radius: blur_radius,
-                _pad: [0.0; 3],
+                kernel_levels: blur_kernel_levels as f32,
+                _pad: [0.0; 2],
             };
             let resources = self.resources();
             resources.queue.write_buffer(
@@ -2279,7 +2284,7 @@ impl WgpuRenderer {
             },
             copy_extent,
         );
-        if let Some(snapshot) = resources.framebuffer_snapshot_texture.as_ref() {
+        if let Some(pyramid) = resources.blur_pyramid_texture.as_ref() {
             encoder.copy_texture_to_texture(
                 wgpu::TexelCopyTextureInfo {
                     texture: frame_texture,
@@ -2288,7 +2293,7 @@ impl WgpuRenderer {
                     aspect: wgpu::TextureAspect::All,
                 },
                 wgpu::TexelCopyTextureInfo {
-                    texture: snapshot,
+                    texture: pyramid,
                     mip_level: 0,
                     origin: wgpu::Origin3d::ZERO,
                     aspect: wgpu::TextureAspect::All,
@@ -2322,6 +2327,46 @@ impl WgpuRenderer {
             pass.set_pipeline(&resources.pipelines.blur_downsample);
             pass.set_bind_group(0, bind_group, &[dynamic_offset]);
             pass.draw(0..3, 0..1);
+        }
+
+        // Preserve the downsample chain into the pyramid before the
+        // upsample loop overwrites `chain[0..kernel_levels-1]`. Each
+        // `chain[i]` is the /2^i-sized result of `i` Kawase downsample
+        // passes, which maps to pyramid mip level `i`. Clamp the copy
+        // extent to the pyramid mip count in case the surface was too
+        // small to host every mip (ensure_intermediate_textures clamps
+        // pyramid mips based on the surface size).
+        if let Some(pyramid) = resources.blur_pyramid_texture.as_ref() {
+            let pyramid_mip_count = pyramid.mip_level_count();
+            for i in 1..=kernel_levels {
+                if (i as u32) >= pyramid_mip_count {
+                    break;
+                }
+                let chain_texture = resources.blur_chain_textures[i]
+                    .as_ref()
+                    .expect("chain level allocated");
+                let level_width = (width >> i).max(1);
+                let level_height = (height >> i).max(1);
+                encoder.copy_texture_to_texture(
+                    wgpu::TexelCopyTextureInfo {
+                        texture: chain_texture,
+                        mip_level: 0,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::All,
+                    },
+                    wgpu::TexelCopyTextureInfo {
+                        texture: pyramid,
+                        mip_level: i as u32,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::All,
+                    },
+                    wgpu::Extent3d {
+                        width: level_width,
+                        height: level_height,
+                        depth_or_array_layers: 1,
+                    },
+                );
+            }
         }
 
         for step in 0..kernel_levels {
@@ -2369,10 +2414,7 @@ impl WgpuRenderer {
             return false;
         };
         let resources = self.resources();
-        let Some(snapshot_view) = resources.blur_chain_views[0].as_ref() else {
-            return true;
-        };
-        let Some(unblurred_view) = resources.framebuffer_snapshot_view.as_ref() else {
+        let Some(pyramid_view) = resources.blur_pyramid_view.as_ref() else {
             return true;
         };
         let bind_group = resources
@@ -2387,15 +2429,11 @@ impl WgpuRenderer {
                     },
                     wgpu::BindGroupEntry {
                         binding: 2,
-                        resource: wgpu::BindingResource::TextureView(snapshot_view),
+                        resource: wgpu::BindingResource::TextureView(pyramid_view),
                     },
                     wgpu::BindGroupEntry {
                         binding: 3,
                         resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 5,
-                        resource: wgpu::BindingResource::TextureView(unblurred_view),
                     },
                     wgpu::BindGroupEntry {
                         binding: 6,
@@ -2436,10 +2474,7 @@ impl WgpuRenderer {
             return false;
         };
         let resources = self.resources();
-        let Some(snapshot_view) = resources.blur_chain_views[0].as_ref() else {
-            return true;
-        };
-        let Some(unblurred_view) = resources.framebuffer_snapshot_view.as_ref() else {
+        let Some(pyramid_view) = resources.blur_pyramid_view.as_ref() else {
             return true;
         };
         let bind_group = resources
@@ -2454,7 +2489,7 @@ impl WgpuRenderer {
                     },
                     wgpu::BindGroupEntry {
                         binding: 2,
-                        resource: wgpu::BindingResource::TextureView(snapshot_view),
+                        resource: wgpu::BindingResource::TextureView(pyramid_view),
                     },
                     wgpu::BindGroupEntry {
                         binding: 3,
@@ -2463,10 +2498,6 @@ impl WgpuRenderer {
                     wgpu::BindGroupEntry {
                         binding: 4,
                         resource: self.instance_binding(shapes_offset, shapes_size),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 5,
-                        resource: wgpu::BindingResource::TextureView(unblurred_view),
                     },
                     wgpu::BindGroupEntry {
                         binding: 6,
@@ -2495,10 +2526,7 @@ impl WgpuRenderer {
             return false;
         };
         let resources = self.resources();
-        let Some(snapshot_view) = resources.blur_chain_views[0].as_ref() else {
-            return true;
-        };
-        let Some(unblurred_view) = resources.framebuffer_snapshot_view.as_ref() else {
+        let Some(pyramid_view) = resources.blur_pyramid_view.as_ref() else {
             return true;
         };
         let bind_group = resources
@@ -2509,15 +2537,11 @@ impl WgpuRenderer {
                 entries: &[
                     wgpu::BindGroupEntry {
                         binding: 2,
-                        resource: wgpu::BindingResource::TextureView(snapshot_view),
+                        resource: wgpu::BindingResource::TextureView(pyramid_view),
                     },
                     wgpu::BindGroupEntry {
                         binding: 3,
                         resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 5,
-                        resource: wgpu::BindingResource::TextureView(unblurred_view),
                     },
                     wgpu::BindGroupEntry {
                         binding: 6,

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -28,6 +28,27 @@ const RENDER_TARGET_FORMAT: DXGI_FORMAT = DXGI_FORMAT_B8G8R8A8_UNORM;
 // This configuration is used for MSAA rendering on paths only, and it's guaranteed to be supported by DirectX 11.
 const PATH_MULTISAMPLE_COUNT: u32 = 4;
 
+// Track whether we've already logged the "not implemented on DirectX"
+// warning for each blur-adjacent primitive kind. The full port is tracked
+// separately; until then, we emit one warning per primitive kind per
+// process so the degradation is visible without spamming every frame.
+static BLUR_RECT_NOT_IMPLEMENTED_WARNED: OnceLock<()> = OnceLock::new();
+static LENS_RECT_NOT_IMPLEMENTED_WARNED: OnceLock<()> = OnceLock::new();
+static MIRROR_RECT_NOT_IMPLEMENTED_WARNED: OnceLock<()> = OnceLock::new();
+
+fn warn_once_primitive_unimplemented(
+    cell: &'static OnceLock<()>,
+    primitive: &'static str,
+) {
+    if cell.set(()).is_ok() {
+        log::warn!(
+            "{primitive} is not yet implemented on the DirectX backend; \
+             these primitives will render as transparent. Tracked as a \
+             follow-up to the blur-primitive PR."
+        );
+    }
+}
+
 pub(crate) struct FontInfo {
     pub gamma_ratios: [f32; 4],
     pub grayscale_enhanced_contrast: f32,
@@ -336,15 +357,24 @@ impl DirectXRenderer {
                 }
                 PrimitiveBatch::Surfaces(range) => self.draw_surfaces(&scene.surfaces[range]),
                 PrimitiveBatch::BlurRects(_) => {
-                    // Not yet implemented on DirectX; tracked as a follow-up.
+                    warn_once_primitive_unimplemented(
+                        &BLUR_RECT_NOT_IMPLEMENTED_WARNED,
+                        "BlurRect",
+                    );
                     Ok(())
                 }
                 PrimitiveBatch::LensRects(_) => {
-                    // Not yet implemented on DirectX; tracked as a follow-up.
+                    warn_once_primitive_unimplemented(
+                        &LENS_RECT_NOT_IMPLEMENTED_WARNED,
+                        "LensRect",
+                    );
                     Ok(())
                 }
                 PrimitiveBatch::MirrorRects(_) => {
-                    // Not yet implemented on DirectX; tracked as a follow-up.
+                    warn_once_primitive_unimplemented(
+                        &MIRROR_RECT_NOT_IMPLEMENTED_WARNED,
+                        "MirrorRect",
+                    );
                     Ok(())
                 }
             }

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -343,10 +343,14 @@ impl DirectXRenderer {
                     // Not yet implemented on DirectX; tracked as a follow-up.
                     Ok(())
                 }
+                PrimitiveBatch::MirrorRects(_) => {
+                    // Not yet implemented on DirectX; tracked as a follow-up.
+                    Ok(())
+                }
             }
             .context(format!(
                 "scene too large:\
-                {} paths, {} shadows, {} quads, {} underlines, {} mono, {} subpixel, {} poly, {} surfaces, {} blur rects, {} lens rects",
+                {} paths, {} shadows, {} quads, {} underlines, {} mono, {} subpixel, {} poly, {} surfaces, {} blur rects, {} lens rects, {} mirror rects",
                 scene.paths.len(),
                 scene.shadows.len(),
                 scene.quads.len(),
@@ -357,6 +361,7 @@ impl DirectXRenderer {
                 scene.surfaces.len(),
                 scene.blur_rects.len(),
                 scene.lens_rects.len(),
+                scene.mirror_rects.len(),
             ))?;
         }
         self.present()


### PR DESCRIPTION
Extends the BlurRect/LensRect stack with the three primitives tahoe-gpui's Phase 2/3 consumers need: multi-shape lens unions (SwiftUI `GlassEffectContainer`), linear-gradient blur strength (HIG scroll-edge), and a framebuffer mirror primitive (SwiftUI `backgroundExtensionEffect`). Metal and wgpu get full implementations with pipeline + shader tests; DirectX stubs are upgraded to `warn_once` pending a follow-up D3D11 port. The variable-radius blur is a `mix(unblurred, max-blurred, t)` approximation that preserves a per-frame `framebuffer_snapshot_texture` alongside the Kawase chain — a mip-pyramid upgrade is noted as follow-up in the plan.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior (scene round-trip, multi-shape, mirror, shape-offset survival; Metal + WGSL pipeline smoke)
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A