### PR TITLE
gpui: Render blur pyramid in place and apply review feedback

### DIFF
--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -135,7 +135,7 @@ impl Scene {
                 blur.order = order;
                 self.blur_rects.push(*blur);
             }
-            Primitive::LensRect(lens) => {
+            Primitive::LensGroup(lens) => {
                 lens.rect.order = order;
                 lens.rect.shape_offset = self.lens_shapes.len() as u32;
                 lens.rect.shape_count = lens.shapes.len() as u32;
@@ -183,9 +183,13 @@ impl Scene {
     /// to size the dual-Kawase snapshot chain for the frame. Returns 0
     /// when no blur-consuming primitive is present.
     pub fn max_blur_kernel_levels(&self) -> u32 {
+        // BlurRect and MirrorRect with zero radius contribute no visible
+        // blur and don't require a pyramid, so filter them. LensRect always
+        // needs the pyramid for refraction sampling even at radius 0.
         let blur = self
             .blur_rects
             .iter()
+            .filter(|b| b.blur_radius.0 > 0.0 || b.blur_radius_end.0 > 0.0)
             .map(|b| b.kernel_levels)
             .max()
             .unwrap_or(0);
@@ -305,18 +309,27 @@ pub enum Primitive {
     PolychromeSprite(PolychromeSprite),
     Surface(PaintSurface),
     BlurRect(BlurRect),
-    LensRect(LensPrimitive),
+    LensGroup(LensPrimitive),
     MirrorRect(MirrorRect),
 }
 
-/// A `LensRect` header paired with its per-shape union inputs. Round-trips
-/// through `PaintOperation::Primitive` so `Scene::replay` can repopulate
-/// `Scene::lens_shapes` with fresh offsets.
+/// A lens primitive as submitted by [`crate::Window::paint_lens_rect_union`]:
+/// the scalar [`LensRect`] header plus the (1..=`MAX_LENS_SHAPES_PER_GROUP`)
+/// [`LensShape`]s it covers.
+///
+/// [`Scene::insert_primitive`] splits this into [`Scene::lens_rects`] and
+/// [`Scene::lens_shapes`], and assigns fresh `shape_offset` / `shape_count`
+/// after [`Scene::finish`]'s sort. Callers should never populate those
+/// offsets by hand — always submit a `LensPrimitive`.
+///
+/// Uses `SmallVec` sized to `MAX_LENS_SHAPES_PER_GROUP` so the usual case
+/// (1..=8 shapes) never allocates, and the `Scene::replay` clone is a
+/// stack copy rather than a fresh heap allocation per replayed lens.
 #[derive(Clone, Debug)]
 #[expect(missing_docs)]
 pub struct LensPrimitive {
     pub rect: LensRect,
-    pub shapes: Vec<LensShape>,
+    pub shapes: smallvec::SmallVec<[LensShape; 8]>,
 }
 
 #[expect(missing_docs)]
@@ -332,7 +345,7 @@ impl Primitive {
             Primitive::PolychromeSprite(sprite) => &sprite.bounds,
             Primitive::Surface(surface) => &surface.bounds,
             Primitive::BlurRect(blur) => &blur.bounds,
-            Primitive::LensRect(lens) => &lens.rect.bounds,
+            Primitive::LensGroup(lens) => &lens.rect.bounds,
             Primitive::MirrorRect(mirror) => &mirror.bounds,
         }
     }
@@ -348,7 +361,7 @@ impl Primitive {
             Primitive::PolychromeSprite(sprite) => &sprite.content_mask,
             Primitive::Surface(surface) => &surface.content_mask,
             Primitive::BlurRect(blur) => &blur.content_mask,
-            Primitive::LensRect(lens) => &lens.rect.content_mask,
+            Primitive::LensGroup(lens) => &lens.rect.content_mask,
             Primitive::MirrorRect(mirror) => &mirror.content_mask,
         }
     }
@@ -747,7 +760,7 @@ pub struct BlurRect {
     /// Pads the stride to 96 bytes so the WGSL `array<BlurRect>` matches
     /// the Rust side (8-byte alignment required for the nested `vec2<f32>`
     /// Bounds).
-    pub _pad_end: [f32; 2],
+    pub pad_end: [f32; 2],
 }
 
 const _: () = assert!(std::mem::size_of::<BlurRect>() == 96);
@@ -783,8 +796,15 @@ pub struct LensRect {
     pub bounds: Bounds<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
     /// Index into `Scene::lens_shapes` of this lens's first shape.
+    ///
+    /// Caller-supplied values are overwritten by
+    /// [`Scene::insert_primitive`] after `finish()`'s sort; submit lens
+    /// primitives via [`LensPrimitive`] rather than constructing a bare
+    /// `LensRect` with hand-picked offsets.
     pub shape_offset: u32,
     /// Number of shapes in this lens (1..=`MAX_LENS_SHAPES_PER_GROUP`).
+    ///
+    /// See [`LensRect::shape_offset`] for the caller-supplied-value caveat.
     pub shape_count: u32,
     /// Smooth-min radius, in pixels, used when merging overlapping shapes
     /// into a single SDF. 0 disables merging (hard min).
@@ -813,7 +833,7 @@ const _: () = assert!(std::mem::size_of::<LensRect>() == 112);
 
 impl From<LensPrimitive> for Primitive {
     fn from(lens: LensPrimitive) -> Self {
-        Primitive::LensRect(lens)
+        Primitive::LensGroup(lens)
     }
 }
 
@@ -1251,7 +1271,8 @@ impl PathVertex<Pixels> {
 #[cfg(test)]
 mod tests {
     use super::{
-        BlurRect, LensPrimitive, LensRect, LensShape, MIRROR_AXIS_HORIZONTAL, MirrorRect,
+        BlurRect, LensPrimitive, LensRect, LensShape, MIRROR_AXIS_HORIZONTAL, MIRROR_AXIS_VERTICAL,
+        MirrorRect,
         PrimitiveBatch, Quad, Scene,
     };
     use crate::{
@@ -1302,7 +1323,7 @@ mod tests {
                 l: 0.0,
                 a: 0.3,
             },
-            _pad_end: [0.0; 2],
+            pad_end: [0.0; 2],
         });
         scene.finish();
 
@@ -1354,7 +1375,7 @@ mod tests {
                 },
                 pad2: 0.0,
             },
-            shapes: vec![test_lens_shape()],
+            shapes: smallvec::smallvec![test_lens_shape()],
         }
     }
 
@@ -1388,7 +1409,7 @@ mod tests {
             origin: point(ScaledPixels(5.0), ScaledPixels(10.0)),
             size: size(ScaledPixels(77.0), ScaledPixels(33.0)),
         };
-        lens.shapes = vec![LensShape {
+        lens.shapes = smallvec::smallvec![LensShape {
             bounds: test_bounds(),
             corner_radii: test_corners(),
             content_mask: custom_mask,
@@ -1455,7 +1476,7 @@ mod tests {
                 l: 0.0,
                 a: 0.3,
             },
-            _pad_end: [0.0; 2],
+            pad_end: [0.0; 2],
         }
     }
 
@@ -1581,10 +1602,28 @@ mod tests {
     #[test]
     fn mirror_rect_round_trip() {
         let mut scene = Scene::default();
-        scene.insert_primitive(make_mirror_rect());
+        let mut inserted = make_mirror_rect();
+        inserted.source_bounds = Bounds {
+            origin: point(ScaledPixels(42.0), ScaledPixels(43.0)),
+            size: size(ScaledPixels(50.0), ScaledPixels(60.0)),
+        };
+        inserted.mirror_axis = MIRROR_AXIS_VERTICAL;
+        inserted.clip_to_destination = 0;
+        inserted.tint = Hsla {
+            h: 0.3,
+            s: 0.4,
+            l: 0.5,
+            a: 0.6,
+        };
+        scene.insert_primitive(inserted);
         scene.finish();
 
         assert_eq!(scene.mirror_rects.len(), 1);
+        let stored = &scene.mirror_rects[0];
+        assert_eq!(stored.source_bounds, inserted.source_bounds);
+        assert_eq!(stored.mirror_axis, inserted.mirror_axis);
+        assert_eq!(stored.clip_to_destination, inserted.clip_to_destination);
+        assert_eq!(stored.tint, inserted.tint);
 
         let batches: Vec<_> = scene.batches().collect();
         assert!(
@@ -1638,5 +1677,130 @@ mod tests {
             blur_batches
         );
         assert_eq!(blur_batches[0].len(), 2);
+    }
+
+    #[test]
+    fn lens_rects_coalesce_when_adjacent() {
+        let mut scene = Scene::default();
+        scene.insert_primitive(make_lens_primitive());
+        scene.insert_primitive(make_lens_primitive());
+        scene.finish();
+
+        let lens_batches: Vec<_> = scene
+            .batches()
+            .filter_map(|b| match b {
+                PrimitiveBatch::LensRects(range) => Some(range),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            lens_batches.len(),
+            1,
+            "expected a single coalesced LensRects batch, got {:?}",
+            lens_batches
+        );
+        assert_eq!(lens_batches[0].len(), 2);
+    }
+
+    #[test]
+    fn mirror_rects_coalesce_when_adjacent() {
+        let mut scene = Scene::default();
+        scene.insert_primitive(make_mirror_rect());
+        scene.insert_primitive(make_mirror_rect());
+        scene.finish();
+
+        let mirror_batches: Vec<_> = scene
+            .batches()
+            .filter_map(|b| match b {
+                PrimitiveBatch::MirrorRects(range) => Some(range),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            mirror_batches.len(),
+            1,
+            "expected a single coalesced MirrorRects batch, got {:?}",
+            mirror_batches
+        );
+        assert_eq!(mirror_batches[0].len(), 2);
+    }
+
+    #[test]
+    fn max_blur_kernel_levels_respects_zero_request() {
+        let mut scene = Scene::default();
+        let mut blur = make_blur_rect();
+        blur.kernel_levels = 0;
+        blur.blur_radius = ScaledPixels(12.0);
+        blur.blur_radius_end = ScaledPixels(12.0);
+        scene.insert_primitive(blur);
+
+        let mut mirror = make_mirror_rect();
+        mirror.kernel_levels = 0;
+        mirror.blur_radius = ScaledPixels(12.0);
+        scene.insert_primitive(mirror);
+
+        scene.finish();
+        // When every primitive asks for kernel_levels == 0, the scene max
+        // stays 0 — the renderer's per-batch fallback is what decides
+        // whether to run any Kawase passes at all.
+        assert_eq!(scene.max_blur_kernel_levels(), 0);
+    }
+
+    #[test]
+    fn blur_rect_without_blur_contributes_zero_kernel() {
+        let mut scene = Scene::default();
+        // BlurRect with both radii at 0: no pyramid work needed, so its
+        // `kernel_levels` must not size the Kawase chain.
+        scene.insert_primitive(BlurRect { ..make_blur_rect() });
+        // Override both radii to zero while keeping kernel_levels high.
+        let last = scene.blur_rects.last_mut().expect("blur rect inserted");
+        last.blur_radius = ScaledPixels(0.0);
+        last.blur_radius_end = ScaledPixels(0.0);
+        last.kernel_levels = 5;
+        scene.finish();
+
+        assert_eq!(scene.max_blur_kernel_levels(), 0);
+    }
+
+    #[test]
+    fn mirror_rect_end_only_radius_contributes_kernel() {
+        // Locks in the OR semantics of the mirror-rect zero-radius filter:
+        // blur_radius == 0 with blur_radius_end > 0 still sizes the chain.
+        let mut scene = Scene::default();
+        let mut mirror = make_mirror_rect();
+        mirror.blur_radius = ScaledPixels(0.0);
+        mirror.blur_radius_end = ScaledPixels(12.0);
+        scene.insert_primitive(mirror);
+        scene.finish();
+        assert_eq!(scene.max_blur_kernel_levels(), 3);
+    }
+
+    #[test]
+    fn lens_and_mirror_rects_interleave_with_quads() {
+        // Blur → non-blur → Blur must produce three distinct batches so
+        // the renderer's snapshot cache invalidates on the non-blur middle.
+        // Regression guard for the batcher's `is_blur_batch` match.
+        let mut scene = Scene::default();
+        scene.insert_primitive(make_quad());
+        scene.insert_primitive(make_lens_primitive());
+        scene.insert_primitive(make_quad());
+        scene.insert_primitive(make_mirror_rect());
+        scene.insert_primitive(make_quad());
+        scene.finish();
+
+        let batch_kinds: Vec<&'static str> = scene
+            .batches()
+            .map(|b| match b {
+                PrimitiveBatch::Quads(_) => "Quads",
+                PrimitiveBatch::LensRects(_) => "LensRects",
+                PrimitiveBatch::MirrorRects(_) => "MirrorRects",
+                PrimitiveBatch::BlurRects(_) => "BlurRects",
+                _ => "Other",
+            })
+            .collect();
+        assert_eq!(
+            batch_kinds,
+            vec!["Quads", "LensRects", "Quads", "MirrorRects", "Quads"],
+        );
     }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -53,7 +53,7 @@ use std::{
     ops::{DerefMut, Range},
     rc::Rc,
     sync::{
-        Arc, Weak,
+        Arc, OnceLock, Weak,
         atomic::{AtomicUsize, Ordering::SeqCst},
     },
     time::Duration,
@@ -3417,7 +3417,7 @@ impl Window {
             blur_radius_end: effect.radius_end.scale(scale_factor),
             gradient_direction: effect.gradient_direction,
             tint: effect.tint.opacity(opacity),
-            _pad_end: [0.0; 2],
+            pad_end: [0.0; 2],
         });
     }
 
@@ -3449,13 +3449,20 @@ impl Window {
     /// distance fields — the GPU-side equivalent of SwiftUI's
     /// `GlassEffectContainer(spacing:)`.
     ///
-    /// `edge_blend_distance` of 0 disables merging: each shape contributes
-    /// its own refraction but they remain visually distinct where they
-    /// overlap. Accepts 1..=`MAX_LENS_SHAPES_PER_GROUP` shapes; violations
-    /// trip a `debug_assert!`.
+    /// `edge_blend_distance` is in window pixels (pre-scale) and defines the
+    /// smooth-minimum radius used when merging shapes' SDFs. The union AABB
+    /// is padded by this distance on every side so the merge field has room
+    /// to settle. Negative values are clamped to zero; `0` disables merging
+    /// entirely.
+    ///
+    /// Accepts 1..=`MAX_LENS_SHAPES_PER_GROUP` shapes; violations trip a
+    /// `debug_assert!`.
     ///
     /// Same render-pass-break caveat as `paint_blur_rect` — keep the number
     /// of lens rects per frame small.
+    ///
+    /// This method should only be called as part of the paint phase of
+    /// element drawing.
     pub fn paint_lens_rect_union(
         &mut self,
         shapes: impl IntoIterator<Item = LensShapeSpec>,
@@ -3478,7 +3485,8 @@ impl Window {
         let content_mask = self.content_mask();
         let opacity = self.element_opacity();
 
-        let mut specs: Vec<LensShapeSpec> = shapes.into_iter().collect();
+        let mut specs: SmallVec<[LensShapeSpec; MAX_LENS_SHAPES_PER_GROUP]> =
+            shapes.into_iter().collect();
         debug_assert!(
             !specs.is_empty(),
             "paint_lens_rect_union requires at least one shape"
@@ -3489,6 +3497,14 @@ impl Window {
             specs.len()
         );
         if specs.is_empty() {
+            static EMPTY_WARNED: OnceLock<()> = OnceLock::new();
+            if EMPTY_WARNED.set(()).is_ok() {
+                log::warn!(
+                    "paint_lens_rect_union called with no shapes; the lens will \
+                     not render. Callers filtering dynamic inputs should early-out \
+                     before calling this."
+                );
+            }
             return;
         }
         specs.truncate(MAX_LENS_SHAPES_PER_GROUP);
@@ -3510,7 +3526,7 @@ impl Window {
         // masks are intersected with the element's mask so callers can't
         // bypass the element clip.
         let element_mask_bounds = content_mask.bounds;
-        let scaled_shapes: Vec<LensShape> = specs
+        let scaled_shapes: SmallVec<[LensShape; MAX_LENS_SHAPES_PER_GROUP]> = specs
             .into_iter()
             .map(|spec| {
                 let shape_mask = spec
@@ -3560,6 +3576,9 @@ impl Window {
     ///
     /// Like `paint_blur_rect` and `paint_lens_rect`, each mirror rect
     /// forces a render-pass break so the framebuffer can be sampled.
+    ///
+    /// This method should only be called as part of the paint phase of
+    /// element drawing.
     pub fn paint_mirror_rect(
         &mut self,
         source: Bounds<Pixels>,
@@ -6372,6 +6391,8 @@ impl MirrorAxis {
 }
 
 /// Configuration for [`Window::paint_mirror_rect`].
+///
+/// Defaults: horizontal flip, clip-to-destination enabled, no blur, no tint.
 #[derive(Clone, Copy, Debug)]
 pub struct MirrorEffect {
     /// How to flip the sampled source region.
@@ -6381,6 +6402,8 @@ pub struct MirrorEffect {
     pub clip_to_destination: bool,
     /// Optional backdrop blur applied to the mirrored source. When
     /// `None`, the un-blurred framebuffer snapshot is sampled directly.
+    /// See [`BlurEffect`] for uniform vs. linear-gradient semantics — the
+    /// gradient, if any, is evaluated in destination (not source) space.
     pub blur: Option<BlurEffect>,
     /// Color overlay applied after mirroring.
     pub tint: Hsla,
@@ -6411,5 +6434,50 @@ impl MirrorEffect {
     pub fn with_blur(mut self, blur: BlurEffect) -> Self {
         self.blur = Some(blur);
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mirror_axis_flags_map_to_expected_bits() {
+        assert_eq!(MirrorAxis::None.flags(), 0);
+        assert_eq!(MirrorAxis::Horizontal.flags(), MIRROR_AXIS_HORIZONTAL);
+        assert_eq!(MirrorAxis::Vertical.flags(), MIRROR_AXIS_VERTICAL);
+        assert_eq!(
+            MirrorAxis::Both.flags(),
+            MIRROR_AXIS_HORIZONTAL | MIRROR_AXIS_VERTICAL,
+        );
+    }
+
+    #[test]
+    fn blur_effect_linear_gradient_sets_axis() {
+        let horizontal = BlurEffect::linear_gradient(px(0.0), px(20.0), BlurAxis::Horizontal);
+        assert_eq!(horizontal.radius, px(0.0));
+        assert_eq!(horizontal.radius_end, px(20.0));
+        assert_eq!(horizontal.gradient_direction, [1.0, 0.0]);
+
+        let vertical = BlurEffect::linear_gradient(px(5.0), px(12.0), BlurAxis::Vertical);
+        assert_eq!(vertical.gradient_direction, [0.0, 1.0]);
+    }
+
+    #[test]
+    fn lens_effect_linear_gradient_sets_axis() {
+        let horizontal = LensEffect::linear_gradient(px(0.0), px(20.0), BlurAxis::Horizontal);
+        assert_eq!(horizontal.radius, px(0.0));
+        assert_eq!(horizontal.radius_end, px(20.0));
+        assert_eq!(horizontal.gradient_direction, [1.0, 0.0]);
+
+        let vertical = LensEffect::linear_gradient(px(5.0), px(12.0), BlurAxis::Vertical);
+        assert_eq!(vertical.gradient_direction, [0.0, 1.0]);
+    }
+
+    #[test]
+    fn with_gradient_direction_overrides_axis() {
+        let effect =
+            BlurEffect::default().with_gradient_direction([0.5f32.sqrt(), 0.5f32.sqrt()]);
+        assert_eq!(effect.gradient_direction, [0.5f32.sqrt(), 0.5f32.sqrt()]);
     }
 }

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -27,7 +27,12 @@ use metal::{
 use objc::{self, msg_send, sel, sel_impl};
 use parking_lot::Mutex;
 
-use std::{cell::Cell, ffi::c_void, mem, ptr, sync::Arc};
+use std::{
+    cell::Cell,
+    ffi::c_void,
+    mem, ptr,
+    sync::{Arc, OnceLock},
+};
 
 // Exported to metal
 pub(crate) type PointF = gpui::Point<f32>;
@@ -39,6 +44,18 @@ const SHADERS_SOURCE_FILE: &str = include_str!(concat!(env!("OUT_DIR"), "/stitch
 // Use 4x MSAA, all devices support it.
 // https://developer.apple.com/documentation/metal/mtldevice/1433355-supportstexturesamplecount
 const PATH_SAMPLE_COUNT: u32 = 4;
+
+static FRAME_SAMPLING_DISABLED_WARNED: OnceLock<()> = OnceLock::new();
+
+fn warn_frame_sampling_disabled() {
+    if FRAME_SAMPLING_DISABLED_WARNED.set(()).is_ok() {
+        log::warn!(
+            "Skipping BlurRect/LensRect/MirrorRect: Metal renderer was constructed \
+             with enable_frame_sampling=false. Re-create the window with frame \
+             sampling enabled to paint these primitives."
+        );
+    }
+}
 
 pub(crate) type Context = Arc<Mutex<InstanceBufferPool>>;
 pub(crate) type Renderer = MetalRenderer;
@@ -139,30 +156,23 @@ pub(crate) struct MetalRenderer {
     path_intermediate_msaa_texture: Option<metal::Texture>,
     path_sample_count: u32,
     blur_downsample_pipeline_state: metal::RenderPipelineState,
-    blur_upsample_pipeline_state: metal::RenderPipelineState,
     blur_rect_pipeline_state: metal::RenderPipelineState,
     lens_rect_pipeline_state: metal::RenderPipelineState,
     mirror_rect_pipeline_state: metal::RenderPipelineState,
     blur_sampler: metal::SamplerState,
-    /// Dual-Kawase scratch chain. `blur_chain_textures[0]` is surface-sized
-    /// and receives the framebuffer snapshot; each subsequent level is
-    /// half-sized. `BlurEffect::kernel_levels` selects the depth used per
-    /// frame (1..=5). The upsample phase overwrites `chain[0..N-1]`, so
-    /// fragment shaders sample `blur_pyramid_texture` for intermediate
-    /// blur radii, not the chain.
-    blur_chain_textures: [Option<metal::Texture>; BLUR_CHAIN_LEVELS],
-    /// Preserved downsample pyramid: a single mipmapped texture where mip
-    /// 0 is the un-blurred framebuffer snapshot and each subsequent mip is
-    /// the Kawase-downsample result of the previous level. Written once
-    /// per frame after the Kawase downsample loop (before upsample would
-    /// overwrite the chain). Fragment shaders sample this with
+    /// Downsample pyramid: a single mipmapped texture where mip 0 is the
+    /// un-blurred framebuffer snapshot and each subsequent mip holds the
+    /// Kawase-downsample result of the previous level. Written in-place
+    /// by `snapshot_and_blur_frame` using per-mip texture views for the
+    /// sampled input and `RenderPassColorAttachmentDescriptor::set_level`
+    /// for the output. Fragment shaders sample this with
     /// `textureSampleLevel` at fractional LOD to produce a per-pixel
     /// variable-radius blur.
     blur_pyramid_texture: Option<metal::Texture>,
 }
 
-/// Maximum blur chain depth (`kernel_levels` is clamped to this).
-const BLUR_CHAIN_LEVELS: usize = 6;
+/// Maximum blur pyramid depth (`kernel_levels` is clamped to this).
+const BLUR_PYRAMID_LEVELS: usize = 6;
 /// Reference blur radius. `BlurEffect::radius` scales the Kawase offset
 /// multiplier linearly relative to this.
 const BLUR_REFERENCE_RADIUS_PX: f32 = 20.0;
@@ -392,14 +402,6 @@ impl MetalRenderer {
             "blur_downsample_fragment",
             MTLPixelFormat::BGRA8Unorm,
         );
-        let blur_upsample_pipeline_state = build_blur_io_pipeline_state(
-            &device,
-            &library,
-            "blur_upsample",
-            "blur_fullscreen_vertex",
-            "blur_upsample_fragment",
-            MTLPixelFormat::BGRA8Unorm,
-        );
         let blur_rect_pipeline_state = build_pipeline_state(
             &device,
             &library,
@@ -467,12 +469,10 @@ impl MetalRenderer {
             path_intermediate_msaa_texture: None,
             path_sample_count: PATH_SAMPLE_COUNT,
             blur_downsample_pipeline_state,
-            blur_upsample_pipeline_state,
             blur_rect_pipeline_state,
             lens_rect_pipeline_state,
             mirror_rect_pipeline_state,
             blur_sampler,
-            blur_chain_textures: Default::default(),
             blur_pyramid_texture: None,
         }
     }
@@ -522,9 +522,7 @@ impl MetalRenderer {
         if size.width.0 <= 0 || size.height.0 <= 0 {
             self.path_intermediate_texture = None;
             self.path_intermediate_msaa_texture = None;
-            for slot in &mut self.blur_chain_textures {
-                *slot = None;
-            }
+            self.blur_pyramid_texture = None;
             return;
         }
 
@@ -556,37 +554,31 @@ impl MetalRenderer {
         }
 
         if self.frame_sampling_enabled {
-            for level in 0..BLUR_CHAIN_LEVELS {
-                let width = (size.width.0 as u64).max(1) >> level;
-                let height = (size.height.0 as u64).max(1) >> level;
-                let width = width.max(1);
-                let height = height.max(1);
-
-                let descriptor = metal::TextureDescriptor::new();
-                descriptor.set_width(width);
-                descriptor.set_height(height);
-                descriptor.set_pixel_format(metal::MTLPixelFormat::BGRA8Unorm);
-                descriptor.set_storage_mode(metal::MTLStorageMode::Private);
-                descriptor.set_usage(
-                    metal::MTLTextureUsage::RenderTarget | metal::MTLTextureUsage::ShaderRead,
-                );
-                self.blur_chain_textures[level] = Some(self.device.new_texture(&descriptor));
-            }
-
             let width = (size.width.0 as u64).max(1);
             let height = (size.height.0 as u64).max(1);
+            // Clamp the mip count to what the surface size actually supports:
+            // a 16x16 surface can only host 5 mips, not 6. Metal rejects the
+            // descriptor if we ask for more than min(log2(width), log2(height))
+            // mip levels and returns nil, which subsequent blit / shader
+            // binds then dereference.
+            let min_dim = width.min(height);
+            let max_mips = 64 - min_dim.leading_zeros() as u64;
+            let pyramid_mip_count = (BLUR_PYRAMID_LEVELS as u64).min(max_mips);
             let descriptor = metal::TextureDescriptor::new();
             descriptor.set_width(width);
             descriptor.set_height(height);
             descriptor.set_pixel_format(metal::MTLPixelFormat::BGRA8Unorm);
-            descriptor.set_mipmap_level_count(BLUR_CHAIN_LEVELS as u64);
+            descriptor.set_mipmap_level_count(pyramid_mip_count);
             descriptor.set_storage_mode(metal::MTLStorageMode::Private);
-            descriptor.set_usage(metal::MTLTextureUsage::ShaderRead);
+            // `RenderTarget` so the downsample render passes can write mips
+            // 1..N directly via `color_attachment.set_level`. `ShaderRead`
+            // for both the per-pass input view and the fragment shaders'
+            // fractional-LOD sampling.
+            descriptor.set_usage(
+                metal::MTLTextureUsage::RenderTarget | metal::MTLTextureUsage::ShaderRead,
+            );
             self.blur_pyramid_texture = Some(self.device.new_texture(&descriptor));
         } else {
-            for slot in &mut self.blur_chain_textures {
-                *slot = None;
-            }
             self.blur_pyramid_texture = None;
         }
     }
@@ -1031,7 +1023,10 @@ impl MetalRenderer {
                 PrimitiveBatch::SubpixelSprites { .. } => unreachable!(),
                 PrimitiveBatch::BlurRects(range) => {
                     let rects = &scene.blur_rects[range];
-                    if rects.is_empty() || !self.frame_sampling_enabled {
+                    if rects.is_empty() {
+                        true
+                    } else if !self.frame_sampling_enabled {
+                        warn_frame_sampling_disabled();
                         true
                     } else {
                         command_encoder.end_encoding();
@@ -1074,7 +1069,10 @@ impl MetalRenderer {
                 }
                 PrimitiveBatch::LensRects(range) => {
                     let rects = &scene.lens_rects[range];
-                    if rects.is_empty() || !self.frame_sampling_enabled {
+                    if rects.is_empty() {
+                        true
+                    } else if !self.frame_sampling_enabled {
+                        warn_frame_sampling_disabled();
                         true
                     } else {
                         command_encoder.end_encoding();
@@ -1118,7 +1116,10 @@ impl MetalRenderer {
                 }
                 PrimitiveBatch::MirrorRects(range) => {
                     let rects = &scene.mirror_rects[range];
-                    if rects.is_empty() || !self.frame_sampling_enabled {
+                    if rects.is_empty() {
+                        true
+                    } else if !self.frame_sampling_enabled {
+                        warn_frame_sampling_disabled();
                         true
                     } else {
                         command_encoder.end_encoding();
@@ -1128,11 +1129,14 @@ impl MetalRenderer {
                         let did_snapshot = if blur_snapshot_valid {
                             true
                         } else {
-                            let levels = blur_kernel_levels.max(1);
+                            // `snapshot_and_blur_frame` accepts `levels == 0`
+                            // and skips the Kawase passes; use that fast path
+                            // when no blur-consuming primitive in the scene
+                            // asked for a blur radius.
                             let ok = self.snapshot_and_blur_frame(
                                 texture,
                                 viewport_size,
-                                levels,
+                                blur_kernel_levels,
                                 blur_offset_multiplier,
                                 command_buffer,
                             );
@@ -1508,31 +1512,28 @@ impl MetalRenderer {
         if viewport_size.width.0 <= 0 || viewport_size.height.0 <= 0 {
             return false;
         }
-        let kernel_levels = kernel_levels.clamp(1, (BLUR_CHAIN_LEVELS - 1) as u32) as usize;
-
-        // All chain levels we need must be populated. Any None means the
-        // renderer was initialized without `enable_frame_sampling`.
-        for level in 0..=kernel_levels {
-            if self.blur_chain_textures[level].is_none() {
-                return false;
-            }
-        }
-
-        let snapshot = self.blur_chain_textures[0]
-            .as_ref()
-            .expect("chain level 0 checked above");
         let Some(ref pyramid) = self.blur_pyramid_texture else {
             return false;
         };
+        let pyramid_mip_count = pyramid.mipmap_level_count() as usize;
 
+        // `kernel_levels == 0` means no primitive in the scene actually
+        // requested blur (e.g., mirror-only batches with zero radius);
+        // skip the Kawase passes entirely and just snapshot mip 0. The
+        // pyramid may have fewer mips than requested on small surfaces
+        // (see `update_path_intermediate_textures`'s clamp), so also cap
+        // to what the pyramid can host.
+        let kernel_levels = (kernel_levels as usize)
+            .min(BLUR_PYRAMID_LEVELS - 1)
+            .min(pyramid_mip_count.saturating_sub(1));
+
+        // Initial snapshot: swapchain → pyramid mip 0.
         let blit = command_buffer.new_blit_command_encoder();
         let full_size = metal::MTLSize {
             width: texture.width(),
             height: texture.height(),
             depth: 1,
         };
-        // Mip 0 of the pyramid is the un-blurred framebuffer; the Kawase
-        // chain runs in parallel on `blur_chain_textures`.
         blit.copy_from_texture(
             texture,
             0,
@@ -1544,32 +1545,27 @@ impl MetalRenderer {
             0,
             metal::MTLOrigin { x: 0, y: 0, z: 0 },
         );
-        blit.copy_from_texture(
-            texture,
-            0,
-            0,
-            metal::MTLOrigin { x: 0, y: 0, z: 0 },
-            full_size,
-            snapshot,
-            0,
-            0,
-            metal::MTLOrigin { x: 0, y: 0, z: 0 },
-        );
         blit.end_encoding();
 
+        // Kawase downsample: each pass samples pyramid mip `i` (via a
+        // single-mip texture view) and renders into pyramid mip `i + 1`
+        // (via `color_attachment.set_level`). Different subresources of
+        // the same texture, which Metal sequences with the implicit
+        // dependency barriers between render command encoders.
         for i in 0..kernel_levels {
-            let src = self.blur_chain_textures[i]
-                .as_ref()
-                .expect("chain level checked above");
-            let dst = self.blur_chain_textures[i + 1]
-                .as_ref()
-                .expect("chain level checked above");
+            let src_view = pyramid.new_texture_view_from_slice(
+                pyramid.pixel_format(),
+                metal::MTLTextureType::D2,
+                NSRange::new(i as u64, 1),
+                NSRange::new(0, 1),
+            );
             let src_w = ((viewport_size.width.0 as f32) * 0.5f32.powi(i as i32)).max(1.0);
             let src_h = ((viewport_size.height.0 as f32) * 0.5f32.powi(i as i32)).max(1.0);
             self.run_blur_pass(
                 command_buffer,
-                src,
-                dst,
+                &src_view,
+                pyramid,
+                (i + 1) as u64,
                 &self.blur_downsample_pipeline_state,
                 BlurParams {
                     viewport_size: [src_w, src_h],
@@ -1579,58 +1575,6 @@ impl MetalRenderer {
             );
         }
 
-        // Preserve the downsample chain into pyramid mip levels before the
-        // upsample loop overwrites `chain[0..N-1]`. Each `chain[i]` is the
-        // /2^i-sized result of `i` Kawase downsample passes, which maps to
-        // pyramid mip level `i`.
-        let preserve_blit = command_buffer.new_blit_command_encoder();
-        for i in 1..=kernel_levels {
-            let src = self.blur_chain_textures[i]
-                .as_ref()
-                .expect("chain level checked above");
-            let width = ((viewport_size.width.0 as u64) >> i).max(1);
-            let height = ((viewport_size.height.0 as u64) >> i).max(1);
-            preserve_blit.copy_from_texture(
-                src,
-                0,
-                0,
-                metal::MTLOrigin { x: 0, y: 0, z: 0 },
-                metal::MTLSize {
-                    width,
-                    height,
-                    depth: 1,
-                },
-                pyramid,
-                0,
-                i as u64,
-                metal::MTLOrigin { x: 0, y: 0, z: 0 },
-            );
-        }
-        preserve_blit.end_encoding();
-
-        for step in 0..kernel_levels {
-            let src_level = kernel_levels - step;
-            let dst_level = src_level - 1;
-            let src = self.blur_chain_textures[src_level]
-                .as_ref()
-                .expect("chain level checked above");
-            let dst = self.blur_chain_textures[dst_level]
-                .as_ref()
-                .expect("chain level checked above");
-            let src_w = ((viewport_size.width.0 as f32) * 0.5f32.powi(src_level as i32)).max(1.0);
-            let src_h = ((viewport_size.height.0 as f32) * 0.5f32.powi(src_level as i32)).max(1.0);
-            self.run_blur_pass(
-                command_buffer,
-                src,
-                dst,
-                &self.blur_upsample_pipeline_state,
-                BlurParams {
-                    viewport_size: [src_w, src_h],
-                    offset_multiplier,
-                    pad: 0.0,
-                },
-            );
-        }
         true
     }
 
@@ -1639,12 +1583,14 @@ impl MetalRenderer {
         command_buffer: &metal::CommandBufferRef,
         input: &metal::TextureRef,
         output: &metal::TextureRef,
+        output_mip_level: u64,
         pipeline: &metal::RenderPipelineStateRef,
         params: BlurParams,
     ) {
         let descriptor = metal::RenderPassDescriptor::new();
         let color_attachment = descriptor.color_attachments().object_at(0).unwrap();
         color_attachment.set_texture(Some(output));
+        color_attachment.set_level(output_mip_level);
         color_attachment.set_load_action(metal::MTLLoadAction::DontCare);
         color_attachment.set_store_action(metal::MTLStoreAction::Store);
 
@@ -1680,6 +1626,20 @@ impl MetalRenderer {
             return false;
         };
         align_offset(instance_offset);
+
+        // Bounds-check and copy the instance data before mutating the
+        // encoder: an overflow early-return otherwise leaves pipeline /
+        // buffer / texture state dirtied for a draw that never runs.
+        let bytes_len = mem::size_of_val(rects);
+        let next_offset = *instance_offset + bytes_len;
+        if next_offset > instance_buffer.size {
+            return false;
+        }
+        let buffer_contents =
+            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
+        unsafe {
+            ptr::copy_nonoverlapping(rects.as_ptr() as *const u8, buffer_contents, bytes_len);
+        }
 
         command_encoder.set_render_pipeline_state(&self.blur_rect_pipeline_state);
         command_encoder.set_vertex_buffer(
@@ -1718,17 +1678,6 @@ impl MetalRenderer {
             BlurRectInputIndex::BlurSampler as u64,
             Some(&self.blur_sampler),
         );
-
-        let bytes_len = mem::size_of_val(rects);
-        let next_offset = *instance_offset + bytes_len;
-        if next_offset > instance_buffer.size {
-            return false;
-        }
-        let buffer_contents =
-            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
-        unsafe {
-            ptr::copy_nonoverlapping(rects.as_ptr() as *const u8, buffer_contents, bytes_len);
-        }
 
         command_encoder.draw_primitives_instanced(
             metal::MTLPrimitiveType::Triangle,
@@ -1862,6 +1811,17 @@ impl MetalRenderer {
         };
         align_offset(instance_offset);
 
+        // Bounds-check and copy before touching the encoder state.
+        let bytes_len = mem::size_of_val(rects);
+        let next_offset = *instance_offset + bytes_len;
+        if next_offset > instance_buffer.size {
+            return false;
+        }
+        unsafe {
+            let dst = (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset);
+            ptr::copy_nonoverlapping(rects.as_ptr() as *const u8, dst, bytes_len);
+        }
+
         command_encoder.set_render_pipeline_state(&self.mirror_rect_pipeline_state);
         command_encoder.set_vertex_buffer(
             MirrorRectInputIndex::Vertices as u64,
@@ -1899,16 +1859,6 @@ impl MetalRenderer {
             MirrorRectInputIndex::BlurSampler as u64,
             Some(&self.blur_sampler),
         );
-
-        let bytes_len = mem::size_of_val(rects);
-        let next_offset = *instance_offset + bytes_len;
-        if next_offset > instance_buffer.size {
-            return false;
-        }
-        unsafe {
-            let dst = (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset);
-            ptr::copy_nonoverlapping(rects.as_ptr() as *const u8, dst, bytes_len);
-        }
 
         command_encoder.draw_primitives_instanced(
             metal::MTLPrimitiveType::Triangle,
@@ -2557,7 +2507,10 @@ mod tests {
     #[test]
     fn pipeline_creation_smoke() {
         if metal::Device::system_default().is_none() {
-            // No Metal device (some CI runners). Nothing to verify here.
+            if std::env::var("CI").is_ok() {
+                panic!("pipeline_creation_smoke requires a Metal device on CI");
+            }
+            eprintln!("skipping pipeline_creation_smoke: no Metal device available");
             return;
         }
         let instance_buffer_pool = Arc::new(Mutex::new(InstanceBufferPool::default()));
@@ -2566,7 +2519,6 @@ mod tests {
         // Touch each new pipeline field so a missing entry point or a
         // linker failure surfaces here rather than on the first draw.
         let _ = renderer.blur_downsample_pipeline_state.as_ptr();
-        let _ = renderer.blur_upsample_pipeline_state.as_ptr();
         let _ = renderer.blur_rect_pipeline_state.as_ptr();
         let _ = renderer.lens_rect_pipeline_state.as_ptr();
         let _ = renderer.mirror_rect_pipeline_state.as_ptr();

--- a/crates/gpui_macos/src/shaders.metal
+++ b/crates/gpui_macos/src/shaders.metal
@@ -1321,25 +1321,6 @@ fragment float4 blur_downsample_fragment(
   return float4(blur_encode_srgb(averaged.rgb), averaged.a);
 }
 
-fragment float4 blur_upsample_fragment(
-  BlurFullscreenVarying input [[stage_in]],
-  texture2d<float> blur_input [[texture(BlurIoInputIndex_InputTexture)]],
-  sampler blur_sampler [[sampler(BlurIoInputIndex_InputSampler)]],
-  constant BlurParams *params [[buffer(BlurIoInputIndex_Params)]]
-) {
-  float2 o = 0.5 / params->viewport_size * params->offset_multiplier;
-  float4 color = blur_sample_linear(blur_input, blur_sampler, input.uv + float2(-o.x,  o.y)) * 2.0;
-  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2( o.x,  o.y)) * 2.0;
-  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2(-o.x, -o.y)) * 2.0;
-  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2( o.x, -o.y)) * 2.0;
-  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2(-o.x * 2.0, 0.0));
-  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2( o.x * 2.0, 0.0));
-  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2(0.0, -o.y * 2.0));
-  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2(0.0,  o.y * 2.0));
-  float4 averaged = color / 12.0;
-  return float4(blur_encode_srgb(averaged.rgb), averaged.a);
-}
-
 // --- BlurRect: rounded rect that samples the blurred framebuffer ---
 
 struct BlurRectVarying {
@@ -1386,10 +1367,13 @@ float gradient_target_radius(
   if (dir_len2 < 1e-6) {
     return radius_start;
   }
+  // Normalize inside so the mapping is magnitude-invariant in
+  // `gradient_direction`; keeps the MSL side bit-identical with WGSL.
+  float2 dir = gradient_direction * rsqrt(dir_len2);
   float2 local = frag_pos - float2(bounds.origin.x, bounds.origin.y);
   float2 size_v = float2(bounds.size.width, bounds.size.height);
-  float extent = max(dot(size_v, gradient_direction), 1.0);
-  float t = clamp(dot(local, gradient_direction) / extent, 0.0, 1.0);
+  float extent = max(dot(size_v, dir), 1.0);
+  float t = clamp(dot(local, dir) / extent, 0.0, 1.0);
   return mix(radius_start, radius_end, t);
 }
 
@@ -1518,7 +1502,7 @@ fragment float4 lens_rect_fragment(
   float2 frag_pos = input.position.xy;
   uint shape_count = rect.shape_count;
   if (shape_count == 0u) {
-    discard_fragment();
+    return float4(0.0, 0.0, 0.0, 0.0);
   }
   float blend_k = max(rect.edge_blend_distance, 0.0);
   bool blend_shapes = blend_k > 0.0 && shape_count > 1u;
@@ -1527,11 +1511,14 @@ fragment float4 lens_rect_fragment(
   // attenuation (0 outside the shape's own `content_mask`, 1 inside,
   // with a ~1-pixel feather).
   const float antialias_threshold = 0.5;
+  // Mirror of `MAX_LENS_SHAPES` in shaders.wgsl / MAX_LENS_SHAPES_PER_GROUP
+  // in window.rs; bumping either requires bumping the others in lockstep.
+  constexpr uint MAX_LENS_SHAPES = 8u;
   Corners_ScaledPixels zero_corners = {0.0, 0.0, 0.0, 0.0};
-  float per_shape_sdf[8];
-  float per_shape_mask_attn[8];
-  float2 per_shape_dir[8];
-  float per_shape_norm_dist[8];
+  float per_shape_sdf[MAX_LENS_SHAPES];
+  float per_shape_mask_attn[MAX_LENS_SHAPES];
+  float2 per_shape_dir[MAX_LENS_SHAPES];
+  float per_shape_norm_dist[MAX_LENS_SHAPES];
   float min_sdf = 1e20;
   for (uint i = 0u; i < shape_count; ++i) {
     LensShape s = shapes[rect.shape_offset + i];
@@ -1554,7 +1541,7 @@ fragment float4 lens_rect_fragment(
   }
 
   float union_sdf;
-  float weights[8];
+  float weights[MAX_LENS_SHAPES];
   // Scales the final fragment alpha to fade at per-shape mask boundaries.
   // 1 when every shape is fully inside its own mask (or no mask in play);
   // smoothly decreases as shapes' mask edges cross the fragment.
@@ -1575,7 +1562,7 @@ fragment float4 lens_rect_fragment(
       total_masked += masked;
     }
     if (total_masked < 1e-6) {
-      discard_fragment();
+      return float4(0.0, 0.0, 0.0, 0.0);
     }
     // Softmin value: -k * log(Σ exp(-d_i / k)), shifted by min_d to avoid
     // overflow. Unmasked sum preserves the geometric union outline even
@@ -1583,8 +1570,11 @@ fragment float4 lens_rect_fragment(
     // refraction weights, not the shape boundary itself.
     union_sdf = min_d - blend_k * log(max(total_pre, 1e-6));
     float inv_masked = 1.0 / max(total_masked, 1e-6);
+    // Clamp to [0, 1]: when `total_masked` approaches the 1e-6 floor,
+    // individual weights can scale past 1.0 and blow up the refraction
+    // accumulator. Matches the WGSL side.
     for (uint i = 0u; i < shape_count; ++i) {
-      weights[i] *= inv_masked;
+      weights[i] = clamp(weights[i] * inv_masked, 0.0, 1.0);
     }
     coverage_factor = clamp(total_masked / max(total_pre, 1e-6), 0.0, 1.0);
   } else {
@@ -1603,13 +1593,13 @@ fragment float4 lens_rect_fragment(
     }
     coverage_factor = per_shape_mask_attn[winner];
     if (coverage_factor < 1e-3) {
-      discard_fragment();
+      return float4(0.0, 0.0, 0.0, 0.0);
     }
   }
 
   float aa = saturate(antialias_threshold - union_sdf) * coverage_factor;
   if (aa <= 0.0) {
-    discard_fragment();
+    return float4(0.0, 0.0, 0.0, 0.0);
   }
 
   // Pass 2: weighted refraction offset. The per-shape parabolic distortion
@@ -1618,6 +1608,10 @@ fragment float4 lens_rect_fragment(
   float depth_scale = clamp(rect.depth * 0.01, 0.0, 1.0);
   float2 offset_px = float2(0.0, 0.0);
   float weighted_norm_dist = 0.0;
+  // `weighted_dir` is a weighted *sum* of unit directions, not a unit
+  // vector. Between shapes with opposing centers it shrinks toward zero,
+  // which fades chromatic dispersion in inter-shape seams. Do not
+  // renormalize — matches WGSL.
   float2 weighted_dir = float2(0.0, 0.0);
   for (uint i = 0u; i < shape_count; ++i) {
     float nd = per_shape_norm_dist[i];
@@ -1627,7 +1621,14 @@ fragment float4 lens_rect_fragment(
     weighted_dir += weights[i] * per_shape_dir[i];
   }
   float2 base_uv = frag_pos / viewport_f;
-  float2 refracted_uv = base_uv - offset_px / viewport_f;
+  // Clamp to [0,1]: strong `refraction` on lens rims can push UVs past
+  // the edge. The pyramid sampler is ClampToEdge, but clamp here too so
+  // a future sampler-state change can't silently wrap across the frame.
+  float2 refracted_uv = clamp(
+      base_uv - offset_px / viewport_f,
+      float2(0.0, 0.0),
+      float2(1.0, 1.0)
+  );
   float target_radius = gradient_target_radius(
     frag_pos,
     rect.bounds,
@@ -1719,7 +1720,7 @@ fragment float4 mirror_rect_fragment(
   // Normalized position within the destination rect.
   float2 dest_origin = float2(rect.bounds.origin.x, rect.bounds.origin.y);
   float2 dest_size = max(float2(rect.bounds.size.width, rect.bounds.size.height), float2(1.0));
-  float2 u = clamp((input.position.xy - dest_origin) / dest_size, 0.0, 1.0);
+  float2 u = clamp((input.position.xy - dest_origin) / dest_size, float2(0.0), float2(1.0));
 
   // Flip per axis. MIRROR_AXIS_HORIZONTAL = bit 0, VERTICAL = bit 1.
   if ((rect.mirror_axis & 1u) != 0u) {
@@ -1736,7 +1737,7 @@ fragment float4 mirror_rect_fragment(
   float2 src_uv = src_pos / viewport_f;
   // Reject out-of-viewport samples to transparent.
   if (src_uv.x < 0.0 || src_uv.x > 1.0 || src_uv.y < 0.0 || src_uv.y > 1.0) {
-    return float4(0.0);
+    return float4(0.0, 0.0, 0.0, 0.0);
   }
 
   float target_radius = gradient_target_radius(

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -753,7 +753,7 @@ impl MacWindow {
                     native_view as *mut _,
                     bounds.size.map(|pixels| pixels.as_f32()),
                     false,
-                    false,
+                    true,
                 ),
                 request_frame_callback: None,
                 event_callback: None,

--- a/crates/gpui_wgpu/src/blur_io_shaders.wgsl
+++ b/crates/gpui_wgpu/src/blur_io_shaders.wgsl
@@ -1,11 +1,11 @@
 // Dual-Kawase blur inner passes (Marius Bjorge, ARM, SIGGRAPH 2015).
 //
-// These fragment entry points run on fullscreen triangles against
-// progressively smaller scratch textures. The driving renderer is
-// responsible for allocating the ping-pong mip chain and orchestrating
-// the down → up sequence. The final upsampled texture is bound into the
-// main shader module's `t_blur_input` slot for `fs_blur_rect` /
-// `fs_lens_rect` to sample.
+// Only the downsample half of the original down→up sequence runs here:
+// the renderer preserves every chain[i] into pyramid mip `i` after the
+// downsample loop, and `fs_blur_rect` / `fs_lens_rect` sample the pyramid
+// at a fractional LOD to produce variable-radius blur. The upsample
+// passes that the original Kawase paper describes are therefore dead
+// code for this renderer and are intentionally omitted.
 
 struct BlurParams {
     viewport_size: vec2<f32>,
@@ -22,6 +22,12 @@ struct BlurFullscreenVarying {
     @location(0) uv: vec2<f32>,
 }
 
+// Gamma conversion uses the fast γ=2.2 power-curve approximation rather
+// than the full piecewise sRGB transfer. The toe (c < 0.04045) is slightly
+// darker than the exact transfer, but downsample runs N passes per frame
+// and the piecewise branch costs more than the perceptual error is worth
+// for a backdrop blur. Keep in sync with any new gamma-sensitive sample
+// sites added here.
 fn linearize(c: vec3<f32>) -> vec3<f32> {
     return pow(c, vec3<f32>(2.2));
 }
@@ -57,17 +63,3 @@ fn fs_blur_downsample(input: BlurFullscreenVarying) -> @location(0) vec4<f32> {
     return vec4<f32>(encode_srgb(averaged.rgb), averaged.a);
 }
 
-@fragment
-fn fs_blur_upsample(input: BlurFullscreenVarying) -> @location(0) vec4<f32> {
-    let o = 0.5 / blur_params.viewport_size * blur_params.offset_multiplier;
-    var color = sample_linear(input.uv + vec2<f32>(-o.x,  o.y)) * 2.0;
-    color += sample_linear(input.uv + vec2<f32>( o.x,  o.y)) * 2.0;
-    color += sample_linear(input.uv + vec2<f32>(-o.x, -o.y)) * 2.0;
-    color += sample_linear(input.uv + vec2<f32>( o.x, -o.y)) * 2.0;
-    color += sample_linear(input.uv + vec2<f32>(-o.x * 2.0, 0.0));
-    color += sample_linear(input.uv + vec2<f32>( o.x * 2.0, 0.0));
-    color += sample_linear(input.uv + vec2<f32>(0.0, -o.y * 2.0));
-    color += sample_linear(input.uv + vec2<f32>(0.0,  o.y * 2.0));
-    let averaged = color / 12.0;
-    return vec4<f32>(encode_srgb(averaged.rgb), averaged.a);
-}

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -1361,7 +1361,7 @@ struct BlurRect {
     gradient_direction: vec2<f32>,
     tint: Hsla,
     // Aligns the struct stride to 96 bytes (matching the Rust side).
-    _pad_end: vec2<f32>,
+    pad_end: vec2<f32>,
 }
 
 struct LensRect {
@@ -1426,8 +1426,8 @@ struct MirrorRect {
 @group(1) @binding(2) var t_blur_pyramid: texture_2d<f32>;
 @group(1) @binding(3) var s_blur_input: sampler;
 @group(1) @binding(4) var<storage, read> b_lens_shapes: array<LensShape>;
+@group(1) @binding(5) var<storage, read> b_mirror_rects: array<MirrorRect>;
 @group(1) @binding(6) var<uniform> scene_blur: SceneBlurParams;
-@group(1) @binding(7) var<storage, read> b_mirror_rects: array<MirrorRect>;
 
 // --- BlurRect: rounded rect that samples the blurred framebuffer ---
 
@@ -1464,9 +1464,15 @@ fn gradient_target_radius(
     if (dir_len2 < 1e-6) {
         return radius_start;
     }
+    // Normalize the direction inside the function so the mapping is
+    // magnitude-invariant in `gradient_direction`. Callers already pass a
+    // unit vector today, but clamping the denominator to 1 px while leaving
+    // the numerator unscaled otherwise gives different `t` for scaled
+    // inputs.
+    let dir = gradient_direction * inverseSqrt(dir_len2);
     let local = frag_pos - bounds.origin;
-    let extent = max(dot(bounds.size, gradient_direction), 1.0);
-    let t = clamp(dot(local, gradient_direction) / extent, 0.0, 1.0);
+    let extent = max(dot(bounds.size, dir), 1.0);
+    let t = clamp(dot(local, dir) / extent, 0.0, 1.0);
     return mix(radius_start, radius_end, t);
 }
 
@@ -1567,10 +1573,10 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
 
     let antialias_threshold = 0.5;
     let zero_corners = Corners(0.0, 0.0, 0.0, 0.0);
-    var per_shape_sdf: array<f32, 8>;
-    var per_shape_mask_attn: array<f32, 8>;
-    var per_shape_dir: array<vec2<f32>, 8>;
-    var per_shape_norm_dist: array<f32, 8>;
+    var per_shape_sdf: array<f32, MAX_LENS_SHAPES>;
+    var per_shape_mask_attn: array<f32, MAX_LENS_SHAPES>;
+    var per_shape_dir: array<vec2<f32>, MAX_LENS_SHAPES>;
+    var per_shape_norm_dist: array<f32, MAX_LENS_SHAPES>;
     var min_sdf: f32 = 1e20;
     for (var i: u32 = 0u; i < shape_count; i = i + 1u) {
         let s = b_lens_shapes[rect.shape_offset + i];
@@ -1595,7 +1601,7 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
     }
 
     var union_sdf: f32;
-    var weights: array<f32, 8>;
+    var weights: array<f32, MAX_LENS_SHAPES>;
     var coverage_factor: f32;
     if (blend_shapes) {
         var total_pre: f32 = 0.0;
@@ -1612,8 +1618,11 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
         }
         union_sdf = min_sdf - blend_k * log(max(total_pre, 1e-6));
         let inv_masked = 1.0 / max(total_masked, 1e-6);
+        // Clamp to [0, 1]: when `total_masked` approaches the 1e-6 floor,
+        // individual masked weights can scale past 1.0 and blow up the
+        // downstream refraction / dispersion vectors.
         for (var i: u32 = 0u; i < shape_count; i = i + 1u) {
-            weights[i] = weights[i] * inv_masked;
+            weights[i] = clamp(weights[i] * inv_masked, 0.0, 1.0);
         }
         coverage_factor = clamp(total_masked / max(total_pre, 1e-6), 0.0, 1.0);
     } else {
@@ -1643,6 +1652,11 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
     let depth_scale = clamp(rect.depth * 0.01, 0.0, 1.0);
     var offset_px = vec2<f32>(0.0, 0.0);
     var weighted_norm_dist: f32 = 0.0;
+    // `weighted_dir` is a weighted *sum* of unit directions, not a unit vector.
+    // For a fragment between two shapes whose centers oppose, the sum shrinks
+    // toward zero even when each contribution is strong — which is intentional:
+    // chromatic dispersion should fade in inter-shape seams so R/B collapse
+    // back onto G instead of streaking. Do not renormalize here.
     var weighted_dir = vec2<f32>(0.0, 0.0);
     for (var i: u32 = 0u; i < shape_count; i = i + 1u) {
         let nd = per_shape_norm_dist[i];
@@ -1652,7 +1666,16 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
         weighted_dir = weighted_dir + weights[i] * per_shape_dir[i];
     }
     let base_uv = input.position.xy / globals.viewport_size;
-    let refracted_uv = base_uv - offset_px / globals.viewport_size;
+    // Large `refraction` on lens rims can push UVs outside [0,1]. The
+    // pyramid sampler is created with ClampToEdge so stretched-edge pixels
+    // replicate the border rather than wrap across the framebuffer; clamp
+    // explicitly to make the contract visible and survive a future
+    // sampler-state change.
+    let refracted_uv = clamp(
+        base_uv - offset_px / globals.viewport_size,
+        vec2<f32>(0.0, 0.0),
+        vec2<f32>(1.0, 1.0),
+    );
     let target_radius = gradient_target_radius(
         input.position.xy,
         rect.bounds,
@@ -1682,9 +1705,12 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
         let edge_dist = abs(union_sdf);
         let edge_falloff = smoothstep(input.edge_band, 0.0, edge_dist);
         let weighted_len = length(weighted_dir);
+        // `select` evaluates both arms, so guard the division with `max`
+        // instead of relying on the predicate. Matches the MSL ?: path.
+        let safe_dir = weighted_dir / max(weighted_len, 1e-4);
         let facing = select(
             1.0,
-            clamp(dot(weighted_dir / weighted_len, input.light_dir), 0.0, 1.0),
+            clamp(dot(safe_dir, input.light_dir), 0.0, 1.0),
             weighted_len > 0.001,
         );
         let edge_glow = edge_falloff * facing * rect.light_intensity;
@@ -1752,12 +1778,11 @@ fn fs_mirror_rect(input: MirrorRectVarying) -> @location(0) vec4<f32> {
     let tint_rgba = hsla_to_rgba(rect.tint);
     color = vec4<f32>(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
 
-    var alpha = color.a;
+    var aa_factor = 1.0;
     if (rect.clip_to_destination != 0u) {
         let sdf = quad_sdf(input.position.xy, rect.bounds, rect.corner_radii);
         let antialias_threshold = 0.5;
-        let aa = saturate(antialias_threshold - sdf);
-        alpha = color.a * aa;
+        aa_factor = saturate(antialias_threshold - sdf);
     }
-    return vec4<f32>(color.rgb, alpha);
+    return blend_color(color, aa_factor);
 }

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -116,7 +116,6 @@ struct WgpuPipelines {
     #[allow(dead_code)]
     surfaces: wgpu::RenderPipeline,
     blur_downsample: wgpu::RenderPipeline,
-    blur_upsample: wgpu::RenderPipeline,
     blur_rect: wgpu::RenderPipeline,
     lens_rect: wgpu::RenderPipeline,
     mirror_rect: wgpu::RenderPipeline,
@@ -152,68 +151,90 @@ struct WgpuResources {
     path_intermediate_view: Option<wgpu::TextureView>,
     path_msaa_texture: Option<wgpu::Texture>,
     path_msaa_view: Option<wgpu::TextureView>,
-    /// Dual-Kawase scratch chain. `blur_chain_textures[0]` is surface-sized
-    /// and receives the framebuffer snapshot; each subsequent level is
-    /// half-sized. `BlurEffect::kernel_levels` selects the depth used per
-    /// frame (1..=5).
-    blur_chain_textures: [Option<wgpu::Texture>; BLUR_CHAIN_LEVELS],
-    blur_chain_views: [Option<wgpu::TextureView>; BLUR_CHAIN_LEVELS],
-    /// Preserved downsample pyramid: a single mipmapped texture where mip
-    /// 0 is the un-blurred framebuffer snapshot and each subsequent mip
-    /// holds the Kawase-downsample result of the previous level. Fragment
-    /// shaders sample this with `textureSampleLevel` at fractional LOD to
-    /// produce a per-pixel variable-radius blur.
+    /// Downsample pyramid: a single mipmapped texture where mip 0 is the
+    /// un-blurred framebuffer snapshot and each subsequent mip holds the
+    /// Kawase-downsample result of the previous level. Used as both a
+    /// render target (via per-mip views) and a sampled input (via a
+    /// full-mip view so `fs_blur_rect` / `fs_lens_rect` can pick fractional
+    /// LOD for a per-pixel variable-radius blur).
     blur_pyramid_texture: Option<wgpu::Texture>,
     blur_pyramid_view: Option<wgpu::TextureView>,
-    /// Bind groups pre-built for downsample/upsample passes. Downsample
-    /// pass `i` samples level `i` and writes level `i + 1`; upsample pass
-    /// `i` samples level `i + 1` and writes level `i`.
-    blur_down_bind_groups: [Option<wgpu::BindGroup>; BLUR_CHAIN_LEVELS - 1],
-    blur_up_bind_groups: [Option<wgpu::BindGroup>; BLUR_CHAIN_LEVELS - 1],
+    /// One single-mip view per pyramid level, used both as the render
+    /// target when writing mip `i + 1` and as the sampled input when
+    /// reading mip `i`. A mip-restricted view (`base_mip_level = i`,
+    /// `mip_level_count = 1`) keeps the downsample pass's read/write
+    /// subresources disjoint so wgpu's resource-tracking is satisfied.
+    blur_pyramid_mip_views: [Option<wgpu::TextureView>; BLUR_PYRAMID_LEVELS],
+    /// Bind groups pre-built for downsample passes. Pass `i` samples
+    /// pyramid mip `i` and writes pyramid mip `i + 1`; mips 1..N end up
+    /// populated directly by the render passes, with no intermediate
+    /// inter-texture copies.
+    blur_down_bind_groups: [Option<wgpu::BindGroup>; BLUR_PYRAMID_LEVELS - 1],
     blur_sampler: wgpu::Sampler,
     /// Uniform buffer with per-pass `BlurParams` packed at
     /// `min_uniform_buffer_offset_alignment`-sized strides. Bound with
-    /// dynamic offsets so each of the 2 × `BLUR_CHAIN_LEVELS - 1` passes
-    /// reads its own slot.
+    /// dynamic offsets so each of the `BLUR_PYRAMID_LEVELS - 1` downsample
+    /// passes reads its own slot.
     blur_params_buffer: wgpu::Buffer,
     /// Stride between adjacent `BlurParams` slots in `blur_params_buffer`,
     /// equal to `size_of::<BlurParams>()` rounded up to
     /// `min_uniform_buffer_offset_alignment`.
     blur_params_slot_stride: u64,
+    /// Reusable scratch for packing `BLUR_PARAMS_SLOT_COUNT` slots per
+    /// snapshot. Lives on the renderer so interleaved blur batches in one
+    /// frame don't each allocate their own ~2.5 KB scratch.
+    blur_params_scratch: Vec<u8>,
     /// Scene-wide gradient-blur params; written once per frame.
     scene_blur_params_buffer: wgpu::Buffer,
 }
 
 impl WgpuResources {
-    fn invalidate_intermediate_textures(&mut self) {
+    /// Drop intermediate textures whose dimensions no longer match the
+    /// current surface. When `target_size` matches the dimensions of the
+    /// existing pyramid mip 0, this is a no-op — the textures stay
+    /// allocated and `ensure_intermediate_textures` skips recreation. This
+    /// keeps Android background/rotation churn (where `replace_surface`
+    /// fires frequently at the same geometry) from stutter-allocating a
+    /// full W×H mip-chain every time.
+    fn invalidate_intermediate_textures(&mut self, target_size: (u32, u32)) {
+        let (target_width, target_height) = target_size;
+        let matches_target = |tex: Option<&wgpu::Texture>| -> bool {
+            tex.is_some_and(|t| t.width() == target_width && t.height() == target_height)
+        };
+
+        // Pyramid mip 0 doubles as the size-witness: if its dimensions
+        // still match, every chain / pyramid-view / bind-group allocated
+        // alongside it is also the right size.
+        let keep = matches_target(self.blur_pyramid_texture.as_ref())
+            && matches_target(self.path_intermediate_texture.as_ref());
+        if keep {
+            return;
+        }
+
         self.path_intermediate_texture = None;
         self.path_intermediate_view = None;
         self.path_msaa_texture = None;
         self.path_msaa_view = None;
-        for slot in &mut self.blur_chain_textures {
-            *slot = None;
-        }
-        for slot in &mut self.blur_chain_views {
-            *slot = None;
-        }
         self.blur_pyramid_texture = None;
         self.blur_pyramid_view = None;
-        for slot in &mut self.blur_down_bind_groups {
+        for slot in &mut self.blur_pyramid_mip_views {
             *slot = None;
         }
-        for slot in &mut self.blur_up_bind_groups {
+        for slot in &mut self.blur_down_bind_groups {
             *slot = None;
         }
     }
 }
 
-/// Maximum blur chain depth (`kernel_levels` is clamped to this). Each
-/// level is half the resolution of the previous; level 0 is the surface
+/// Maximum blur pyramid depth (`kernel_levels` is clamped to this). Each
+/// mip is half the resolution of the previous; mip 0 is the surface
 /// snapshot.
-const BLUR_CHAIN_LEVELS: usize = 6;
-/// One `BlurParams` slot per Kawase pass (down + up over the transitions
-/// between adjacent chain levels).
-const BLUR_PARAMS_SLOT_COUNT: usize = 2 * (BLUR_CHAIN_LEVELS - 1);
+const BLUR_PYRAMID_LEVELS: usize = 6;
+/// One `BlurParams` slot per Kawase downsample pass between adjacent
+/// pyramid mips. The upsample half of the original Kawase algorithm is
+/// not needed (fragment shaders sample the pyramid mips directly), so
+/// only `BLUR_PYRAMID_LEVELS - 1` slots are required.
+const BLUR_PARAMS_SLOT_COUNT: usize = BLUR_PYRAMID_LEVELS - 1;
 /// Reference blur radius. `BlurEffect::radius` scales the Kawase offset
 /// multiplier linearly relative to this.
 const BLUR_REFERENCE_RADIUS_PX: f32 = 20.0;
@@ -594,15 +615,17 @@ impl WgpuRenderer {
             path_intermediate_view: None,
             path_msaa_texture: None,
             path_msaa_view: None,
-            blur_chain_textures: Default::default(),
-            blur_chain_views: Default::default(),
             blur_pyramid_texture: None,
             blur_pyramid_view: None,
+            blur_pyramid_mip_views: Default::default(),
             blur_down_bind_groups: Default::default(),
-            blur_up_bind_groups: Default::default(),
             blur_sampler,
             blur_params_buffer,
             blur_params_slot_stride,
+            blur_params_scratch: vec![
+                0u8;
+                (blur_params_slot_stride as usize) * BLUR_PARAMS_SLOT_COUNT
+            ],
             scene_blur_params_buffer,
         };
 
@@ -860,8 +883,8 @@ impl WgpuRenderer {
                     ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                     count: None,
                 },
+                storage_buffer_entry(5),
                 scene_blur_params_entry,
-                storage_buffer_entry(7),
             ],
         });
 
@@ -1195,7 +1218,6 @@ impl WgpuRenderer {
         };
 
         let blur_downsample = make_blur_io_pipeline("blur_downsample", "fs_blur_downsample");
-        let blur_upsample = make_blur_io_pipeline("blur_upsample", "fs_blur_upsample");
 
         let blur_rect = create_pipeline(
             "blur_rect",
@@ -1242,7 +1264,6 @@ impl WgpuRenderer {
             poly_sprites,
             surfaces,
             blur_downsample,
-            blur_upsample,
             blur_rect,
             lens_rect,
             mirror_rect,
@@ -1338,10 +1359,8 @@ impl WgpuRenderer {
             if let Some(ref texture) = resources.path_msaa_texture {
                 texture.destroy();
             }
-            for slot in &resources.blur_chain_textures {
-                if let Some(texture) = slot.as_ref() {
-                    texture.destroy();
-                }
+            if let Some(ref pyramid) = resources.blur_pyramid_texture {
+                pyramid.destroy();
             }
 
             resources
@@ -1351,13 +1370,18 @@ impl WgpuRenderer {
             // Invalidate intermediate textures - they will be lazily recreated
             // in draw() after we confirm the surface is healthy. This avoids
             // panics when the device/surface is in an invalid state during resize.
-            resources.invalidate_intermediate_textures();
+            // Size is guaranteed to differ here (see the outer width/height
+            // guard), so pass the new size through.
+            resources.invalidate_intermediate_textures((
+                surface_config.width,
+                surface_config.height,
+            ));
         }
     }
 
     fn ensure_intermediate_textures(&mut self) {
         let needs_path = self.resources().path_intermediate_texture.is_none();
-        let needs_blur = self.resources().blur_chain_textures[0].is_none();
+        let needs_blur = self.resources().blur_pyramid_texture.is_none();
         if !needs_path && !needs_blur {
             return;
         }
@@ -1387,11 +1411,11 @@ impl WgpuRenderer {
         }
 
         if needs_blur {
-            Self::create_blur_chain(resources, format, width, height);
+            Self::create_blur_pyramid(resources, format, width, height);
         }
     }
 
-    fn create_blur_chain(
+    fn create_blur_pyramid(
         resources: &mut WgpuResources,
         surface_format: wgpu::TextureFormat,
         width: u32,
@@ -1401,47 +1425,17 @@ impl WgpuRenderer {
         // gamma chain in `blur_io_shaders.wgsl` is not double-applied when
         // the surface itself is sRGB. When the surface is already
         // non-sRGB this is a no-op.
-        let chain_format = surface_format.remove_srgb_suffix();
+        let pyramid_format = surface_format.remove_srgb_suffix();
 
-        for level in 0..BLUR_CHAIN_LEVELS {
-            let level_width = (width >> level).max(1);
-            let level_height = (height >> level).max(1);
-            let usage = if level == 0 {
-                wgpu::TextureUsages::COPY_DST
-                    | wgpu::TextureUsages::RENDER_ATTACHMENT
-                    | wgpu::TextureUsages::TEXTURE_BINDING
-            } else {
-                wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING
-            };
-            let texture = resources.device.create_texture(&wgpu::TextureDescriptor {
-                label: Some(&format!("blur_chain_{level}")),
-                size: wgpu::Extent3d {
-                    width: level_width,
-                    height: level_height,
-                    depth_or_array_layers: 1,
-                },
-                mip_level_count: 1,
-                sample_count: 1,
-                dimension: wgpu::TextureDimension::D2,
-                format: chain_format,
-                usage,
-                view_formats: &[],
-            });
-            let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
-            resources.blur_chain_textures[level] = Some(texture);
-            resources.blur_chain_views[level] = Some(view);
-        }
-
-        // Preserved downsample pyramid. Mip 0 holds the un-blurred
-        // framebuffer snapshot; each subsequent mip is the Kawase
-        // downsample result of the previous level. A single mipmapped
-        // texture plus trilinear sampling lets the fragment shader pick a
-        // fractional LOD per pixel, producing a smooth variable-radius
-        // blur. Clamp the mip count to what the surface size actually
-        // supports: a 16x16 surface can only host 5 mips, not 6.
+        // Mip 0 holds the un-blurred framebuffer snapshot; each subsequent
+        // mip is the Kawase-downsample result of the previous level. A
+        // single mipmapped texture plus trilinear sampling lets the
+        // fragment shader pick a fractional LOD per pixel. Clamp the mip
+        // count to what the surface size actually supports: a 16x16
+        // surface can only host 5 mips, not 6.
         let min_dim = width.min(height).max(1);
         let max_mips = 32 - min_dim.leading_zeros();
-        let pyramid_mip_count = (BLUR_CHAIN_LEVELS as u32).min(max_mips);
+        let pyramid_mip_count = (BLUR_PYRAMID_LEVELS as u32).min(max_mips);
         let pyramid_texture = resources.device.create_texture(&wgpu::TextureDescriptor {
             label: Some("blur_pyramid"),
             size: wgpu::Extent3d {
@@ -1452,31 +1446,54 @@ impl WgpuRenderer {
             mip_level_count: pyramid_mip_count,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
-            format: chain_format,
-            usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
+            format: pyramid_format,
+            // `COPY_DST` for the initial frame-to-mip-0 snapshot blit.
+            // `RENDER_ATTACHMENT` because downsample passes render directly
+            // into mips 1..N via per-mip views.
+            // `TEXTURE_BINDING` for both downsample sampling (per-mip views)
+            // and the full-mip view used by `fs_blur_rect` / `fs_lens_rect`.
+            usage: wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING,
             view_formats: &[],
         });
         let pyramid_view = pyramid_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        // Single-mip views: each restricted to `base_mip_level = i`,
+        // `mip_level_count = 1`. The downsample pass binds view `i` as
+        // sampled input AND view `i + 1` as render target — different
+        // subresources of the same texture, which wgpu's resource tracker
+        // allows (no read/write aliasing).
+        let mut mip_views: [Option<wgpu::TextureView>; BLUR_PYRAMID_LEVELS] = Default::default();
+        for level in 0..pyramid_mip_count as usize {
+            let view = pyramid_texture.create_view(&wgpu::TextureViewDescriptor {
+                label: Some(&format!("blur_pyramid_mip_{level}")),
+                format: None,
+                dimension: Some(wgpu::TextureViewDimension::D2),
+                aspect: wgpu::TextureAspect::All,
+                base_mip_level: level as u32,
+                mip_level_count: Some(1),
+                base_array_layer: 0,
+                array_layer_count: Some(1),
+                usage: None,
+            });
+            mip_views[level] = Some(view);
+        }
+
         resources.blur_pyramid_texture = Some(pyramid_texture);
         resources.blur_pyramid_view = Some(pyramid_view);
+        resources.blur_pyramid_mip_views = mip_views;
 
-        // Pre-build every bind group for the passes the chain can host.
-        // Each pass reads one level and writes the adjacent level; the
-        // bind-group inputs (source view + sampler + params buffer) are
-        // stable for the lifetime of the chain.
-        for i in 0..BLUR_CHAIN_LEVELS - 1 {
-            let src_view = resources.blur_chain_views[i]
-                .as_ref()
-                .expect("chain view allocated above");
+        // Pre-build one bind group per downsample pass. Pass `i` samples
+        // `mip_views[i]` and writes `mip_views[i + 1]`. Only pairs up to
+        // the actual `pyramid_mip_count - 1` are valid; the rest remain
+        // `None` and callers must not attempt passes past that point.
+        for i in 0..BLUR_PYRAMID_LEVELS - 1 {
+            let Some(src_view) = resources.blur_pyramid_mip_views[i].as_ref() else {
+                break;
+            };
             resources.blur_down_bind_groups[i] =
                 Some(Self::create_blur_io_bind_group(resources, src_view, "blur_down"));
-        }
-        for i in 0..BLUR_CHAIN_LEVELS - 1 {
-            let src_view = resources.blur_chain_views[i + 1]
-                .as_ref()
-                .expect("chain view allocated above");
-            resources.blur_up_bind_groups[i] =
-                Some(Self::create_blur_io_bind_group(resources, src_view, "blur_up"));
         }
     }
 
@@ -1586,8 +1603,9 @@ impl WgpuRenderer {
 
             // TBD. Does retrying more actually help?
             if self.failed_frame_count > 5 {
+                let size = (self.surface_config.width, self.surface_config.height);
                 if let Some(res) = self.resources.as_mut() {
-                    res.invalidate_intermediate_textures();
+                    res.invalidate_intermediate_textures(size);
                 }
                 self.atlas.clear();
                 self.needs_redraw = true;
@@ -1704,7 +1722,7 @@ impl WgpuRenderer {
         loop {
             let mut instance_offset: u64 = 0;
             let mut overflow = false;
-            // Tracks whether the cached blur chain already reflects the
+            // Tracks whether the cached blur pyramid already reflects the
             // contents of `frame.texture` as of the last non-blur batch.
             // Reset to `false` at frame start and whenever a primitive
             // batch draws to the main target.
@@ -1920,14 +1938,17 @@ impl WgpuRenderer {
 
                             drop(pass);
 
-                            let levels = blur_kernel_levels.max(1);
+                            // Pass `blur_kernel_levels` directly: when no
+                            // primitive in the scene requests blur this is 0,
+                            // and `snapshot_and_blur_frame` then does a
+                            // copy-only fast path for mirror-no-blur batches.
                             let did_snapshot = if blur_snapshot_valid {
                                 true
                             } else {
                                 let ok = self.snapshot_and_blur_frame(
                                     &mut encoder,
                                     &frame.texture,
-                                    levels,
+                                    blur_kernel_levels,
                                     blur_offset_multiplier,
                                 );
                                 if ok {
@@ -2187,17 +2208,17 @@ impl WgpuRenderer {
         }
     }
 
-    /// Copy the current swapchain contents into `blur_chain_textures[0]`
-    /// and run `kernel_levels` downsample + upsample passes (dual-Kawase).
-    /// The blurred result ends up back in `blur_chain_textures[0]`, which
-    /// `fs_blur_rect` / `fs_lens_rect` sample.
+    /// Copy the current swapchain contents into pyramid mip 0, then run
+    /// `kernel_levels` Kawase downsample passes that render directly into
+    /// mips 1..N+1 of the same pyramid. `fs_blur_rect` / `fs_lens_rect`
+    /// subsequently sample the full pyramid at a fractional LOD.
     ///
     /// `offset_multiplier` scales the Kawase tap offset; typically
     /// `BlurEffect::radius / BLUR_REFERENCE_RADIUS_PX`.
     ///
     /// Returns `false` if the platform cannot snapshot the framebuffer
-    /// (COPY_SRC missing) or if scratch textures aren't allocated yet;
-    /// callers should skip the blur/lens draw in that case.
+    /// (COPY_SRC missing) or if the pyramid isn't allocated yet; callers
+    /// should skip the blur/lens draw in that case.
     fn snapshot_and_blur_frame(
         &mut self,
         encoder: &mut wgpu::CommandEncoder,
@@ -2209,23 +2230,34 @@ impl WgpuRenderer {
             return false;
         }
 
-        let kernel_levels = kernel_levels.clamp(1, (BLUR_CHAIN_LEVELS - 1) as u32) as usize;
+        // `kernel_levels == 0` means no primitive in the scene asked for
+        // blur; skip the Kawase passes and snapshot mip 0 only.
+        let kernel_levels = kernel_levels.min((BLUR_PYRAMID_LEVELS - 1) as u32) as usize;
         self.ensure_intermediate_textures();
 
         let width = self.surface_config.width.max(1);
         let height = self.surface_config.height.max(1);
-        let resources = self.resources();
+        let resources = self.resources_mut();
 
-        if resources.blur_chain_textures[0].is_none() {
+        if resources.blur_pyramid_texture.is_none() {
             return false;
         }
+        // The pyramid may have fewer mips than requested on small surfaces
+        // (see `create_blur_pyramid`'s clamp). Cap the pass count so we
+        // never try to sample or render a mip the pyramid doesn't have.
+        let available_mips = resources
+            .blur_pyramid_texture
+            .as_ref()
+            .map(|t| t.mip_level_count() as usize)
+            .unwrap_or(0);
+        let kernel_levels = kernel_levels.min(available_mips.saturating_sub(1));
 
-        // Pack per-pass BlurParams. Slot layout:
-        //   0..kernel_levels              → downsample passes (i → i+1)
-        //   kernel_levels..2*kernel_levels → upsample passes  (i+1 → i),
-        //                                     iterated back down.
+        // Pack per-pass BlurParams, one slot per downsample pass (`i`
+        // samples pyramid mip `i` and writes pyramid mip `i + 1`).
         let slot_stride = resources.blur_params_slot_stride;
-        let mut slot_bytes = vec![0u8; (slot_stride as usize) * BLUR_PARAMS_SLOT_COUNT];
+        let slot_bytes_len = (slot_stride as usize) * BLUR_PARAMS_SLOT_COUNT;
+        resources.blur_params_scratch.clear();
+        resources.blur_params_scratch.resize(slot_bytes_len, 0);
         let write_slot = |slot_bytes: &mut [u8], slot: usize, params: BlurParams| {
             let offset = slot * slot_stride as usize;
             slot_bytes[offset..offset + std::mem::size_of::<BlurParams>()]
@@ -2235,7 +2267,7 @@ impl WgpuRenderer {
             let src_w = (width >> i).max(1);
             let src_h = (height >> i).max(1);
             write_slot(
-                &mut slot_bytes,
+                &mut resources.blur_params_scratch,
                 i,
                 BlurParams {
                     viewport_size: [src_w as f32, src_h as f32],
@@ -2244,29 +2276,19 @@ impl WgpuRenderer {
                 },
             );
         }
-        for step in 0..kernel_levels {
-            let src_level = kernel_levels - step;
-            let src_w = (width >> src_level).max(1);
-            let src_h = (height >> src_level).max(1);
-            write_slot(
-                &mut slot_bytes,
-                kernel_levels + step,
-                BlurParams {
-                    viewport_size: [src_w as f32, src_h as f32],
-                    offset_multiplier,
-                    pad: 0.0,
-                },
-            );
-        }
-        resources
-            .queue
-            .write_buffer(&resources.blur_params_buffer, 0, &slot_bytes);
+        resources.queue.write_buffer(
+            &resources.blur_params_buffer,
+            0,
+            &resources.blur_params_scratch,
+        );
+        let resources = self.resources();
 
-        let copy_extent = wgpu::Extent3d {
-            width,
-            height,
-            depth_or_array_layers: 1,
-        };
+        let pyramid = resources
+            .blur_pyramid_texture
+            .as_ref()
+            .expect("pyramid checked above");
+
+        // Initial snapshot: swapchain → pyramid mip 0.
         encoder.copy_texture_to_texture(
             wgpu::TexelCopyTextureInfo {
                 texture: frame_texture,
@@ -2275,40 +2297,29 @@ impl WgpuRenderer {
                 aspect: wgpu::TextureAspect::All,
             },
             wgpu::TexelCopyTextureInfo {
-                texture: resources.blur_chain_textures[0]
-                    .as_ref()
-                    .expect("chain level 0 checked above"),
+                texture: pyramid,
                 mip_level: 0,
                 origin: wgpu::Origin3d::ZERO,
                 aspect: wgpu::TextureAspect::All,
             },
-            copy_extent,
+            wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
         );
-        if let Some(pyramid) = resources.blur_pyramid_texture.as_ref() {
-            encoder.copy_texture_to_texture(
-                wgpu::TexelCopyTextureInfo {
-                    texture: frame_texture,
-                    mip_level: 0,
-                    origin: wgpu::Origin3d::ZERO,
-                    aspect: wgpu::TextureAspect::All,
-                },
-                wgpu::TexelCopyTextureInfo {
-                    texture: pyramid,
-                    mip_level: 0,
-                    origin: wgpu::Origin3d::ZERO,
-                    aspect: wgpu::TextureAspect::All,
-                },
-                copy_extent,
-            );
-        }
 
+        // Kawase downsample: each pass samples pyramid mip `i` via a
+        // single-mip view and renders into pyramid mip `i + 1` via
+        // another single-mip view. Different subresources of the same
+        // texture, which wgpu treats as read/write-disjoint.
         for i in 0..kernel_levels {
-            let dst_view = resources.blur_chain_views[i + 1]
+            let dst_view = resources.blur_pyramid_mip_views[i + 1]
                 .as_ref()
-                .expect("chain view allocated");
+                .expect("pyramid mip view allocated for active pass");
             let bind_group = resources.blur_down_bind_groups[i]
                 .as_ref()
-                .expect("down bind group allocated");
+                .expect("down bind group allocated for active pass");
             let dynamic_offset = (i as u64 * slot_stride) as u32;
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("blur_downsample_pass"),
@@ -2325,74 +2336,6 @@ impl WgpuRenderer {
                 ..Default::default()
             });
             pass.set_pipeline(&resources.pipelines.blur_downsample);
-            pass.set_bind_group(0, bind_group, &[dynamic_offset]);
-            pass.draw(0..3, 0..1);
-        }
-
-        // Preserve the downsample chain into the pyramid before the
-        // upsample loop overwrites `chain[0..kernel_levels-1]`. Each
-        // `chain[i]` is the /2^i-sized result of `i` Kawase downsample
-        // passes, which maps to pyramid mip level `i`. Clamp the copy
-        // extent to the pyramid mip count in case the surface was too
-        // small to host every mip (ensure_intermediate_textures clamps
-        // pyramid mips based on the surface size).
-        if let Some(pyramid) = resources.blur_pyramid_texture.as_ref() {
-            let pyramid_mip_count = pyramid.mip_level_count();
-            for i in 1..=kernel_levels {
-                if (i as u32) >= pyramid_mip_count {
-                    break;
-                }
-                let chain_texture = resources.blur_chain_textures[i]
-                    .as_ref()
-                    .expect("chain level allocated");
-                let level_width = (width >> i).max(1);
-                let level_height = (height >> i).max(1);
-                encoder.copy_texture_to_texture(
-                    wgpu::TexelCopyTextureInfo {
-                        texture: chain_texture,
-                        mip_level: 0,
-                        origin: wgpu::Origin3d::ZERO,
-                        aspect: wgpu::TextureAspect::All,
-                    },
-                    wgpu::TexelCopyTextureInfo {
-                        texture: pyramid,
-                        mip_level: i as u32,
-                        origin: wgpu::Origin3d::ZERO,
-                        aspect: wgpu::TextureAspect::All,
-                    },
-                    wgpu::Extent3d {
-                        width: level_width,
-                        height: level_height,
-                        depth_or_array_layers: 1,
-                    },
-                );
-            }
-        }
-
-        for step in 0..kernel_levels {
-            let dst_level = kernel_levels - step - 1;
-            let dst_view = resources.blur_chain_views[dst_level]
-                .as_ref()
-                .expect("chain view allocated");
-            let bind_group = resources.blur_up_bind_groups[dst_level]
-                .as_ref()
-                .expect("up bind group allocated");
-            let dynamic_offset = ((kernel_levels + step) as u64 * slot_stride) as u32;
-            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: Some("blur_upsample_pass"),
-                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: dst_view,
-                    resolve_target: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
-                        store: wgpu::StoreOp::Store,
-                    },
-                    depth_slice: None,
-                })],
-                depth_stencil_attachment: None,
-                ..Default::default()
-            });
-            pass.set_pipeline(&resources.pipelines.blur_upsample);
             pass.set_bind_group(0, bind_group, &[dynamic_offset]);
             pass.draw(0..3, 0..1);
         }
@@ -2544,12 +2487,12 @@ impl WgpuRenderer {
                         resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
                     },
                     wgpu::BindGroupEntry {
-                        binding: 6,
-                        resource: resources.scene_blur_params_buffer.as_entire_binding(),
+                        binding: 5,
+                        resource: self.instance_binding(offset, size),
                     },
                     wgpu::BindGroupEntry {
-                        binding: 7,
-                        resource: self.instance_binding(offset, size),
+                        binding: 6,
+                        resource: resources.scene_blur_params_buffer.as_entire_binding(),
                     },
                 ],
             });
@@ -2723,8 +2666,9 @@ impl WgpuRenderer {
     pub fn unconfigure_surface(&mut self) {
         self.surface_configured = false;
         // Drop intermediate textures since they reference the old surface size.
+        let size = (self.surface_config.width, self.surface_config.height);
         if let Some(res) = self.resources.as_mut() {
-            res.invalidate_intermediate_textures();
+            res.invalidate_intermediate_textures(size);
         }
     }
 
@@ -2795,8 +2739,11 @@ impl WgpuRenderer {
             surface.configure(&res.device, &self.surface_config);
             res.surface = surface;
 
-            // Invalidate intermediate textures — they'll be recreated lazily.
-            res.invalidate_intermediate_textures();
+            // Invalidate intermediate textures — they'll be recreated lazily
+            // if the new surface geometry differs. Same-size replace_surface
+            // (common on Android rotation back-and-forth) keeps the existing
+            // pyramid + chain so the next frame doesn't stutter.
+            res.invalidate_intermediate_textures((width, height));
         }
 
         self.surface_configured = true;
@@ -3021,7 +2968,7 @@ mod tests {
     }
 
     /// Compiles every render pipeline used by the renderer, including the
-    /// new `blur_downsample` / `blur_upsample` / `blur_rect` / `lens_rect`
+    /// new `blur_downsample` / `blur_rect` / `lens_rect` / `mirror_rect`
     /// ones. Silently skipped locally when no adapter is available; panics
     /// on CI (`CI` env var set) so a missing adapter is loud rather than
     /// hidden in green build output.
@@ -3056,7 +3003,6 @@ mod tests {
         let _ = &pipelines.poly_sprites;
         let _ = &pipelines.surfaces;
         let _ = &pipelines.blur_downsample;
-        let _ = &pipelines.blur_upsample;
         let _ = &pipelines.blur_rect;
         let _ = &pipelines.lens_rect;
         let _ = &pipelines.mirror_rect;

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -43,9 +43,28 @@ fn warn_once_primitive_unimplemented(
     if cell.set(()).is_ok() {
         log::warn!(
             "{primitive} is not yet implemented on the DirectX backend; \
-             these primitives will render as transparent. Tracked as a \
-             follow-up to the blur-primitive PR."
+             the backend falls back to a flat tinted rectangle until the \
+             full port lands. Tracked as a follow-up to the blur-primitive PR."
         );
+    }
+}
+
+/// Build a plain-quad fallback for a blur / lens / mirror rect. Returns a
+/// `Quad` tinted with `tint` and otherwise untouched, so the full port's
+/// missing features (refraction, Fresnel, source-sampling, gradient blur)
+/// degrade to a flat colored rectangle instead of a hole.
+fn fallback_quad(
+    bounds: Bounds<ScaledPixels>,
+    content_mask: ContentMask<ScaledPixels>,
+    corner_radii: Corners<ScaledPixels>,
+    tint: Hsla,
+) -> Quad {
+    Quad {
+        bounds,
+        content_mask,
+        corner_radii,
+        background: Background::from(tint),
+        ..Quad::default()
     }
 }
 
@@ -104,6 +123,11 @@ struct DirectXResources {
 struct DirectXRenderPipelines {
     shadow_pipeline: PipelineState<Shadow>,
     quad_pipeline: PipelineState<Quad>,
+    /// Dedicated quad pipeline used only for the BlurRect / LensRect /
+    /// MirrorRect fallback — reuses the quad shader but owns its own buffer
+    /// so it can be refreshed per batch without clobbering `quad_pipeline`'s
+    /// scene-wide contents.
+    blur_fallback_pipeline: PipelineState<Quad>,
     path_rasterization_pipeline: PipelineState<PathRasterizationSprite>,
     path_sprite_pipeline: PipelineState<PathSprite>,
     underline_pipeline: PipelineState<Underline>,
@@ -356,26 +380,38 @@ impl DirectXRenderer {
                     self.draw_polychrome_sprites(texture_id, range.start, range.len())
                 }
                 PrimitiveBatch::Surfaces(range) => self.draw_surfaces(&scene.surfaces[range]),
-                PrimitiveBatch::BlurRects(_) => {
+                PrimitiveBatch::BlurRects(range) => {
                     warn_once_primitive_unimplemented(
                         &BLUR_RECT_NOT_IMPLEMENTED_WARNED,
                         "BlurRect",
                     );
-                    Ok(())
+                    let fallback_quads: Vec<Quad> = scene.blur_rects[range]
+                        .iter()
+                        .map(|r| fallback_quad(r.bounds, r.content_mask, r.corner_radii, r.tint))
+                        .collect();
+                    self.draw_fallback_quads(&fallback_quads)
                 }
-                PrimitiveBatch::LensRects(_) => {
+                PrimitiveBatch::LensRects(range) => {
                     warn_once_primitive_unimplemented(
                         &LENS_RECT_NOT_IMPLEMENTED_WARNED,
                         "LensRect",
                     );
-                    Ok(())
+                    let fallback_quads: Vec<Quad> = scene.lens_rects[range]
+                        .iter()
+                        .map(|r| fallback_quad(r.bounds, r.content_mask, Corners::default(), r.tint))
+                        .collect();
+                    self.draw_fallback_quads(&fallback_quads)
                 }
-                PrimitiveBatch::MirrorRects(_) => {
+                PrimitiveBatch::MirrorRects(range) => {
                     warn_once_primitive_unimplemented(
                         &MIRROR_RECT_NOT_IMPLEMENTED_WARNED,
                         "MirrorRect",
                     );
-                    Ok(())
+                    let fallback_quads: Vec<Quad> = scene.mirror_rects[range]
+                        .iter()
+                        .map(|r| fallback_quad(r.bounds, r.content_mask, r.corner_radii, r.tint))
+                        .collect();
+                    self.draw_fallback_quads(&fallback_quads)
                 }
             }
             .context(format!(
@@ -536,6 +572,37 @@ impl DirectXRenderer {
             4,
             start as u32,
             len as u32,
+        )
+    }
+
+    /// Draw synthesized quads for the BlurRect / LensRect / MirrorRect
+    /// fallback. Uses a dedicated pipeline so `update_buffer` here does
+    /// not clobber the scene-wide `quad_pipeline` contents that earlier /
+    /// later batches in the same frame still depend on.
+    fn draw_fallback_quads(&mut self, quads: &[Quad]) -> Result<()> {
+        if quads.is_empty() {
+            return Ok(());
+        }
+        let devices = self.devices.as_ref().context("devices missing")?;
+        self.pipelines.blur_fallback_pipeline.update_buffer(
+            &devices.device,
+            &devices.device_context,
+            quads,
+        )?;
+        self.pipelines.blur_fallback_pipeline.draw_range(
+            &devices.device,
+            &devices.device_context,
+            slice::from_ref(
+                &self
+                    .resources
+                    .as_ref()
+                    .context("resources missing")?
+                    .viewport,
+            ),
+            slice::from_ref(&self.globals.global_params_buffer),
+            4,
+            0,
+            quads.len() as u32,
         )
     }
 
@@ -880,6 +947,13 @@ impl DirectXRenderPipelines {
             64,
             create_blend_state(device)?,
         )?;
+        let blur_fallback_pipeline = PipelineState::new(
+            device,
+            "blur_fallback_pipeline",
+            ShaderModule::Quad,
+            16,
+            create_blend_state(device)?,
+        )?;
         let path_rasterization_pipeline = PipelineState::new(
             device,
             "path_rasterization_pipeline",
@@ -926,6 +1000,7 @@ impl DirectXRenderPipelines {
         Ok(Self {
             shadow_pipeline,
             quad_pipeline,
+            blur_fallback_pipeline,
             path_rasterization_pipeline,
             path_sprite_pipeline,
             underline_pipeline,


### PR DESCRIPTION
Resolves a deep-review pass over the BlurRect / LensRect / MirrorRect pipeline: Metal `enable_frame_sampling` now defaults to `true` with a `warn_once` diagnostic when off; pyramid mip count is clamped to surface size on both backends; shader parity fixes (MSL `discard_fragment` → `return float4(0)`, mirror `blend_color` path, `refracted_uv` clamp, Fresnel `safe_dir`, softmin weight clamp, normalized `gradient_direction`); draw-order hoist in the Metal `draw_*_rects` encoders; `Primitive::LensRect(LensPrimitive)` → `Primitive::LensGroup`; `SmallVec<[_; MAX_LENS_SHAPES_PER_GROUP]>` on the paint path so the usual 1..=8 case never heap-allocates; DirectX tinted-quad fallback via a dedicated pipeline so missing-backend cases render a flat tint instead of a hole; size-aware `invalidate_intermediate_textures` so same-size `replace_surface` keeps the pyramid. The Kawase chain is gone — pyramid is now `RENDER_ATTACHMENT | TEXTURE_BINDING | COPY_DST` on wgpu and `RenderTarget | ShaderRead` on Metal, with downsample passes rendering directly into mips via per-mip views / `set_level`, removing one full-W×H copy plus N blit copies per snapshot and halving scratch VRAM. Tests cover lens/mirror coalesce + interleave-with-quads, kernel/radius edge cases, and the new builder APIs; \`./script/clippy\` clean on gpui / gpui_wgpu / gpui_macos / gpui_windows.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)