### PR TITLE
gpui_wgpu: Cache frame-stable blur bind group, split instance data to group(2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7837,6 +7837,7 @@ dependencies = [
  "itertools 0.14.0",
  "js-sys",
  "log",
+ "naga 29.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot",
  "pollster 0.4.0",
  "profiling",

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -162,6 +162,42 @@ impl Scene {
         self.lens_rects.sort_by_key(|lens| lens.order);
     }
 
+    /// Maximum `kernel_levels` requested by any `BlurRect` or `LensRect`
+    /// in the scene, clamped to `1..=5`. Used by renderers to size the
+    /// dual-Kawase snapshot chain for the frame. Returns 0 when neither
+    /// primitive kind is present.
+    pub fn max_blur_kernel_levels(&self) -> u32 {
+        let blur = self
+            .blur_rects
+            .iter()
+            .map(|b| b.kernel_levels)
+            .max()
+            .unwrap_or(0);
+        let lens = self
+            .lens_rects
+            .iter()
+            .map(|l| l.kernel_levels)
+            .max()
+            .unwrap_or(0);
+        blur.max(lens).min(5)
+    }
+
+    /// Maximum `blur_radius` requested by any `BlurRect` or `LensRect` in
+    /// the scene. Zero when neither primitive kind is present.
+    pub fn max_blur_radius(&self) -> ScaledPixels {
+        let blur = self
+            .blur_rects
+            .iter()
+            .map(|b| b.blur_radius.0)
+            .fold(0.0_f32, f32::max);
+        let lens = self
+            .lens_rects
+            .iter()
+            .map(|l| l.blur_radius.0)
+            .fold(0.0_f32, f32::max);
+        ScaledPixels(blur.max(lens))
+    }
+
     #[cfg_attr(
         all(
             any(target_os = "linux", target_os = "freebsd"),

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -36,6 +36,8 @@ pub struct Scene {
     pub subpixel_sprites: Vec<SubpixelSprite>,
     pub polychrome_sprites: Vec<PolychromeSprite>,
     pub surfaces: Vec<PaintSurface>,
+    pub blur_rects: Vec<BlurRect>,
+    pub lens_rects: Vec<LensRect>,
 }
 
 #[expect(missing_docs)]
@@ -52,6 +54,8 @@ impl Scene {
         self.subpixel_sprites.clear();
         self.polychrome_sprites.clear();
         self.surfaces.clear();
+        self.blur_rects.clear();
+        self.lens_rects.clear();
     }
 
     pub fn len(&self) -> usize {
@@ -119,6 +123,14 @@ impl Scene {
                 surface.order = order;
                 self.surfaces.push(surface.clone());
             }
+            Primitive::BlurRect(blur) => {
+                blur.order = order;
+                self.blur_rects.push(blur.clone());
+            }
+            Primitive::LensRect(lens) => {
+                lens.order = order;
+                self.lens_rects.push(lens.clone());
+            }
         }
         self.paint_operations
             .push(PaintOperation::Primitive(primitive));
@@ -146,6 +158,8 @@ impl Scene {
         self.polychrome_sprites
             .sort_by_key(|sprite| (sprite.order, sprite.tile.tile_id));
         self.surfaces.sort_by_key(|surface| surface.order);
+        self.blur_rects.sort_by_key(|blur| blur.order);
+        self.lens_rects.sort_by_key(|lens| lens.order);
     }
 
     #[cfg_attr(
@@ -173,6 +187,10 @@ impl Scene {
             polychrome_sprites_iter: self.polychrome_sprites.iter().peekable(),
             surfaces_start: 0,
             surfaces_iter: self.surfaces.iter().peekable(),
+            blur_rects_start: 0,
+            blur_rects_iter: self.blur_rects.iter().peekable(),
+            lens_rects_start: 0,
+            lens_rects_iter: self.lens_rects.iter().peekable(),
         }
     }
 }
@@ -195,6 +213,8 @@ pub(crate) enum PrimitiveKind {
     SubpixelSprite,
     PolychromeSprite,
     Surface,
+    BlurRect,
+    LensRect,
 }
 
 pub(crate) enum PaintOperation {
@@ -214,6 +234,8 @@ pub enum Primitive {
     SubpixelSprite(SubpixelSprite),
     PolychromeSprite(PolychromeSprite),
     Surface(PaintSurface),
+    BlurRect(BlurRect),
+    LensRect(LensRect),
 }
 
 #[expect(missing_docs)]
@@ -228,6 +250,8 @@ impl Primitive {
             Primitive::SubpixelSprite(sprite) => &sprite.bounds,
             Primitive::PolychromeSprite(sprite) => &sprite.bounds,
             Primitive::Surface(surface) => &surface.bounds,
+            Primitive::BlurRect(blur) => &blur.bounds,
+            Primitive::LensRect(lens) => &lens.bounds,
         }
     }
 
@@ -241,6 +265,8 @@ impl Primitive {
             Primitive::SubpixelSprite(sprite) => &sprite.content_mask,
             Primitive::PolychromeSprite(sprite) => &sprite.content_mask,
             Primitive::Surface(surface) => &surface.content_mask,
+            Primitive::BlurRect(blur) => &blur.content_mask,
+            Primitive::LensRect(lens) => &lens.content_mask,
         }
     }
 }
@@ -269,6 +295,10 @@ struct BatchIterator<'a> {
     polychrome_sprites_iter: Peekable<slice::Iter<'a, PolychromeSprite>>,
     surfaces_start: usize,
     surfaces_iter: Peekable<slice::Iter<'a, PaintSurface>>,
+    blur_rects_start: usize,
+    blur_rects_iter: Peekable<slice::Iter<'a, BlurRect>>,
+    lens_rects_start: usize,
+    lens_rects_iter: Peekable<slice::Iter<'a, LensRect>>,
 }
 
 impl<'a> Iterator for BatchIterator<'a> {
@@ -301,6 +331,14 @@ impl<'a> Iterator for BatchIterator<'a> {
             (
                 self.surfaces_iter.peek().map(|s| s.order),
                 PrimitiveKind::Surface,
+            ),
+            (
+                self.blur_rects_iter.peek().map(|b| b.order),
+                PrimitiveKind::BlurRect,
+            ),
+            (
+                self.lens_rects_iter.peek().map(|l| l.order),
+                PrimitiveKind::LensRect,
             ),
         ];
         orders_and_kinds.sort_by_key(|(order, kind)| (order.unwrap_or(u32::MAX), *kind));
@@ -447,6 +485,34 @@ impl<'a> Iterator for BatchIterator<'a> {
                 self.surfaces_start = surfaces_end;
                 Some(PrimitiveBatch::Surfaces(surfaces_start..surfaces_end))
             }
+            PrimitiveKind::BlurRect => {
+                let blur_rects_start = self.blur_rects_start;
+                let mut blur_rects_end = blur_rects_start + 1;
+                self.blur_rects_iter.next();
+                while self
+                    .blur_rects_iter
+                    .next_if(|blur| (blur.order, batch_kind) < max_order_and_kind)
+                    .is_some()
+                {
+                    blur_rects_end += 1;
+                }
+                self.blur_rects_start = blur_rects_end;
+                Some(PrimitiveBatch::BlurRects(blur_rects_start..blur_rects_end))
+            }
+            PrimitiveKind::LensRect => {
+                let lens_rects_start = self.lens_rects_start;
+                let mut lens_rects_end = lens_rects_start + 1;
+                self.lens_rects_iter.next();
+                while self
+                    .lens_rects_iter
+                    .next_if(|lens| (lens.order, batch_kind) < max_order_and_kind)
+                    .is_some()
+                {
+                    lens_rects_end += 1;
+                }
+                self.lens_rects_start = lens_rects_end;
+                Some(PrimitiveBatch::LensRects(lens_rects_start..lens_rects_end))
+            }
         }
     }
 }
@@ -479,6 +545,8 @@ pub enum PrimitiveBatch {
         range: Range<usize>,
     },
     Surfaces(Range<usize>),
+    BlurRects(Range<usize>),
+    LensRects(Range<usize>),
 }
 
 #[derive(Default, Debug, Copy, Clone)]
@@ -535,6 +603,71 @@ pub struct Shadow {
 impl From<Shadow> for Primitive {
     fn from(shadow: Shadow) -> Self {
         Primitive::Shadow(shadow)
+    }
+}
+
+/// A rounded rectangle that samples the framebuffer behind it, runs a
+/// dual-Kawase blur, and composites the result with a tint. Used for
+/// backdrop-blurred materials like Apple's Liquid Glass.
+///
+/// Unlike `Quad` / `Shadow` / etc., a `BlurRect` is not drawn with an
+/// instanced pipeline — each one breaks the current render pass so the
+/// framebuffer can be sampled, then runs its own post-process chain before
+/// the main pass resumes. Overuse is therefore expensive; prefer a handful
+/// per frame.
+#[derive(Debug, Clone)]
+#[repr(C)]
+#[allow(missing_docs)]
+pub struct BlurRect {
+    pub order: DrawOrder,
+    pub kernel_levels: u32,
+    pub bounds: Bounds<ScaledPixels>,
+    pub content_mask: ContentMask<ScaledPixels>,
+    pub corner_radii: Corners<ScaledPixels>,
+    pub blur_radius: ScaledPixels,
+    pub _pad: f32,
+    pub tint: Hsla,
+}
+
+impl From<BlurRect> for Primitive {
+    fn from(blur: BlurRect) -> Self {
+        Primitive::BlurRect(blur)
+    }
+}
+
+/// A rounded rectangle with a full Liquid Glass composite: backdrop blur
+/// plus parabolic refraction, chromatic aberration, and a directional
+/// Fresnel edge highlight. Field layout mirrors the reference shader at
+/// `tahoe-gpui/crates/tahoe-gpui/src/foundations/shaders/glass_composite.wgsl`.
+///
+/// Same caveat as `BlurRect`: each `LensRect` forces a render-pass break.
+#[derive(Debug, Clone)]
+#[repr(C)]
+#[allow(missing_docs)]
+pub struct LensRect {
+    pub order: DrawOrder,
+    pub kernel_levels: u32,
+    pub bounds: Bounds<ScaledPixels>,
+    pub content_mask: ContentMask<ScaledPixels>,
+    pub corner_radii: Corners<ScaledPixels>,
+    pub blur_radius: ScaledPixels,
+    pub refraction: f32,
+    pub depth: f32,
+    pub dispersion: f32,
+    pub splay: ScaledPixels,
+    pub light_dir: Point<f32>,
+    pub light_intensity: f32,
+    pub _pad: f32,
+    pub tint: Hsla,
+    // Pad struct size to 112 bytes so that its WGSL `array<LensRect>` stride
+    // (rounded to the 8-byte alignment imposed by the nested `Bounds`' `vec2<f32>`)
+    // matches the Rust storage-buffer stride.
+    pub _pad2: f32,
+}
+
+impl From<LensRect> for Primitive {
+    fn from(lens: LensRect) -> Self {
+        Primitive::LensRect(lens)
     }
 }
 
@@ -892,5 +1025,109 @@ impl PathVertex<Pixels> {
             st_position: self.st_position,
             content_mask: self.content_mask.scale(factor),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BlurRect, LensRect, PrimitiveBatch, Scene};
+    use crate::{Bounds, ContentMask, Corners, Hsla, Point, ScaledPixels, point, size};
+
+    fn test_bounds() -> Bounds<ScaledPixels> {
+        Bounds {
+            origin: point(ScaledPixels(10.0), ScaledPixels(20.0)),
+            size: size(ScaledPixels(100.0), ScaledPixels(50.0)),
+        }
+    }
+
+    fn test_content_mask() -> ContentMask<ScaledPixels> {
+        ContentMask {
+            bounds: Bounds {
+                origin: point(ScaledPixels(0.0), ScaledPixels(0.0)),
+                size: size(ScaledPixels(1000.0), ScaledPixels(1000.0)),
+            },
+        }
+    }
+
+    fn test_corners() -> Corners<ScaledPixels> {
+        Corners {
+            top_left: ScaledPixels(4.0),
+            top_right: ScaledPixels(4.0),
+            bottom_right: ScaledPixels(4.0),
+            bottom_left: ScaledPixels(4.0),
+        }
+    }
+
+    #[test]
+    fn blur_rect_round_trip() {
+        let mut scene = Scene::default();
+        scene.insert_primitive(BlurRect {
+            order: 0,
+            kernel_levels: 3,
+            bounds: test_bounds(),
+            content_mask: test_content_mask(),
+            corner_radii: test_corners(),
+            blur_radius: ScaledPixels(12.0),
+            _pad: 0.0,
+            tint: Hsla {
+                h: 0.0,
+                s: 0.0,
+                l: 0.0,
+                a: 0.3,
+            },
+        });
+        scene.finish();
+
+        assert_eq!(scene.blur_rects.len(), 1);
+        assert!(scene.lens_rects.is_empty());
+
+        let batches: Vec<_> = scene.batches().collect();
+        assert!(
+            batches
+                .iter()
+                .any(|b| matches!(b, PrimitiveBatch::BlurRects(r) if r.len() == 1)),
+            "expected a BlurRects batch of size 1, got {:?}",
+            batches
+        );
+    }
+
+    #[test]
+    fn lens_rect_round_trip() {
+        let mut scene = Scene::default();
+        scene.insert_primitive(LensRect {
+            order: 0,
+            kernel_levels: 3,
+            bounds: test_bounds(),
+            content_mask: test_content_mask(),
+            corner_radii: test_corners(),
+            blur_radius: ScaledPixels(8.0),
+            refraction: 12.0,
+            depth: 6.0,
+            dispersion: 2.0,
+            splay: ScaledPixels(1.5),
+            light_dir: Point { x: 0.5, y: 0.5 },
+            light_intensity: 0.2,
+            _pad: 0.0,
+            tint: Hsla {
+                h: 0.6,
+                s: 0.2,
+                l: 0.8,
+                a: 0.1,
+            },
+            _pad2: 0.0,
+        });
+        scene.finish();
+
+        assert_eq!(scene.lens_rects.len(), 1);
+        assert!(scene.blur_rects.is_empty());
+
+        let batches: Vec<_> = scene.batches().collect();
+        assert!(
+            batches
+                .iter()
+                .any(|b| matches!(b, PrimitiveBatch::LensRects(r) if r.len() == 1)),
+            "expected a LensRects batch of size 1, got {:?}",
+            batches
+        );
     }
 }

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -125,11 +125,11 @@ impl Scene {
             }
             Primitive::BlurRect(blur) => {
                 blur.order = order;
-                self.blur_rects.push(blur.clone());
+                self.blur_rects.push(*blur);
             }
             Primitive::LensRect(lens) => {
                 lens.order = order;
-                self.lens_rects.push(lens.clone());
+                self.lens_rects.push(*lens);
             }
         }
         self.paint_operations
@@ -615,9 +615,9 @@ impl From<Shadow> for Primitive {
 /// framebuffer can be sampled, then runs its own post-process chain before
 /// the main pass resumes. Overuse is therefore expensive; prefer a handful
 /// per frame.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct BlurRect {
     pub order: DrawOrder,
     pub kernel_levels: u32,
@@ -625,9 +625,11 @@ pub struct BlurRect {
     pub content_mask: ContentMask<ScaledPixels>,
     pub corner_radii: Corners<ScaledPixels>,
     pub blur_radius: ScaledPixels,
-    pub _pad: f32,
+    pub pad: f32,
     pub tint: Hsla,
 }
+
+const _: () = assert!(std::mem::size_of::<BlurRect>() == 80);
 
 impl From<BlurRect> for Primitive {
     fn from(blur: BlurRect) -> Self {
@@ -641,9 +643,9 @@ impl From<BlurRect> for Primitive {
 /// `tahoe-gpui/crates/tahoe-gpui/src/foundations/shaders/glass_composite.wgsl`.
 ///
 /// Same caveat as `BlurRect`: each `LensRect` forces a render-pass break.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct LensRect {
     pub order: DrawOrder,
     pub kernel_levels: u32,
@@ -655,15 +657,18 @@ pub struct LensRect {
     pub depth: f32,
     pub dispersion: f32,
     pub splay: ScaledPixels,
-    pub light_dir: Point<f32>,
+    pub light_angle_radians: f32,
+    pub pad_light: f32,
     pub light_intensity: f32,
-    pub _pad: f32,
+    pub pad: f32,
     pub tint: Hsla,
-    // Pad struct size to 112 bytes so that its WGSL `array<LensRect>` stride
-    // (rounded to the 8-byte alignment imposed by the nested `Bounds`' `vec2<f32>`)
+    // Pads the struct to 112 bytes so its WGSL `array<LensRect>` stride
+    // (rounded to 8-byte alignment for the nested `Bounds` `vec2<f32>`)
     // matches the Rust storage-buffer stride.
-    pub _pad2: f32,
+    pub pad2: f32,
 }
+
+const _: () = assert!(std::mem::size_of::<LensRect>() == 112);
 
 impl From<LensRect> for Primitive {
     fn from(lens: LensRect) -> Self {
@@ -1068,7 +1073,7 @@ mod tests {
             content_mask: test_content_mask(),
             corner_radii: test_corners(),
             blur_radius: ScaledPixels(12.0),
-            _pad: 0.0,
+            pad: 0.0,
             tint: Hsla {
                 h: 0.0,
                 s: 0.0,
@@ -1105,16 +1110,17 @@ mod tests {
             depth: 6.0,
             dispersion: 2.0,
             splay: ScaledPixels(1.5),
-            light_dir: Point { x: 0.5, y: 0.5 },
+            light_angle_radians: std::f32::consts::FRAC_PI_4,
+            pad_light: 0.0,
             light_intensity: 0.2,
-            _pad: 0.0,
+            pad: 0.0,
             tint: Hsla {
                 h: 0.6,
                 s: 0.2,
                 l: 0.8,
                 a: 0.1,
             },
-            _pad2: 0.0,
+            pad2: 0.0,
         });
         scene.finish();
 

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -675,8 +675,8 @@ impl From<BlurRect> for Primitive {
 
 /// A rounded rectangle with a full Liquid Glass composite: backdrop blur
 /// plus parabolic refraction, chromatic aberration, and a directional
-/// Fresnel edge highlight. Field layout mirrors the reference shader at
-/// `tahoe-gpui/crates/tahoe-gpui/src/foundations/shaders/glass_composite.wgsl`.
+/// Fresnel edge highlight. Field layout is kept in lockstep with the WGSL
+/// / MSL `LensRect` struct and padded to a 112-byte stride.
 ///
 /// Same caveat as `BlurRect`: each `LensRect` forces a render-pass break.
 #[derive(Debug, Clone, Copy)]

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -1250,6 +1250,57 @@ mod tests {
     }
 
     #[test]
+    fn max_blur_kernel_levels_clamps_to_five() {
+        let mut scene = Scene::default();
+        let mut blur = make_blur_rect();
+        blur.kernel_levels = 10;
+        scene.insert_primitive(blur);
+        scene.finish();
+        assert_eq!(scene.max_blur_kernel_levels(), 5);
+    }
+
+    #[test]
+    fn max_blur_kernel_levels_empty_is_zero() {
+        let scene = Scene::default();
+        assert_eq!(scene.max_blur_kernel_levels(), 0);
+    }
+
+    #[test]
+    fn max_blur_radius_returns_max_of_blur_and_lens() {
+        let mut scene = Scene::default();
+        let mut blur = make_blur_rect();
+        blur.blur_radius = ScaledPixels(8.0);
+        scene.insert_primitive(blur);
+
+        scene.insert_primitive(LensRect {
+            order: 0,
+            kernel_levels: 3,
+            bounds: test_bounds(),
+            content_mask: test_content_mask(),
+            corner_radii: test_corners(),
+            blur_radius: ScaledPixels(24.0),
+            refraction: 12.0,
+            depth: 6.0,
+            dispersion: 0.0,
+            splay: ScaledPixels(1.5),
+            light_angle_radians: 0.0,
+            pad_light: 0.0,
+            light_intensity: 0.0,
+            pad: 0.0,
+            tint: Hsla {
+                h: 0.0,
+                s: 0.0,
+                l: 0.0,
+                a: 0.0,
+            },
+            pad2: 0.0,
+        });
+        scene.finish();
+
+        assert_eq!(scene.max_blur_radius(), ScaledPixels(24.0));
+    }
+
+    #[test]
     fn blur_rects_coalesce_when_adjacent() {
         let mut scene = Scene::default();
         scene.insert_primitive(BlurRect { ..make_blur_rect() });

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -1035,8 +1035,11 @@ impl PathVertex<Pixels> {
 
 #[cfg(test)]
 mod tests {
-    use super::{BlurRect, LensRect, PrimitiveBatch, Scene};
-    use crate::{Bounds, ContentMask, Corners, Hsla, Point, ScaledPixels, point, size};
+    use super::{BlurRect, LensRect, PrimitiveBatch, Quad, Scene};
+    use crate::{
+        Background, BorderStyle, Bounds, ContentMask, Corners, Edges, Hsla, ScaledPixels, point,
+        size,
+    };
 
     fn test_bounds() -> Bounds<ScaledPixels> {
         Bounds {
@@ -1135,5 +1138,101 @@ mod tests {
             "expected a LensRects batch of size 1, got {:?}",
             batches
         );
+    }
+
+    fn make_blur_rect() -> BlurRect {
+        BlurRect {
+            order: 0,
+            kernel_levels: 3,
+            bounds: test_bounds(),
+            content_mask: test_content_mask(),
+            corner_radii: test_corners(),
+            blur_radius: ScaledPixels(12.0),
+            pad: 0.0,
+            tint: Hsla {
+                h: 0.0,
+                s: 0.0,
+                l: 0.0,
+                a: 0.3,
+            },
+        }
+    }
+
+    fn make_quad() -> Quad {
+        Quad {
+            order: 0,
+            border_style: BorderStyle::default(),
+            bounds: test_bounds(),
+            content_mask: test_content_mask(),
+            background: Background::from(Hsla {
+                h: 0.0,
+                s: 0.0,
+                l: 0.0,
+                a: 1.0,
+            }),
+            border_color: Hsla {
+                h: 0.0,
+                s: 0.0,
+                l: 0.0,
+                a: 0.0,
+            },
+            corner_radii: test_corners(),
+            border_widths: Edges {
+                top: ScaledPixels(0.0),
+                right: ScaledPixels(0.0),
+                bottom: ScaledPixels(0.0),
+                left: ScaledPixels(0.0),
+            },
+        }
+    }
+
+    #[test]
+    fn blur_rects_interleave_with_quads() {
+        let mut scene = Scene::default();
+        for order in 0..4 {
+            if order % 2 == 0 {
+                scene.insert_primitive(Quad { ..make_quad() });
+            } else {
+                scene.insert_primitive(BlurRect { ..make_blur_rect() });
+            }
+        }
+        scene.finish();
+
+        let batch_kinds: Vec<_> = scene
+            .batches()
+            .map(|b| match b {
+                PrimitiveBatch::Quads(_) => "Quads",
+                PrimitiveBatch::BlurRects(_) => "BlurRects",
+                other => panic!("unexpected batch kind: {:?}", other),
+            })
+            .collect();
+        assert_eq!(
+            batch_kinds,
+            vec!["Quads", "BlurRects", "Quads", "BlurRects"],
+            "expected alternating Quad/BlurRects batches"
+        );
+    }
+
+    #[test]
+    fn blur_rects_coalesce_when_adjacent() {
+        let mut scene = Scene::default();
+        scene.insert_primitive(BlurRect { ..make_blur_rect() });
+        scene.insert_primitive(BlurRect { ..make_blur_rect() });
+        scene.finish();
+
+        let blur_batches: Vec<_> = scene
+            .batches()
+            .filter_map(|b| match b {
+                PrimitiveBatch::BlurRects(range) => Some(range),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            blur_batches.len(),
+            1,
+            "expected a single coalesced BlurRects batch, got {:?}",
+            blur_batches
+        );
+        assert_eq!(blur_batches[0].len(), 2);
     }
 }

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -135,7 +135,7 @@ impl Scene {
                 blur.order = order;
                 self.blur_rects.push(*blur);
             }
-            Primitive::LensRect(lens) => {
+            Primitive::LensGroup(lens) => {
                 lens.rect.order = order;
                 lens.rect.shape_offset = self.lens_shapes.len() as u32;
                 lens.rect.shape_count = lens.shapes.len() as u32;
@@ -183,9 +183,13 @@ impl Scene {
     /// to size the dual-Kawase snapshot chain for the frame. Returns 0
     /// when no blur-consuming primitive is present.
     pub fn max_blur_kernel_levels(&self) -> u32 {
+        // BlurRect and MirrorRect with zero radius contribute no visible
+        // blur and don't require a pyramid, so filter them. LensRect always
+        // needs the pyramid for refraction sampling even at radius 0.
         let blur = self
             .blur_rects
             .iter()
+            .filter(|b| b.blur_radius.0 > 0.0 || b.blur_radius_end.0 > 0.0)
             .map(|b| b.kernel_levels)
             .max()
             .unwrap_or(0);
@@ -305,18 +309,27 @@ pub enum Primitive {
     PolychromeSprite(PolychromeSprite),
     Surface(PaintSurface),
     BlurRect(BlurRect),
-    LensRect(LensPrimitive),
+    LensGroup(LensPrimitive),
     MirrorRect(MirrorRect),
 }
 
-/// A `LensRect` header paired with its per-shape union inputs. Round-trips
-/// through `PaintOperation::Primitive` so `Scene::replay` can repopulate
-/// `Scene::lens_shapes` with fresh offsets.
+/// A lens primitive as submitted by [`crate::Window::paint_lens_rect_union`]:
+/// the scalar [`LensRect`] header plus the (1..=`MAX_LENS_SHAPES_PER_GROUP`)
+/// [`LensShape`]s it covers.
+///
+/// [`Scene::insert_primitive`] splits this into [`Scene::lens_rects`] and
+/// [`Scene::lens_shapes`], and assigns fresh `shape_offset` / `shape_count`
+/// after [`Scene::finish`]'s sort. Callers should never populate those
+/// offsets by hand — always submit a `LensPrimitive`.
+///
+/// Uses `SmallVec` sized to `MAX_LENS_SHAPES_PER_GROUP` so the usual case
+/// (1..=8 shapes) never allocates, and the `Scene::replay` clone is a
+/// stack copy rather than a fresh heap allocation per replayed lens.
 #[derive(Clone, Debug)]
 #[expect(missing_docs)]
 pub struct LensPrimitive {
     pub rect: LensRect,
-    pub shapes: Vec<LensShape>,
+    pub shapes: smallvec::SmallVec<[LensShape; 8]>,
 }
 
 #[expect(missing_docs)]
@@ -332,7 +345,7 @@ impl Primitive {
             Primitive::PolychromeSprite(sprite) => &sprite.bounds,
             Primitive::Surface(surface) => &surface.bounds,
             Primitive::BlurRect(blur) => &blur.bounds,
-            Primitive::LensRect(lens) => &lens.rect.bounds,
+            Primitive::LensGroup(lens) => &lens.rect.bounds,
             Primitive::MirrorRect(mirror) => &mirror.bounds,
         }
     }
@@ -348,7 +361,7 @@ impl Primitive {
             Primitive::PolychromeSprite(sprite) => &sprite.content_mask,
             Primitive::Surface(surface) => &surface.content_mask,
             Primitive::BlurRect(blur) => &blur.content_mask,
-            Primitive::LensRect(lens) => &lens.rect.content_mask,
+            Primitive::LensGroup(lens) => &lens.rect.content_mask,
             Primitive::MirrorRect(mirror) => &mirror.content_mask,
         }
     }
@@ -747,7 +760,7 @@ pub struct BlurRect {
     /// Pads the stride to 96 bytes so the WGSL `array<BlurRect>` matches
     /// the Rust side (8-byte alignment required for the nested `vec2<f32>`
     /// Bounds).
-    pub _pad_end: [f32; 2],
+    pub pad_end: [f32; 2],
 }
 
 const _: () = assert!(std::mem::size_of::<BlurRect>() == 96);
@@ -783,8 +796,15 @@ pub struct LensRect {
     pub bounds: Bounds<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
     /// Index into `Scene::lens_shapes` of this lens's first shape.
+    ///
+    /// Caller-supplied values are overwritten by
+    /// [`Scene::insert_primitive`] after `finish()`'s sort; submit lens
+    /// primitives via [`LensPrimitive`] rather than constructing a bare
+    /// `LensRect` with hand-picked offsets.
     pub shape_offset: u32,
     /// Number of shapes in this lens (1..=`MAX_LENS_SHAPES_PER_GROUP`).
+    ///
+    /// See [`LensRect::shape_offset`] for the caller-supplied-value caveat.
     pub shape_count: u32,
     /// Smooth-min radius, in pixels, used when merging overlapping shapes
     /// into a single SDF. 0 disables merging (hard min).
@@ -813,7 +833,7 @@ const _: () = assert!(std::mem::size_of::<LensRect>() == 112);
 
 impl From<LensPrimitive> for Primitive {
     fn from(lens: LensPrimitive) -> Self {
-        Primitive::LensRect(lens)
+        Primitive::LensGroup(lens)
     }
 }
 
@@ -1251,7 +1271,8 @@ impl PathVertex<Pixels> {
 #[cfg(test)]
 mod tests {
     use super::{
-        BlurRect, LensPrimitive, LensRect, LensShape, MIRROR_AXIS_HORIZONTAL, MirrorRect,
+        BlurRect, LensPrimitive, LensRect, LensShape, MIRROR_AXIS_HORIZONTAL, MIRROR_AXIS_VERTICAL,
+        MirrorRect,
         PrimitiveBatch, Quad, Scene,
     };
     use crate::{
@@ -1302,7 +1323,7 @@ mod tests {
                 l: 0.0,
                 a: 0.3,
             },
-            _pad_end: [0.0; 2],
+            pad_end: [0.0; 2],
         });
         scene.finish();
 
@@ -1354,7 +1375,7 @@ mod tests {
                 },
                 pad2: 0.0,
             },
-            shapes: vec![test_lens_shape()],
+            shapes: smallvec::smallvec![test_lens_shape()],
         }
     }
 
@@ -1388,7 +1409,7 @@ mod tests {
             origin: point(ScaledPixels(5.0), ScaledPixels(10.0)),
             size: size(ScaledPixels(77.0), ScaledPixels(33.0)),
         };
-        lens.shapes = vec![LensShape {
+        lens.shapes = smallvec::smallvec![LensShape {
             bounds: test_bounds(),
             corner_radii: test_corners(),
             content_mask: custom_mask,
@@ -1455,7 +1476,7 @@ mod tests {
                 l: 0.0,
                 a: 0.3,
             },
-            _pad_end: [0.0; 2],
+            pad_end: [0.0; 2],
         }
     }
 
@@ -1581,10 +1602,28 @@ mod tests {
     #[test]
     fn mirror_rect_round_trip() {
         let mut scene = Scene::default();
-        scene.insert_primitive(make_mirror_rect());
+        let mut inserted = make_mirror_rect();
+        inserted.source_bounds = Bounds {
+            origin: point(ScaledPixels(42.0), ScaledPixels(43.0)),
+            size: size(ScaledPixels(50.0), ScaledPixels(60.0)),
+        };
+        inserted.mirror_axis = MIRROR_AXIS_VERTICAL;
+        inserted.clip_to_destination = 0;
+        inserted.tint = Hsla {
+            h: 0.3,
+            s: 0.4,
+            l: 0.5,
+            a: 0.6,
+        };
+        scene.insert_primitive(inserted);
         scene.finish();
 
         assert_eq!(scene.mirror_rects.len(), 1);
+        let stored = &scene.mirror_rects[0];
+        assert_eq!(stored.source_bounds, inserted.source_bounds);
+        assert_eq!(stored.mirror_axis, inserted.mirror_axis);
+        assert_eq!(stored.clip_to_destination, inserted.clip_to_destination);
+        assert_eq!(stored.tint, inserted.tint);
 
         let batches: Vec<_> = scene.batches().collect();
         assert!(
@@ -1638,5 +1677,130 @@ mod tests {
             blur_batches
         );
         assert_eq!(blur_batches[0].len(), 2);
+    }
+
+    #[test]
+    fn lens_rects_coalesce_when_adjacent() {
+        let mut scene = Scene::default();
+        scene.insert_primitive(make_lens_primitive());
+        scene.insert_primitive(make_lens_primitive());
+        scene.finish();
+
+        let lens_batches: Vec<_> = scene
+            .batches()
+            .filter_map(|b| match b {
+                PrimitiveBatch::LensRects(range) => Some(range),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            lens_batches.len(),
+            1,
+            "expected a single coalesced LensRects batch, got {:?}",
+            lens_batches
+        );
+        assert_eq!(lens_batches[0].len(), 2);
+    }
+
+    #[test]
+    fn mirror_rects_coalesce_when_adjacent() {
+        let mut scene = Scene::default();
+        scene.insert_primitive(make_mirror_rect());
+        scene.insert_primitive(make_mirror_rect());
+        scene.finish();
+
+        let mirror_batches: Vec<_> = scene
+            .batches()
+            .filter_map(|b| match b {
+                PrimitiveBatch::MirrorRects(range) => Some(range),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            mirror_batches.len(),
+            1,
+            "expected a single coalesced MirrorRects batch, got {:?}",
+            mirror_batches
+        );
+        assert_eq!(mirror_batches[0].len(), 2);
+    }
+
+    #[test]
+    fn max_blur_kernel_levels_respects_zero_request() {
+        let mut scene = Scene::default();
+        let mut blur = make_blur_rect();
+        blur.kernel_levels = 0;
+        blur.blur_radius = ScaledPixels(12.0);
+        blur.blur_radius_end = ScaledPixels(12.0);
+        scene.insert_primitive(blur);
+
+        let mut mirror = make_mirror_rect();
+        mirror.kernel_levels = 0;
+        mirror.blur_radius = ScaledPixels(12.0);
+        scene.insert_primitive(mirror);
+
+        scene.finish();
+        // When every primitive asks for kernel_levels == 0, the scene max
+        // stays 0 — the renderer's per-batch fallback is what decides
+        // whether to run any Kawase passes at all.
+        assert_eq!(scene.max_blur_kernel_levels(), 0);
+    }
+
+    #[test]
+    fn blur_rect_without_blur_contributes_zero_kernel() {
+        let mut scene = Scene::default();
+        // BlurRect with both radii at 0: no pyramid work needed, so its
+        // `kernel_levels` must not size the Kawase chain.
+        scene.insert_primitive(BlurRect { ..make_blur_rect() });
+        // Override both radii to zero while keeping kernel_levels high.
+        let last = scene.blur_rects.last_mut().expect("blur rect inserted");
+        last.blur_radius = ScaledPixels(0.0);
+        last.blur_radius_end = ScaledPixels(0.0);
+        last.kernel_levels = 5;
+        scene.finish();
+
+        assert_eq!(scene.max_blur_kernel_levels(), 0);
+    }
+
+    #[test]
+    fn mirror_rect_end_only_radius_contributes_kernel() {
+        // Locks in the OR semantics of the mirror-rect zero-radius filter:
+        // blur_radius == 0 with blur_radius_end > 0 still sizes the chain.
+        let mut scene = Scene::default();
+        let mut mirror = make_mirror_rect();
+        mirror.blur_radius = ScaledPixels(0.0);
+        mirror.blur_radius_end = ScaledPixels(12.0);
+        scene.insert_primitive(mirror);
+        scene.finish();
+        assert_eq!(scene.max_blur_kernel_levels(), 3);
+    }
+
+    #[test]
+    fn lens_and_mirror_rects_interleave_with_quads() {
+        // Blur → non-blur → Blur must produce three distinct batches so
+        // the renderer's snapshot cache invalidates on the non-blur middle.
+        // Regression guard for the batcher's `is_blur_batch` match.
+        let mut scene = Scene::default();
+        scene.insert_primitive(make_quad());
+        scene.insert_primitive(make_lens_primitive());
+        scene.insert_primitive(make_quad());
+        scene.insert_primitive(make_mirror_rect());
+        scene.insert_primitive(make_quad());
+        scene.finish();
+
+        let batch_kinds: Vec<&'static str> = scene
+            .batches()
+            .map(|b| match b {
+                PrimitiveBatch::Quads(_) => "Quads",
+                PrimitiveBatch::LensRects(_) => "LensRects",
+                PrimitiveBatch::MirrorRects(_) => "MirrorRects",
+                PrimitiveBatch::BlurRects(_) => "BlurRects",
+                _ => "Other",
+            })
+            .collect();
+        assert_eq!(
+            batch_kinds,
+            vec!["Quads", "LensRects", "Quads", "MirrorRects", "Quads"],
+        );
     }
 }

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -38,6 +38,12 @@ pub struct Scene {
     pub surfaces: Vec<PaintSurface>,
     pub blur_rects: Vec<BlurRect>,
     pub lens_rects: Vec<LensRect>,
+    pub mirror_rects: Vec<MirrorRect>,
+    /// Per-shape data for `LensRect`s that represent a multi-shape union.
+    /// Each `LensRect` points at a `shape_offset..shape_offset+shape_count`
+    /// slice of this vec. Shapes are never reordered after insertion, so the
+    /// offsets stored in `lens_rects` survive `finish()`'s sort.
+    pub lens_shapes: Vec<LensShape>,
 }
 
 #[expect(missing_docs)]
@@ -56,6 +62,8 @@ impl Scene {
         self.surfaces.clear();
         self.blur_rects.clear();
         self.lens_rects.clear();
+        self.mirror_rects.clear();
+        self.lens_shapes.clear();
     }
 
     pub fn len(&self) -> usize {
@@ -128,8 +136,15 @@ impl Scene {
                 self.blur_rects.push(*blur);
             }
             Primitive::LensRect(lens) => {
-                lens.order = order;
-                self.lens_rects.push(*lens);
+                lens.rect.order = order;
+                lens.rect.shape_offset = self.lens_shapes.len() as u32;
+                lens.rect.shape_count = lens.shapes.len() as u32;
+                self.lens_shapes.extend_from_slice(&lens.shapes);
+                self.lens_rects.push(lens.rect);
+            }
+            Primitive::MirrorRect(mirror) => {
+                mirror.order = order;
+                self.mirror_rects.push(*mirror);
             }
         }
         self.paint_operations
@@ -160,12 +175,13 @@ impl Scene {
         self.surfaces.sort_by_key(|surface| surface.order);
         self.blur_rects.sort_by_key(|blur| blur.order);
         self.lens_rects.sort_by_key(|lens| lens.order);
+        self.mirror_rects.sort_by_key(|mirror| mirror.order);
     }
 
-    /// Maximum `kernel_levels` requested by any `BlurRect` or `LensRect`
-    /// in the scene, clamped to `1..=5`. Used by renderers to size the
-    /// dual-Kawase snapshot chain for the frame. Returns 0 when neither
-    /// primitive kind is present.
+    /// Maximum `kernel_levels` requested by any `BlurRect`, `LensRect`, or
+    /// `MirrorRect` in the scene, clamped to `1..=5`. Used by renderers
+    /// to size the dual-Kawase snapshot chain for the frame. Returns 0
+    /// when no blur-consuming primitive is present.
     pub fn max_blur_kernel_levels(&self) -> u32 {
         let blur = self
             .blur_rects
@@ -179,23 +195,38 @@ impl Scene {
             .map(|l| l.kernel_levels)
             .max()
             .unwrap_or(0);
-        blur.max(lens).min(5)
+        let mirror = self
+            .mirror_rects
+            .iter()
+            .filter(|m| m.blur_radius.0 > 0.0 || m.blur_radius_end.0 > 0.0)
+            .map(|m| m.kernel_levels)
+            .max()
+            .unwrap_or(0);
+        blur.max(lens).max(mirror).min(5)
     }
 
-    /// Maximum `blur_radius` requested by any `BlurRect` or `LensRect` in
-    /// the scene. Zero when neither primitive kind is present.
+    /// Maximum `blur_radius` requested by any `BlurRect`, `LensRect`, or
+    /// `MirrorRect` in the scene. For gradient blurs, considers both
+    /// endpoints (`radius` and `radius_end`) — the bigger of the two
+    /// determines how much blurring the Kawase chain must be able to
+    /// produce. Zero when no blur-consuming primitive is present.
     pub fn max_blur_radius(&self) -> ScaledPixels {
         let blur = self
             .blur_rects
             .iter()
-            .map(|b| b.blur_radius.0)
+            .map(|b| b.blur_radius.0.max(b.blur_radius_end.0))
             .fold(0.0_f32, f32::max);
         let lens = self
             .lens_rects
             .iter()
-            .map(|l| l.blur_radius.0)
+            .map(|l| l.blur_radius.0.max(l.blur_radius_end.0))
             .fold(0.0_f32, f32::max);
-        ScaledPixels(blur.max(lens))
+        let mirror = self
+            .mirror_rects
+            .iter()
+            .map(|m| m.blur_radius.0.max(m.blur_radius_end.0))
+            .fold(0.0_f32, f32::max);
+        ScaledPixels(blur.max(lens).max(mirror))
     }
 
     #[cfg_attr(
@@ -227,6 +258,8 @@ impl Scene {
             blur_rects_iter: self.blur_rects.iter().peekable(),
             lens_rects_start: 0,
             lens_rects_iter: self.lens_rects.iter().peekable(),
+            mirror_rects_start: 0,
+            mirror_rects_iter: self.mirror_rects.iter().peekable(),
         }
     }
 }
@@ -251,6 +284,7 @@ pub(crate) enum PrimitiveKind {
     Surface,
     BlurRect,
     LensRect,
+    MirrorRect,
 }
 
 pub(crate) enum PaintOperation {
@@ -271,7 +305,18 @@ pub enum Primitive {
     PolychromeSprite(PolychromeSprite),
     Surface(PaintSurface),
     BlurRect(BlurRect),
-    LensRect(LensRect),
+    LensRect(LensPrimitive),
+    MirrorRect(MirrorRect),
+}
+
+/// A `LensRect` header paired with its per-shape union inputs. Round-trips
+/// through `PaintOperation::Primitive` so `Scene::replay` can repopulate
+/// `Scene::lens_shapes` with fresh offsets.
+#[derive(Clone, Debug)]
+#[expect(missing_docs)]
+pub struct LensPrimitive {
+    pub rect: LensRect,
+    pub shapes: Vec<LensShape>,
 }
 
 #[expect(missing_docs)]
@@ -287,7 +332,8 @@ impl Primitive {
             Primitive::PolychromeSprite(sprite) => &sprite.bounds,
             Primitive::Surface(surface) => &surface.bounds,
             Primitive::BlurRect(blur) => &blur.bounds,
-            Primitive::LensRect(lens) => &lens.bounds,
+            Primitive::LensRect(lens) => &lens.rect.bounds,
+            Primitive::MirrorRect(mirror) => &mirror.bounds,
         }
     }
 
@@ -302,7 +348,8 @@ impl Primitive {
             Primitive::PolychromeSprite(sprite) => &sprite.content_mask,
             Primitive::Surface(surface) => &surface.content_mask,
             Primitive::BlurRect(blur) => &blur.content_mask,
-            Primitive::LensRect(lens) => &lens.content_mask,
+            Primitive::LensRect(lens) => &lens.rect.content_mask,
+            Primitive::MirrorRect(mirror) => &mirror.content_mask,
         }
     }
 }
@@ -335,6 +382,8 @@ struct BatchIterator<'a> {
     blur_rects_iter: Peekable<slice::Iter<'a, BlurRect>>,
     lens_rects_start: usize,
     lens_rects_iter: Peekable<slice::Iter<'a, LensRect>>,
+    mirror_rects_start: usize,
+    mirror_rects_iter: Peekable<slice::Iter<'a, MirrorRect>>,
 }
 
 impl<'a> Iterator for BatchIterator<'a> {
@@ -375,6 +424,10 @@ impl<'a> Iterator for BatchIterator<'a> {
             (
                 self.lens_rects_iter.peek().map(|l| l.order),
                 PrimitiveKind::LensRect,
+            ),
+            (
+                self.mirror_rects_iter.peek().map(|m| m.order),
+                PrimitiveKind::MirrorRect,
             ),
         ];
         orders_and_kinds.sort_by_key(|(order, kind)| (order.unwrap_or(u32::MAX), *kind));
@@ -549,6 +602,22 @@ impl<'a> Iterator for BatchIterator<'a> {
                 self.lens_rects_start = lens_rects_end;
                 Some(PrimitiveBatch::LensRects(lens_rects_start..lens_rects_end))
             }
+            PrimitiveKind::MirrorRect => {
+                let mirror_rects_start = self.mirror_rects_start;
+                let mut mirror_rects_end = mirror_rects_start + 1;
+                self.mirror_rects_iter.next();
+                while self
+                    .mirror_rects_iter
+                    .next_if(|mirror| (mirror.order, batch_kind) < max_order_and_kind)
+                    .is_some()
+                {
+                    mirror_rects_end += 1;
+                }
+                self.mirror_rects_start = mirror_rects_end;
+                Some(PrimitiveBatch::MirrorRects(
+                    mirror_rects_start..mirror_rects_end,
+                ))
+            }
         }
     }
 }
@@ -583,6 +652,7 @@ pub enum PrimitiveBatch {
     Surfaces(Range<usize>),
     BlurRects(Range<usize>),
     LensRects(Range<usize>),
+    MirrorRects(Range<usize>),
 }
 
 #[derive(Default, Debug, Copy, Clone)]
@@ -646,6 +716,12 @@ impl From<Shadow> for Primitive {
 /// dual-Kawase blur, and composites the result with a tint. Used for
 /// backdrop-blurred materials like Apple's Liquid Glass.
 ///
+/// Supports uniform or linear-gradient blur strength: when
+/// `gradient_direction != [0, 0]`, the fragment shader interpolates
+/// `blur_radius_start -> blur_radius_end` along that axis and mixes between
+/// the un-blurred framebuffer and the maximum-blur output. Used for HIG
+/// scroll-edge fades.
+///
 /// Unlike `Quad` / `Shadow` / etc., a `BlurRect` is not drawn with an
 /// instanced pipeline — each one breaks the current render pass so the
 /// framebuffer can be sampled, then runs its own post-process chain before
@@ -660,12 +736,21 @@ pub struct BlurRect {
     pub bounds: Bounds<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
     pub corner_radii: Corners<ScaledPixels>,
+    /// Starting blur radius (in device pixels). For uniform blur, equals
+    /// `blur_radius_end`. The max of the two is what sizes the Kawase chain.
     pub blur_radius: ScaledPixels,
-    pub pad: f32,
+    /// Ending blur radius (in device pixels) for linear-gradient blur.
+    pub blur_radius_end: ScaledPixels,
+    /// Normalized gradient direction. `[0.0, 0.0]` means uniform blur.
+    pub gradient_direction: [f32; 2],
     pub tint: Hsla,
+    /// Pads the stride to 96 bytes so the WGSL `array<BlurRect>` matches
+    /// the Rust side (8-byte alignment required for the nested `vec2<f32>`
+    /// Bounds).
+    pub _pad_end: [f32; 2],
 }
 
-const _: () = assert!(std::mem::size_of::<BlurRect>() == 80);
+const _: () = assert!(std::mem::size_of::<BlurRect>() == 96);
 
 impl From<BlurRect> for Primitive {
     fn from(blur: BlurRect) -> Self {
@@ -673,10 +758,20 @@ impl From<BlurRect> for Primitive {
     }
 }
 
-/// A rounded rectangle with a full Liquid Glass composite: backdrop blur
-/// plus parabolic refraction, chromatic aberration, and a directional
-/// Fresnel edge highlight. Field layout is kept in lockstep with the WGSL
-/// / MSL `LensRect` struct and padded to a 112-byte stride.
+/// A rounded-rectangle group with a full Liquid Glass composite: backdrop
+/// blur plus parabolic refraction, chromatic aberration, and a directional
+/// Fresnel edge highlight. `bounds` is the union AABB of the shapes this
+/// primitive covers, expanded by `edge_blend_distance` on all sides so the
+/// merge field has room to settle. Per-shape `corner_radii` and `bounds`
+/// live on separate `LensShape` entries at
+/// `Scene::lens_shapes[shape_offset..shape_offset + shape_count]`.
+///
+/// Supports uniform or linear-gradient blur strength the same way
+/// [`BlurRect`] does: `gradient_direction != [0, 0]` enables a per-pixel
+/// interpolation between `blur_radius..blur_radius_end`.
+///
+/// The field layout is kept in lockstep with the WGSL / MSL `LensRect`
+/// struct and padded to a 112-byte stride.
 ///
 /// Same caveat as `BlurRect`: each `LensRect` forces a render-pass break.
 #[derive(Debug, Clone, Copy)]
@@ -687,16 +782,26 @@ pub struct LensRect {
     pub kernel_levels: u32,
     pub bounds: Bounds<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
-    pub corner_radii: Corners<ScaledPixels>,
+    /// Index into `Scene::lens_shapes` of this lens's first shape.
+    pub shape_offset: u32,
+    /// Number of shapes in this lens (1..=`MAX_LENS_SHAPES_PER_GROUP`).
+    pub shape_count: u32,
+    /// Smooth-min radius, in pixels, used when merging overlapping shapes
+    /// into a single SDF. 0 disables merging (hard min).
+    pub edge_blend_distance: ScaledPixels,
+    /// Starting blur radius (in device pixels). For uniform blur, equals
+    /// `blur_radius_end`.
     pub blur_radius: ScaledPixels,
+    /// Normalized gradient direction. `[0.0, 0.0]` means uniform blur.
+    pub gradient_direction: [f32; 2],
+    /// Ending blur radius (in device pixels) for linear-gradient blur.
+    pub blur_radius_end: ScaledPixels,
     pub refraction: f32,
     pub depth: f32,
     pub dispersion: f32,
     pub splay: ScaledPixels,
     pub light_angle_radians: f32,
-    pub pad_light: f32,
     pub light_intensity: f32,
-    pub pad: f32,
     pub tint: Hsla,
     // Pads the struct to 112 bytes so its WGSL `array<LensRect>` stride
     // (rounded to 8-byte alignment for the nested `Bounds` `vec2<f32>`)
@@ -706,9 +811,83 @@ pub struct LensRect {
 
 const _: () = assert!(std::mem::size_of::<LensRect>() == 112);
 
-impl From<LensRect> for Primitive {
-    fn from(lens: LensRect) -> Self {
+impl From<LensPrimitive> for Primitive {
+    fn from(lens: LensPrimitive) -> Self {
         Primitive::LensRect(lens)
+    }
+}
+
+/// One shape in a multi-shape `LensRect` union. The lens fragment shader
+/// computes a signed distance to each shape, combines them with a smooth-min
+/// weighted by `LensRect::edge_blend_distance`, and refracts against the
+/// resulting field — letting overlapping shapes visually morph into one.
+///
+/// `content_mask` is applied per-shape: fragments outside the mask get a
+/// soft attenuation applied to the shape's contribution (weight → 0), so
+/// clipped shapes dissolve into their neighbors in the smooth-min union
+/// instead of producing a hard seam at the mask edge.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+#[expect(missing_docs)]
+pub struct LensShape {
+    pub bounds: Bounds<ScaledPixels>,
+    pub corner_radii: Corners<ScaledPixels>,
+    /// Per-shape clip rectangle. Fragments outside this rect attenuate
+    /// the shape's SDF-union weight to zero (with a ~1-pixel smoothing
+    /// band) so masked-out regions yield to the remaining shapes.
+    pub content_mask: Bounds<ScaledPixels>,
+}
+
+const _: () = assert!(std::mem::size_of::<LensShape>() == 48);
+
+/// Bit flag enabling a horizontal (left/right) flip in
+/// [`MirrorRect::mirror_axis`].
+pub const MIRROR_AXIS_HORIZONTAL: u32 = 1 << 0;
+/// Bit flag enabling a vertical (top/bottom) flip in
+/// [`MirrorRect::mirror_axis`]. Combine with
+/// [`MIRROR_AXIS_HORIZONTAL`] to produce a 180° rotation.
+pub const MIRROR_AXIS_VERTICAL: u32 = 1 << 1;
+
+/// A rounded rectangle that samples a region of the framebuffer, optionally
+/// flipped across one or both axes, and composites the result back at a
+/// different location. Used for SwiftUI's `backgroundExtensionEffect()` —
+/// extend an image's edge into a decorative out-of-frame mirror, optionally
+/// blurred with the scene's Kawase chain.
+///
+/// Supports the same uniform-or-gradient blur as [`BlurRect`] /
+/// [`LensRect`]. `blur_radius == 0 && blur_radius_end == 0` samples the
+/// un-blurred framebuffer snapshot directly (no blur).
+///
+/// Like `BlurRect` and `LensRect`, each mirror primitive forces a
+/// render-pass break so the framebuffer can be sampled.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+#[expect(missing_docs)]
+pub struct MirrorRect {
+    pub order: DrawOrder,
+    pub kernel_levels: u32,
+    pub bounds: Bounds<ScaledPixels>,
+    pub content_mask: ContentMask<ScaledPixels>,
+    pub corner_radii: Corners<ScaledPixels>,
+    pub source_bounds: Bounds<ScaledPixels>,
+    /// Bitmask of `MIRROR_AXIS_*` flags. `0` disables flipping; the
+    /// primitive then acts as a relocated copy of `source_bounds`.
+    pub mirror_axis: u32,
+    /// `1` clips the mirrored sample against the rounded-rect SDF so
+    /// out-of-corner pixels go transparent. `0` lets the mirrored
+    /// rectangle bleed into the AA band.
+    pub clip_to_destination: u32,
+    pub blur_radius: ScaledPixels,
+    pub blur_radius_end: ScaledPixels,
+    pub gradient_direction: [f32; 2],
+    pub tint: Hsla,
+}
+
+const _: () = assert!(std::mem::size_of::<MirrorRect>() == 112);
+
+impl From<MirrorRect> for Primitive {
+    fn from(mirror: MirrorRect) -> Self {
+        Primitive::MirrorRect(mirror)
     }
 }
 
@@ -1071,7 +1250,10 @@ impl PathVertex<Pixels> {
 
 #[cfg(test)]
 mod tests {
-    use super::{BlurRect, LensRect, PrimitiveBatch, Quad, Scene};
+    use super::{
+        BlurRect, LensPrimitive, LensRect, LensShape, MIRROR_AXIS_HORIZONTAL, MirrorRect,
+        PrimitiveBatch, Quad, Scene,
+    };
     use crate::{
         Background, BorderStyle, Bounds, ContentMask, Corners, Edges, Hsla, ScaledPixels, point,
         size,
@@ -1112,13 +1294,15 @@ mod tests {
             content_mask: test_content_mask(),
             corner_radii: test_corners(),
             blur_radius: ScaledPixels(12.0),
-            pad: 0.0,
+            blur_radius_end: ScaledPixels(12.0),
+            gradient_direction: [0.0, 0.0],
             tint: Hsla {
                 h: 0.0,
                 s: 0.0,
                 l: 0.0,
                 a: 0.3,
             },
+            _pad_end: [0.0; 2],
         });
         scene.finish();
 
@@ -1135,36 +1319,56 @@ mod tests {
         );
     }
 
+    fn test_lens_shape() -> LensShape {
+        LensShape {
+            bounds: test_bounds(),
+            corner_radii: test_corners(),
+            content_mask: test_content_mask().bounds,
+        }
+    }
+
+    fn make_lens_primitive() -> LensPrimitive {
+        LensPrimitive {
+            rect: LensRect {
+                order: 0,
+                kernel_levels: 3,
+                bounds: test_bounds(),
+                content_mask: test_content_mask(),
+                shape_offset: 0,
+                shape_count: 0,
+                edge_blend_distance: ScaledPixels(0.0),
+                blur_radius: ScaledPixels(8.0),
+                gradient_direction: [0.0, 0.0],
+                blur_radius_end: ScaledPixels(8.0),
+                refraction: 12.0,
+                depth: 6.0,
+                dispersion: 2.0,
+                splay: ScaledPixels(1.5),
+                light_angle_radians: std::f32::consts::FRAC_PI_4,
+                light_intensity: 0.2,
+                tint: Hsla {
+                    h: 0.6,
+                    s: 0.2,
+                    l: 0.8,
+                    a: 0.1,
+                },
+                pad2: 0.0,
+            },
+            shapes: vec![test_lens_shape()],
+        }
+    }
+
     #[test]
     fn lens_rect_round_trip() {
         let mut scene = Scene::default();
-        scene.insert_primitive(LensRect {
-            order: 0,
-            kernel_levels: 3,
-            bounds: test_bounds(),
-            content_mask: test_content_mask(),
-            corner_radii: test_corners(),
-            blur_radius: ScaledPixels(8.0),
-            refraction: 12.0,
-            depth: 6.0,
-            dispersion: 2.0,
-            splay: ScaledPixels(1.5),
-            light_angle_radians: std::f32::consts::FRAC_PI_4,
-            pad_light: 0.0,
-            light_intensity: 0.2,
-            pad: 0.0,
-            tint: Hsla {
-                h: 0.6,
-                s: 0.2,
-                l: 0.8,
-                a: 0.1,
-            },
-            pad2: 0.0,
-        });
+        scene.insert_primitive(make_lens_primitive());
         scene.finish();
 
         assert_eq!(scene.lens_rects.len(), 1);
+        assert_eq!(scene.lens_shapes.len(), 1);
         assert!(scene.blur_rects.is_empty());
+        assert_eq!(scene.lens_rects[0].shape_offset, 0);
+        assert_eq!(scene.lens_rects[0].shape_count, 1);
 
         let batches: Vec<_> = scene.batches().collect();
         assert!(
@@ -1176,6 +1380,65 @@ mod tests {
         );
     }
 
+    #[test]
+    fn lens_shape_preserves_content_mask() {
+        let mut scene = Scene::default();
+        let mut lens = make_lens_primitive();
+        let custom_mask = Bounds {
+            origin: point(ScaledPixels(5.0), ScaledPixels(10.0)),
+            size: size(ScaledPixels(77.0), ScaledPixels(33.0)),
+        };
+        lens.shapes = vec![LensShape {
+            bounds: test_bounds(),
+            corner_radii: test_corners(),
+            content_mask: custom_mask,
+        }];
+        scene.insert_primitive(lens);
+        scene.finish();
+
+        assert_eq!(scene.lens_shapes.len(), 1);
+        assert_eq!(scene.lens_shapes[0].content_mask, custom_mask);
+    }
+
+    #[test]
+    fn lens_rect_multi_shape_roundtrip() {
+        let mut scene = Scene::default();
+        let mut lens = make_lens_primitive();
+        lens.shapes = (0..8).map(|_| test_lens_shape()).collect();
+        scene.insert_primitive(lens);
+        scene.finish();
+
+        assert_eq!(scene.lens_rects.len(), 1);
+        assert_eq!(scene.lens_shapes.len(), 8);
+        assert_eq!(scene.lens_rects[0].shape_offset, 0);
+        assert_eq!(scene.lens_rects[0].shape_count, 8);
+    }
+
+    #[test]
+    fn lens_shapes_survive_lens_rect_sort() {
+        let mut scene = Scene::default();
+        // Insert two lens primitives in reverse draw order; lens_shapes must
+        // still be indexable by the final, sorted lens_rects.
+        for (draw_order, shape_count) in [(5u32, 3usize), (1u32, 2usize)] {
+            let mut lens = make_lens_primitive();
+            lens.rect.order = draw_order;
+            lens.shapes = (0..shape_count).map(|_| test_lens_shape()).collect();
+            scene.insert_primitive(lens);
+        }
+        scene.finish();
+
+        assert_eq!(scene.lens_rects.len(), 2);
+        assert_eq!(scene.lens_shapes.len(), 5);
+        // After sort by order, the lower-order lens (2 shapes) comes first.
+        // Its shape_offset was set at insertion time and must still address
+        // a valid slice of lens_shapes.
+        for lens in &scene.lens_rects {
+            let start = lens.shape_offset as usize;
+            let end = start + lens.shape_count as usize;
+            assert!(end <= scene.lens_shapes.len());
+        }
+    }
+
     fn make_blur_rect() -> BlurRect {
         BlurRect {
             order: 0,
@@ -1184,13 +1447,15 @@ mod tests {
             content_mask: test_content_mask(),
             corner_radii: test_corners(),
             blur_radius: ScaledPixels(12.0),
-            pad: 0.0,
+            blur_radius_end: ScaledPixels(12.0),
+            gradient_direction: [0.0, 0.0],
             tint: Hsla {
                 h: 0.0,
                 s: 0.0,
                 l: 0.0,
                 a: 0.3,
             },
+            _pad_end: [0.0; 2],
         }
     }
 
@@ -1272,32 +1537,84 @@ mod tests {
         blur.blur_radius = ScaledPixels(8.0);
         scene.insert_primitive(blur);
 
-        scene.insert_primitive(LensRect {
+        let mut lens = make_lens_primitive();
+        lens.rect.blur_radius = ScaledPixels(24.0);
+        lens.rect.dispersion = 0.0;
+        lens.rect.light_intensity = 0.0;
+        lens.rect.light_angle_radians = 0.0;
+        lens.rect.refraction = 12.0;
+        lens.rect.depth = 6.0;
+        lens.rect.tint = Hsla {
+            h: 0.0,
+            s: 0.0,
+            l: 0.0,
+            a: 0.0,
+        };
+        scene.insert_primitive(lens);
+        scene.finish();
+
+        assert_eq!(scene.max_blur_radius(), ScaledPixels(24.0));
+    }
+
+    fn make_mirror_rect() -> MirrorRect {
+        MirrorRect {
             order: 0,
             kernel_levels: 3,
             bounds: test_bounds(),
             content_mask: test_content_mask(),
             corner_radii: test_corners(),
-            blur_radius: ScaledPixels(24.0),
-            refraction: 12.0,
-            depth: 6.0,
-            dispersion: 0.0,
-            splay: ScaledPixels(1.5),
-            light_angle_radians: 0.0,
-            pad_light: 0.0,
-            light_intensity: 0.0,
-            pad: 0.0,
+            source_bounds: test_bounds(),
+            mirror_axis: MIRROR_AXIS_HORIZONTAL,
+            clip_to_destination: 1,
+            blur_radius: ScaledPixels(0.0),
+            blur_radius_end: ScaledPixels(0.0),
+            gradient_direction: [0.0, 0.0],
             tint: Hsla {
                 h: 0.0,
                 s: 0.0,
                 l: 0.0,
                 a: 0.0,
             },
-            pad2: 0.0,
-        });
+        }
+    }
+
+    #[test]
+    fn mirror_rect_round_trip() {
+        let mut scene = Scene::default();
+        scene.insert_primitive(make_mirror_rect());
         scene.finish();
 
-        assert_eq!(scene.max_blur_radius(), ScaledPixels(24.0));
+        assert_eq!(scene.mirror_rects.len(), 1);
+
+        let batches: Vec<_> = scene.batches().collect();
+        assert!(
+            batches
+                .iter()
+                .any(|b| matches!(b, PrimitiveBatch::MirrorRects(r) if r.len() == 1)),
+            "expected a MirrorRects batch of size 1, got {:?}",
+            batches
+        );
+    }
+
+    #[test]
+    fn mirror_rect_with_blur_affects_max_blur_radius() {
+        let mut scene = Scene::default();
+        let mut mirror = make_mirror_rect();
+        mirror.blur_radius = ScaledPixels(18.0);
+        mirror.blur_radius_end = ScaledPixels(30.0);
+        scene.insert_primitive(mirror);
+        scene.finish();
+        assert_eq!(scene.max_blur_radius(), ScaledPixels(30.0));
+        assert_eq!(scene.max_blur_kernel_levels(), 3);
+    }
+
+    #[test]
+    fn mirror_rect_without_blur_contributes_zero_kernel() {
+        let mut scene = Scene::default();
+        scene.insert_primitive(make_mirror_rect());
+        scene.finish();
+        // blur_radius == 0 and blur_radius_end == 0: no Kawase chain needed.
+        assert_eq!(scene.max_blur_kernel_levels(), 0);
     }
 
     #[test]

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -53,7 +53,7 @@ use std::{
     ops::{DerefMut, Range},
     rc::Rc,
     sync::{
-        Arc, Weak,
+        Arc, OnceLock, Weak,
         atomic::{AtomicUsize, Ordering::SeqCst},
     },
     time::Duration,
@@ -3417,7 +3417,7 @@ impl Window {
             blur_radius_end: effect.radius_end.scale(scale_factor),
             gradient_direction: effect.gradient_direction,
             tint: effect.tint.opacity(opacity),
-            _pad_end: [0.0; 2],
+            pad_end: [0.0; 2],
         });
     }
 
@@ -3449,13 +3449,20 @@ impl Window {
     /// distance fields — the GPU-side equivalent of SwiftUI's
     /// `GlassEffectContainer(spacing:)`.
     ///
-    /// `edge_blend_distance` of 0 disables merging: each shape contributes
-    /// its own refraction but they remain visually distinct where they
-    /// overlap. Accepts 1..=`MAX_LENS_SHAPES_PER_GROUP` shapes; violations
-    /// trip a `debug_assert!`.
+    /// `edge_blend_distance` is in window pixels (pre-scale) and defines the
+    /// smooth-minimum radius used when merging shapes' SDFs. The union AABB
+    /// is padded by this distance on every side so the merge field has room
+    /// to settle. Negative values are clamped to zero; `0` disables merging
+    /// entirely.
+    ///
+    /// Accepts 1..=`MAX_LENS_SHAPES_PER_GROUP` shapes; violations trip a
+    /// `debug_assert!`.
     ///
     /// Same render-pass-break caveat as `paint_blur_rect` — keep the number
     /// of lens rects per frame small.
+    ///
+    /// This method should only be called as part of the paint phase of
+    /// element drawing.
     pub fn paint_lens_rect_union(
         &mut self,
         shapes: impl IntoIterator<Item = LensShapeSpec>,
@@ -3478,7 +3485,8 @@ impl Window {
         let content_mask = self.content_mask();
         let opacity = self.element_opacity();
 
-        let mut specs: Vec<LensShapeSpec> = shapes.into_iter().collect();
+        let mut specs: SmallVec<[LensShapeSpec; MAX_LENS_SHAPES_PER_GROUP]> =
+            shapes.into_iter().collect();
         debug_assert!(
             !specs.is_empty(),
             "paint_lens_rect_union requires at least one shape"
@@ -3489,6 +3497,14 @@ impl Window {
             specs.len()
         );
         if specs.is_empty() {
+            static EMPTY_WARNED: OnceLock<()> = OnceLock::new();
+            if EMPTY_WARNED.set(()).is_ok() {
+                log::warn!(
+                    "paint_lens_rect_union called with no shapes; the lens will \
+                     not render. Callers filtering dynamic inputs should early-out \
+                     before calling this."
+                );
+            }
             return;
         }
         specs.truncate(MAX_LENS_SHAPES_PER_GROUP);
@@ -3510,7 +3526,7 @@ impl Window {
         // masks are intersected with the element's mask so callers can't
         // bypass the element clip.
         let element_mask_bounds = content_mask.bounds;
-        let scaled_shapes: Vec<LensShape> = specs
+        let scaled_shapes: SmallVec<[LensShape; MAX_LENS_SHAPES_PER_GROUP]> = specs
             .into_iter()
             .map(|spec| {
                 let shape_mask = spec
@@ -3560,6 +3576,9 @@ impl Window {
     ///
     /// Like `paint_blur_rect` and `paint_lens_rect`, each mirror rect
     /// forces a render-pass break so the framebuffer can be sampled.
+    ///
+    /// This method should only be called as part of the paint phase of
+    /// element drawing.
     pub fn paint_mirror_rect(
         &mut self,
         source: Bounds<Pixels>,
@@ -6372,6 +6391,8 @@ impl MirrorAxis {
 }
 
 /// Configuration for [`Window::paint_mirror_rect`].
+///
+/// Defaults: horizontal flip, clip-to-destination enabled, no blur, no tint.
 #[derive(Clone, Copy, Debug)]
 pub struct MirrorEffect {
     /// How to flip the sampled source region.
@@ -6381,6 +6402,8 @@ pub struct MirrorEffect {
     pub clip_to_destination: bool,
     /// Optional backdrop blur applied to the mirrored source. When
     /// `None`, the un-blurred framebuffer snapshot is sampled directly.
+    /// See [`BlurEffect`] for uniform vs. linear-gradient semantics — the
+    /// gradient, if any, is evaluated in destination (not source) space.
     pub blur: Option<BlurEffect>,
     /// Color overlay applied after mirroring.
     pub tint: Hsla,
@@ -6411,5 +6434,50 @@ impl MirrorEffect {
     pub fn with_blur(mut self, blur: BlurEffect) -> Self {
         self.blur = Some(blur);
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mirror_axis_flags_map_to_expected_bits() {
+        assert_eq!(MirrorAxis::None.flags(), 0);
+        assert_eq!(MirrorAxis::Horizontal.flags(), MIRROR_AXIS_HORIZONTAL);
+        assert_eq!(MirrorAxis::Vertical.flags(), MIRROR_AXIS_VERTICAL);
+        assert_eq!(
+            MirrorAxis::Both.flags(),
+            MIRROR_AXIS_HORIZONTAL | MIRROR_AXIS_VERTICAL,
+        );
+    }
+
+    #[test]
+    fn blur_effect_linear_gradient_sets_axis() {
+        let horizontal = BlurEffect::linear_gradient(px(0.0), px(20.0), BlurAxis::Horizontal);
+        assert_eq!(horizontal.radius, px(0.0));
+        assert_eq!(horizontal.radius_end, px(20.0));
+        assert_eq!(horizontal.gradient_direction, [1.0, 0.0]);
+
+        let vertical = BlurEffect::linear_gradient(px(5.0), px(12.0), BlurAxis::Vertical);
+        assert_eq!(vertical.gradient_direction, [0.0, 1.0]);
+    }
+
+    #[test]
+    fn lens_effect_linear_gradient_sets_axis() {
+        let horizontal = LensEffect::linear_gradient(px(0.0), px(20.0), BlurAxis::Horizontal);
+        assert_eq!(horizontal.radius, px(0.0));
+        assert_eq!(horizontal.radius_end, px(20.0));
+        assert_eq!(horizontal.gradient_direction, [1.0, 0.0]);
+
+        let vertical = LensEffect::linear_gradient(px(5.0), px(12.0), BlurAxis::Vertical);
+        assert_eq!(vertical.gradient_direction, [0.0, 1.0]);
+    }
+
+    #[test]
+    fn with_gradient_direction_overrides_axis() {
+        let effect =
+            BlurEffect::default().with_gradient_direction([0.5f32.sqrt(), 0.5f32.sqrt()]);
+        assert_eq!(effect.gradient_direction, [0.5f32.sqrt(), 0.5f32.sqrt()]);
     }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2,11 +2,11 @@
 use crate::Inspector;
 use crate::{
     Action, AnyDrag, AnyElement, AnyImageCache, AnyTooltip, AnyView, App, AppContext, Arena, Asset,
-    AsyncWindowContext, AvailableSpace, Background, BorderStyle, Bounds, BoxShadow, Capslock,
-    Context, Corners, CursorStyle, Decorations, DevicePixels, DispatchActionListener,
+    AsyncWindowContext, AvailableSpace, Background, BlurRect, BorderStyle, Bounds, BoxShadow,
+    Capslock, Context, Corners, CursorStyle, Decorations, DevicePixels, DispatchActionListener,
     DispatchNodeId, DispatchTree, DisplayId, Edges, Effect, Entity, EntityId, EventEmitter,
     FileDropEvent, FontId, Global, GlobalElementId, GlyphId, GpuSpecs, Hsla, InputHandler, IsZero,
-    KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke, KeystrokeEvent, LayoutId,
+    KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke, KeystrokeEvent, LayoutId, LensRect,
     LineLayoutIndex, Modifiers, ModifiersChangedEvent, MonochromeSprite, MouseButton, MouseEvent,
     MouseMoveEvent, MouseUpEvent, Path, Pixels, PlatformAtlas, PlatformDisplay, PlatformInput,
     PlatformInputHandler, PlatformWindow, Point, PolychromeSprite, Priority, PromptButton,
@@ -3382,6 +3382,83 @@ impl Window {
         });
     }
 
+    /// Paint a dual-Kawase backdrop blur behind the given rounded rectangle.
+    /// Samples the framebuffer under `bounds`, blurs it, and composites with
+    /// `effect.tint`. Used for backdrop-blurred materials like Apple's Liquid
+    /// Glass.
+    ///
+    /// Each `paint_blur_rect` call forces the renderer to break the current
+    /// render pass so the framebuffer can be sampled — using many per frame
+    /// is expensive. Prefer one per glass surface.
+    ///
+    /// This method should only be called as part of the paint phase of
+    /// element drawing.
+    pub fn paint_blur_rect(
+        &mut self,
+        bounds: Bounds<Pixels>,
+        corner_radii: Corners<Pixels>,
+        effect: BlurEffect,
+    ) {
+        self.invalidator.debug_assert_paint();
+
+        let scale_factor = self.scale_factor();
+        let content_mask = self.content_mask();
+        let opacity = self.element_opacity();
+        self.next_frame.scene.insert_primitive(BlurRect {
+            order: 0,
+            kernel_levels: effect.kernel_levels,
+            bounds: bounds.scale(scale_factor),
+            content_mask: content_mask.scale(scale_factor),
+            corner_radii: corner_radii.scale(scale_factor),
+            blur_radius: effect.radius.scale(scale_factor),
+            _pad: 0.0,
+            tint: effect.tint.opacity(opacity),
+        });
+    }
+
+    /// Paint a Liquid Glass composite behind the given rounded rectangle:
+    /// backdrop blur plus parabolic refraction, chromatic aberration, and a
+    /// directional Fresnel edge glow.
+    ///
+    /// Same render-pass-break caveat as `paint_blur_rect` — keep the number
+    /// of lens rects per frame small.
+    ///
+    /// This method should only be called as part of the paint phase of
+    /// element drawing.
+    pub fn paint_lens_rect(
+        &mut self,
+        bounds: Bounds<Pixels>,
+        corner_radii: Corners<Pixels>,
+        effect: LensEffect,
+    ) {
+        self.invalidator.debug_assert_paint();
+
+        let scale_factor = self.scale_factor();
+        let content_mask = self.content_mask();
+        let opacity = self.element_opacity();
+        let light_dir = Point {
+            x: effect.light_angle_radians.cos(),
+            y: effect.light_angle_radians.sin(),
+        };
+        self.next_frame.scene.insert_primitive(LensRect {
+            order: 0,
+            kernel_levels: effect.kernel_levels,
+            bounds: bounds.scale(scale_factor),
+            content_mask: content_mask.scale(scale_factor),
+            corner_radii: corner_radii.scale(scale_factor),
+            blur_radius: effect.radius.scale(scale_factor),
+            refraction: effect.refraction,
+            depth: effect.depth,
+            dispersion: effect.dispersion,
+            splay: effect.splay.scale(scale_factor),
+            light_dir,
+            light_intensity: effect.light_intensity,
+            _pad: 0.0,
+            tint: effect.tint.opacity(opacity),
+            _pad2: 0.0,
+        });
+    }
+
     /// Paint the given `Path` into the scene for the next frame at the current z-index.
     ///
     /// This method should only be called as part of the paint phase of element drawing.
@@ -5889,5 +5966,74 @@ pub fn outline(
         border_widths: (1.).into(),
         border_color: border_color.into(),
         border_style,
+    }
+}
+
+/// A dual-Kawase backdrop blur with tint, applied to a rounded rectangle.
+/// Passed to [`Window::paint_blur_rect`].
+#[derive(Clone, Copy, Debug)]
+pub struct BlurEffect {
+    /// Gaussian-equivalent blur radius, in window pixels.
+    pub radius: Pixels,
+    /// Number of Kawase downsample/upsample passes. Higher = wider blur,
+    /// lower = sharper. Clamped to 1..=5 by the renderer. Typical: 3.
+    pub kernel_levels: u32,
+    /// Colour layered on top of the blurred backdrop.
+    pub tint: Hsla,
+}
+
+impl Default for BlurEffect {
+    fn default() -> Self {
+        Self {
+            radius: px(20.0),
+            kernel_levels: 3,
+            tint: transparent_black(),
+        }
+    }
+}
+
+/// A Liquid Glass composite (backdrop blur + refraction + chromatic
+/// aberration + Fresnel edge glow), applied to a rounded rectangle. Passed
+/// to [`Window::paint_lens_rect`].
+///
+/// HIG defaults: refraction 100, depth 16, dispersion 0, splay 6 pt, light
+/// angle -45°, light intensity 67%.
+#[derive(Clone, Copy, Debug)]
+pub struct LensEffect {
+    /// Backdrop-blur radius, in window pixels.
+    pub radius: Pixels,
+    /// Number of Kawase downsample/upsample passes.
+    pub kernel_levels: u32,
+    /// Parabolic refraction strength (Figma 0..100).
+    pub refraction: f32,
+    /// Glass thickness (Figma 0..100). Modulates the refraction envelope —
+    /// thicker glass bends more.
+    pub depth: f32,
+    /// Chromatic aberration amount. 0 = disabled.
+    pub dispersion: f32,
+    /// Fresnel edge-highlight band width, in window pixels.
+    pub splay: Pixels,
+    /// Light source direction, in radians. 0 = +x (right); rotates
+    /// counterclockwise. HIG default = -45° (upper-left quadrant).
+    pub light_angle_radians: f32,
+    /// Intensity of the Fresnel edge highlight, 0..1.
+    pub light_intensity: f32,
+    /// Colour overlay applied after refraction.
+    pub tint: Hsla,
+}
+
+impl Default for LensEffect {
+    fn default() -> Self {
+        Self {
+            radius: px(20.0),
+            kernel_levels: 3,
+            refraction: 100.0,
+            depth: 16.0,
+            dispersion: 0.0,
+            splay: px(6.0),
+            light_angle_radians: -std::f32::consts::FRAC_PI_4,
+            light_intensity: 0.67,
+            tint: transparent_black(),
+        }
     }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -6,8 +6,10 @@ use crate::{
     Capslock, Context, Corners, CursorStyle, Decorations, DevicePixels, DispatchActionListener,
     DispatchNodeId, DispatchTree, DisplayId, Edges, Effect, Entity, EntityId, EventEmitter,
     FileDropEvent, FontId, Global, GlobalElementId, GlyphId, GpuSpecs, Hsla, InputHandler, IsZero,
-    KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke, KeystrokeEvent, LayoutId, LensRect,
-    LineLayoutIndex, Modifiers, ModifiersChangedEvent, MonochromeSprite, MouseButton, MouseEvent,
+    KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke, KeystrokeEvent, LayoutId,
+    LensPrimitive, LensRect, LensShape, LineLayoutIndex, MIRROR_AXIS_HORIZONTAL,
+    MIRROR_AXIS_VERTICAL, MirrorRect, Modifiers, ModifiersChangedEvent, MonochromeSprite,
+    MouseButton, MouseEvent,
     MouseMoveEvent, MouseUpEvent, Path, Pixels, PlatformAtlas, PlatformDisplay, PlatformInput,
     PlatformInputHandler, PlatformWindow, Point, PolychromeSprite, Priority, PromptButton,
     PromptLevel, Quad, Radians, Render, RenderGlyphParams, RenderImage, RenderImageParams,
@@ -3412,8 +3414,10 @@ impl Window {
             content_mask: content_mask.scale(scale_factor),
             corner_radii: corner_radii.scale(scale_factor),
             blur_radius: effect.radius.scale(scale_factor),
-            pad: 0.0,
+            blur_radius_end: effect.radius_end.scale(scale_factor),
+            gradient_direction: effect.gradient_direction,
             tint: effect.tint.opacity(opacity),
+            _pad_end: [0.0; 2],
         });
     }
 
@@ -3432,6 +3436,32 @@ impl Window {
         corner_radii: Corners<Pixels>,
         effect: LensEffect,
     ) {
+        self.paint_lens_rect_union(
+            [LensShapeSpec::new(bounds, corner_radii)],
+            px(0.0),
+            effect,
+        );
+    }
+
+    /// Paint a Liquid Glass composite over the union of multiple rounded
+    /// rectangles. Shapes within `edge_blend_distance` of each other morph
+    /// into a single continuous lens via a smooth-minimum of their signed
+    /// distance fields — the GPU-side equivalent of SwiftUI's
+    /// `GlassEffectContainer(spacing:)`.
+    ///
+    /// `edge_blend_distance` of 0 disables merging: each shape contributes
+    /// its own refraction but they remain visually distinct where they
+    /// overlap. Accepts 1..=`MAX_LENS_SHAPES_PER_GROUP` shapes; violations
+    /// trip a `debug_assert!`.
+    ///
+    /// Same render-pass-break caveat as `paint_blur_rect` — keep the number
+    /// of lens rects per frame small.
+    pub fn paint_lens_rect_union(
+        &mut self,
+        shapes: impl IntoIterator<Item = LensShapeSpec>,
+        edge_blend_distance: Pixels,
+        effect: LensEffect,
+    ) {
         self.invalidator.debug_assert_paint();
         debug_assert!(
             effect.light_angle.0.is_finite(),
@@ -3447,23 +3477,132 @@ impl Window {
         let scale_factor = self.scale_factor();
         let content_mask = self.content_mask();
         let opacity = self.element_opacity();
-        self.next_frame.scene.insert_primitive(LensRect {
+
+        let mut specs: Vec<LensShapeSpec> = shapes.into_iter().collect();
+        debug_assert!(
+            !specs.is_empty(),
+            "paint_lens_rect_union requires at least one shape"
+        );
+        debug_assert!(
+            specs.len() <= MAX_LENS_SHAPES_PER_GROUP,
+            "paint_lens_rect_union accepts at most {MAX_LENS_SHAPES_PER_GROUP} shapes, got {}",
+            specs.len()
+        );
+        if specs.is_empty() {
+            return;
+        }
+        specs.truncate(MAX_LENS_SHAPES_PER_GROUP);
+
+        let mut union = specs[0].bounds;
+        for spec in specs.iter().skip(1) {
+            union = union.union(&spec.bounds);
+        }
+        let blend = edge_blend_distance.max(px(0.0));
+        let padded_origin = point(union.origin.x - blend, union.origin.y - blend);
+        let padded_size = size(union.size.width + blend * 2.0, union.size.height + blend * 2.0);
+        let padded_bounds = Bounds {
+            origin: padded_origin,
+            size: padded_size,
+        };
+
+        // Each shape gets its own content_mask; if the caller didn't
+        // supply one, fall back to the element's content mask. Per-shape
+        // masks are intersected with the element's mask so callers can't
+        // bypass the element clip.
+        let element_mask_bounds = content_mask.bounds;
+        let scaled_shapes: Vec<LensShape> = specs
+            .into_iter()
+            .map(|spec| {
+                let shape_mask = spec
+                    .content_mask
+                    .map(|m| m.intersect(&element_mask_bounds))
+                    .unwrap_or(element_mask_bounds);
+                LensShape {
+                    bounds: spec.bounds.scale(scale_factor),
+                    corner_radii: spec.corner_radii.scale(scale_factor),
+                    content_mask: shape_mask.scale(scale_factor),
+                }
+            })
+            .collect();
+
+        self.next_frame.scene.insert_primitive(LensPrimitive {
+            rect: LensRect {
+                order: 0,
+                kernel_levels: effect.kernel_levels.clamp(1, 5),
+                bounds: padded_bounds.scale(scale_factor),
+                content_mask: content_mask.scale(scale_factor),
+                shape_offset: 0,
+                shape_count: 0,
+                edge_blend_distance: blend.scale(scale_factor),
+                blur_radius: effect.radius.scale(scale_factor),
+                gradient_direction: effect.gradient_direction,
+                blur_radius_end: effect.radius_end.scale(scale_factor),
+                refraction: effect.refraction * 100.0,
+                depth: effect.depth * 100.0,
+                dispersion: effect.dispersion * 100.0,
+                splay: effect.splay.scale(scale_factor),
+                light_angle_radians: effect.light_angle.0,
+                light_intensity: effect.light_intensity,
+                tint: effect.tint.opacity(opacity),
+                pad2: 0.0,
+            },
+            shapes: scaled_shapes,
+        });
+    }
+
+    /// Paint a mirrored slice of the current frame into `destination`. The
+    /// rectangle `source` is read from the framebuffer snapshot, optionally
+    /// flipped horizontally / vertically per `effect.axis`, and composited
+    /// at `destination` with an optional rounded-rect clip and tint.
+    ///
+    /// Used to extend an element beyond its own frame — SwiftUI's
+    /// `backgroundExtensionEffect()` is the direct analogue.
+    ///
+    /// Like `paint_blur_rect` and `paint_lens_rect`, each mirror rect
+    /// forces a render-pass break so the framebuffer can be sampled.
+    pub fn paint_mirror_rect(
+        &mut self,
+        source: Bounds<Pixels>,
+        destination: Bounds<Pixels>,
+        corner_radii: Corners<Pixels>,
+        effect: MirrorEffect,
+    ) {
+        self.invalidator.debug_assert_paint();
+
+        let scale_factor = self.scale_factor();
+        let content_mask = self.content_mask();
+        let opacity = self.element_opacity();
+
+        let (blur_radius, blur_radius_end, gradient_direction, kernel_levels) =
+            if let Some(blur) = effect.blur {
+                (
+                    blur.radius.scale(scale_factor),
+                    blur.radius_end.scale(scale_factor),
+                    blur.gradient_direction,
+                    blur.kernel_levels.clamp(1, 5),
+                )
+            } else {
+                (
+                    ScaledPixels(0.0),
+                    ScaledPixels(0.0),
+                    [0.0, 0.0],
+                    1,
+                )
+            };
+
+        self.next_frame.scene.insert_primitive(MirrorRect {
             order: 0,
-            kernel_levels: effect.kernel_levels.clamp(1, 5),
-            bounds: bounds.scale(scale_factor),
+            kernel_levels,
+            bounds: destination.scale(scale_factor),
             content_mask: content_mask.scale(scale_factor),
             corner_radii: corner_radii.scale(scale_factor),
-            blur_radius: effect.radius.scale(scale_factor),
-            refraction: effect.refraction * 100.0,
-            depth: effect.depth * 100.0,
-            dispersion: effect.dispersion * 100.0,
-            splay: effect.splay.scale(scale_factor),
-            light_angle_radians: effect.light_angle.0,
-            pad_light: 0.0,
-            light_intensity: effect.light_intensity,
-            pad: 0.0,
+            source_bounds: source.scale(scale_factor),
+            mirror_axis: effect.axis.flags(),
+            clip_to_destination: if effect.clip_to_destination { 1 } else { 0 },
+            blur_radius,
+            blur_radius_end,
+            gradient_direction,
             tint: effect.tint.opacity(opacity),
-            pad2: 0.0,
         });
     }
 
@@ -5977,12 +6116,49 @@ pub fn outline(
     }
 }
 
+/// Direction along which a linear-gradient blur fades. Horizontal (leading →
+/// trailing) or Vertical (top → bottom). Used by the `_gradient` builders on
+/// [`BlurEffect`] / [`LensEffect`] when the consumer wants a simple
+/// axis-aligned fade (HIG scroll-edge blur). For diagonal fades, use
+/// [`BlurEffect::with_gradient_direction`] directly.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BlurAxis {
+    /// Left-to-right (+x) fade.
+    Horizontal,
+    /// Top-to-bottom (+y) fade.
+    Vertical,
+}
+
+impl BlurAxis {
+    fn direction(self) -> [f32; 2] {
+        match self {
+            BlurAxis::Horizontal => [1.0, 0.0],
+            BlurAxis::Vertical => [0.0, 1.0],
+        }
+    }
+}
+
 /// A dual-Kawase backdrop blur with tint, applied to a rounded rectangle.
 /// Passed to [`Window::paint_blur_rect`].
+///
+/// Supports either a uniform blur (`radius_end == radius`, no gradient) or a
+/// linear-gradient blur along `gradient_direction` where the per-pixel
+/// strength interpolates from `radius` at the leading edge of the rect to
+/// `radius_end` at the trailing edge. The gradient variant is a
+/// `mix(unblurred, max-blurred, t)` approximation — visually plausible for
+/// HIG scroll-edge fades but not a true Gaussian per-pixel blur.
 #[derive(Clone, Copy, Debug)]
 pub struct BlurEffect {
-    /// Gaussian-equivalent blur radius, in window pixels.
+    /// Gaussian-equivalent blur radius at the start of the gradient (or the
+    /// uniform radius if `gradient_direction` is zero), in window pixels.
     pub radius: Pixels,
+    /// Blur radius at the end of the gradient. Equal to `radius` for a
+    /// uniform blur; differs to fade the blur strength along
+    /// `gradient_direction`.
+    pub radius_end: Pixels,
+    /// Normalized 2D axis the gradient runs along. `[0.0, 0.0]` disables the
+    /// gradient (uniform `radius`).
+    pub gradient_direction: [f32; 2],
     /// Number of Kawase downsample/upsample passes. Higher = wider blur,
     /// lower = sharper. Clamped to 1..=5 by the renderer. Typical: 3.
     ///
@@ -5999,6 +6175,8 @@ impl Default for BlurEffect {
     fn default() -> Self {
         Self {
             radius: px(20.0),
+            radius_end: px(20.0),
+            gradient_direction: [0.0, 0.0],
             kernel_levels: 3,
             tint: transparent_black(),
         }
@@ -6006,13 +6184,32 @@ impl Default for BlurEffect {
 }
 
 impl BlurEffect {
-    /// Construct a blur with HIG defaults (3 Kawase levels, no tint) at the
-    /// given radius.
+    /// Construct a uniform blur with HIG defaults (3 Kawase levels, no tint)
+    /// at the given radius.
     pub fn new(radius: Pixels) -> Self {
         Self {
             radius,
+            radius_end: radius,
             ..Default::default()
         }
+    }
+
+    /// Construct a linear-gradient blur that fades from `from` to `to` along
+    /// the given [`BlurAxis`].
+    pub fn linear_gradient(from: Pixels, to: Pixels, axis: BlurAxis) -> Self {
+        Self {
+            radius: from,
+            radius_end: to,
+            gradient_direction: axis.direction(),
+            ..Default::default()
+        }
+    }
+
+    /// Override the gradient direction with an arbitrary 2D vector. The
+    /// shader normalizes the input; callers should pass a non-zero vector.
+    pub fn with_gradient_direction(mut self, direction: [f32; 2]) -> Self {
+        self.gradient_direction = direction;
+        self
     }
 }
 
@@ -6024,8 +6221,14 @@ impl BlurEffect {
 /// light angle -45°, light intensity 0.67.
 #[derive(Clone, Copy, Debug)]
 pub struct LensEffect {
-    /// Backdrop-blur radius, in window pixels.
+    /// Backdrop-blur radius (start of the gradient, or the uniform radius),
+    /// in window pixels.
     pub radius: Pixels,
+    /// Backdrop-blur radius at the end of the gradient, in window pixels.
+    /// Equal to `radius` for uniform blur.
+    pub radius_end: Pixels,
+    /// Normalized gradient direction. `[0.0, 0.0]` means uniform blur.
+    pub gradient_direction: [f32; 2],
     /// Number of Kawase downsample/upsample passes. Higher = wider blur,
     /// lower = sharper. Clamped to 1..=5 by the renderer. Typical: 3.
     ///
@@ -6058,6 +6261,8 @@ impl Default for LensEffect {
     fn default() -> Self {
         Self {
             radius: px(20.0),
+            radius_end: px(20.0),
+            gradient_direction: [0.0, 0.0],
             kernel_levels: 3,
             refraction: 1.0,
             depth: 0.16,
@@ -6071,13 +6276,140 @@ impl Default for LensEffect {
 }
 
 impl LensEffect {
-    /// Construct a lens with HIG defaults (3 Kawase levels, full refraction,
-    /// no dispersion, -45° light at 0.67 intensity, no tint) at the given
-    /// blur radius.
+    /// Construct a uniform lens with HIG defaults (3 Kawase levels, full
+    /// refraction, no dispersion, -45° light at 0.67 intensity, no tint) at
+    /// the given blur radius.
     pub fn new(radius: Pixels) -> Self {
         Self {
             radius,
+            radius_end: radius,
             ..Default::default()
         }
+    }
+
+    /// Construct a linear-gradient lens that fades the blur strength from
+    /// `from` to `to` along the given [`BlurAxis`]. Other lens parameters
+    /// keep their HIG defaults.
+    pub fn linear_gradient(from: Pixels, to: Pixels, axis: BlurAxis) -> Self {
+        Self {
+            radius: from,
+            radius_end: to,
+            gradient_direction: axis.direction(),
+            ..Default::default()
+        }
+    }
+
+    /// Override the gradient direction with an arbitrary 2D vector.
+    pub fn with_gradient_direction(mut self, direction: [f32; 2]) -> Self {
+        self.gradient_direction = direction;
+        self
+    }
+}
+
+/// Maximum number of shapes in a single [`Window::paint_lens_rect_union`]
+/// call. Kept small so the per-fragment smooth-min loop stays cheap and the
+/// per-primitive GPU shape buffer is bounded.
+pub const MAX_LENS_SHAPES_PER_GROUP: usize = 8;
+
+/// A single rounded-rectangle shape inside a multi-shape lens group. Passed
+/// to [`Window::paint_lens_rect_union`].
+#[derive(Clone, Copy, Debug)]
+pub struct LensShapeSpec {
+    /// Bounds of this shape in window pixels.
+    pub bounds: Bounds<Pixels>,
+    /// Per-corner radii of this shape in window pixels.
+    pub corner_radii: Corners<Pixels>,
+    /// Optional per-shape clip. `None` inherits the element's
+    /// `content_mask`. When set, fragments outside this rect softly
+    /// attenuate this shape's contribution to the smooth-min union —
+    /// adjacent shapes in the same group keep rendering normally.
+    pub content_mask: Option<Bounds<Pixels>>,
+}
+
+impl LensShapeSpec {
+    /// Construct a shape spec with no per-shape `content_mask`, inheriting
+    /// the element's clip at paint time.
+    pub fn new(bounds: Bounds<Pixels>, corner_radii: Corners<Pixels>) -> Self {
+        Self {
+            bounds,
+            corner_radii,
+            content_mask: None,
+        }
+    }
+
+    /// Chain a per-shape `content_mask` onto this spec. The mask is
+    /// intersected with the element's own `content_mask` at paint time.
+    pub fn with_content_mask(mut self, content_mask: Bounds<Pixels>) -> Self {
+        self.content_mask = Some(content_mask);
+        self
+    }
+}
+
+/// How [`Window::paint_mirror_rect`] flips the sampled source region before
+/// compositing at the destination.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MirrorAxis {
+    /// Mirror left/right (flip around the vertical axis).
+    Horizontal,
+    /// Mirror top/bottom (flip around the horizontal axis).
+    Vertical,
+    /// Flip both axes — equivalent to a 180° rotation.
+    Both,
+    /// No flip; `paint_mirror_rect` becomes a translated copy of the
+    /// source region.
+    None,
+}
+
+impl MirrorAxis {
+    fn flags(self) -> u32 {
+        match self {
+            MirrorAxis::Horizontal => MIRROR_AXIS_HORIZONTAL,
+            MirrorAxis::Vertical => MIRROR_AXIS_VERTICAL,
+            MirrorAxis::Both => MIRROR_AXIS_HORIZONTAL | MIRROR_AXIS_VERTICAL,
+            MirrorAxis::None => 0,
+        }
+    }
+}
+
+/// Configuration for [`Window::paint_mirror_rect`].
+#[derive(Clone, Copy, Debug)]
+pub struct MirrorEffect {
+    /// How to flip the sampled source region.
+    pub axis: MirrorAxis,
+    /// When `true`, the mirrored sample is masked against the destination's
+    /// rounded-rect SDF so out-of-corner pixels go transparent.
+    pub clip_to_destination: bool,
+    /// Optional backdrop blur applied to the mirrored source. When
+    /// `None`, the un-blurred framebuffer snapshot is sampled directly.
+    pub blur: Option<BlurEffect>,
+    /// Color overlay applied after mirroring.
+    pub tint: Hsla,
+}
+
+impl Default for MirrorEffect {
+    fn default() -> Self {
+        Self {
+            axis: MirrorAxis::Horizontal,
+            clip_to_destination: true,
+            blur: None,
+            tint: transparent_black(),
+        }
+    }
+}
+
+impl MirrorEffect {
+    /// Construct a mirror effect with the given flip axis, clip-to-dest
+    /// enabled, no blur, and no tint.
+    pub fn new(axis: MirrorAxis) -> Self {
+        Self {
+            axis,
+            ..Default::default()
+        }
+    }
+
+    /// Override the blur to apply to the mirrored source.
+    pub fn with_blur(mut self, blur: BlurEffect) -> Self {
+        self.blur = Some(blur);
+        self
     }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3437,6 +3437,12 @@ impl Window {
             effect.light_angle.0.is_finite(),
             "LensEffect::light_angle must be finite"
         );
+        debug_assert!(
+            effect.refraction.is_finite()
+                && effect.depth.is_finite()
+                && effect.dispersion.is_finite(),
+            "LensEffect refraction/depth/dispersion must be finite"
+        );
 
         let scale_factor = self.scale_factor();
         let content_mask = self.content_mask();
@@ -6034,8 +6040,8 @@ pub struct LensEffect {
     /// Glass thickness, normalized 0..1. Modulates the refraction envelope
     /// — thicker glass bends more.
     pub depth: f32,
-    /// Chromatic aberration amount, normalized 0..1 (1.0 ≈ max CA shift).
-    /// 0 = disabled.
+    /// Chromatic aberration amount, normalized 0..1 (1.0 ≈ 100 px R/B shift
+    /// at the rim). 0 = disabled.
     pub dispersion: f32,
     /// Fresnel edge-highlight band width, in window pixels.
     pub splay: Pixels,

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -10,14 +10,15 @@ use crate::{
     LineLayoutIndex, Modifiers, ModifiersChangedEvent, MonochromeSprite, MouseButton, MouseEvent,
     MouseMoveEvent, MouseUpEvent, Path, Pixels, PlatformAtlas, PlatformDisplay, PlatformInput,
     PlatformInputHandler, PlatformWindow, Point, PolychromeSprite, Priority, PromptButton,
-    PromptLevel, Quad, Render, RenderGlyphParams, RenderImage, RenderImageParams, RenderSvgParams,
-    Replay, ResizeEdge, SMOOTH_SVG_SCALE_FACTOR, SUBPIXEL_VARIANTS_X, SUBPIXEL_VARIANTS_Y,
-    ScaledPixels, Scene, Shadow, SharedString, Size, StrikethroughStyle, Style, SubpixelSprite,
-    SubscriberSet, Subscription, SystemWindowTab, SystemWindowTabController, TabStopMap,
-    TaffyLayoutEngine, Task, TextRenderingMode, TextStyle, TextStyleRefinement, ThermalState,
-    TransformationMatrix, Underline, UnderlineStyle, WindowAppearance, WindowBackgroundAppearance,
-    WindowBounds, WindowControls, WindowDecorations, WindowOptions, WindowParams, WindowTextSystem,
-    point, prelude::*, px, rems, size, transparent_black,
+    PromptLevel, Quad, Radians, Render, RenderGlyphParams, RenderImage, RenderImageParams,
+    RenderSvgParams, Replay, ResizeEdge, SMOOTH_SVG_SCALE_FACTOR, SUBPIXEL_VARIANTS_X,
+    SUBPIXEL_VARIANTS_Y, ScaledPixels, Scene, Shadow, SharedString, Size, StrikethroughStyle,
+    Style, SubpixelSprite, SubscriberSet, Subscription, SystemWindowTab,
+    SystemWindowTabController, TabStopMap, TaffyLayoutEngine, Task, TextRenderingMode, TextStyle,
+    TextStyleRefinement, ThermalState, TransformationMatrix, Underline, UnderlineStyle,
+    WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowControls, WindowDecorations,
+    WindowOptions, WindowParams, WindowTextSystem, point, prelude::*, px, radians, rems, size,
+    transparent_black,
 };
 use anyhow::{Context as _, Result, anyhow};
 use collections::{FxHashMap, FxHashSet};
@@ -3406,12 +3407,12 @@ impl Window {
         let opacity = self.element_opacity();
         self.next_frame.scene.insert_primitive(BlurRect {
             order: 0,
-            kernel_levels: effect.kernel_levels,
+            kernel_levels: effect.kernel_levels.clamp(1, 5),
             bounds: bounds.scale(scale_factor),
             content_mask: content_mask.scale(scale_factor),
             corner_radii: corner_radii.scale(scale_factor),
             blur_radius: effect.radius.scale(scale_factor),
-            _pad: 0.0,
+            pad: 0.0,
             tint: effect.tint.opacity(opacity),
         });
     }
@@ -3432,17 +3433,17 @@ impl Window {
         effect: LensEffect,
     ) {
         self.invalidator.debug_assert_paint();
+        debug_assert!(
+            effect.light_angle.0.is_finite(),
+            "LensEffect::light_angle must be finite"
+        );
 
         let scale_factor = self.scale_factor();
         let content_mask = self.content_mask();
         let opacity = self.element_opacity();
-        let light_dir = Point {
-            x: effect.light_angle_radians.cos(),
-            y: effect.light_angle_radians.sin(),
-        };
         self.next_frame.scene.insert_primitive(LensRect {
             order: 0,
-            kernel_levels: effect.kernel_levels,
+            kernel_levels: effect.kernel_levels.clamp(1, 5),
             bounds: bounds.scale(scale_factor),
             content_mask: content_mask.scale(scale_factor),
             corner_radii: corner_radii.scale(scale_factor),
@@ -3451,11 +3452,12 @@ impl Window {
             depth: effect.depth,
             dispersion: effect.dispersion,
             splay: effect.splay.scale(scale_factor),
-            light_dir,
+            light_angle_radians: effect.light_angle.0,
+            pad_light: 0.0,
             light_intensity: effect.light_intensity,
-            _pad: 0.0,
+            pad: 0.0,
             tint: effect.tint.opacity(opacity),
-            _pad2: 0.0,
+            pad2: 0.0,
         });
     }
 
@@ -6013,9 +6015,9 @@ pub struct LensEffect {
     pub dispersion: f32,
     /// Fresnel edge-highlight band width, in window pixels.
     pub splay: Pixels,
-    /// Light source direction, in radians. 0 = +x (right); rotates
-    /// counterclockwise. HIG default = -45° (upper-left quadrant).
-    pub light_angle_radians: f32,
+    /// Light source direction. 0 = +x (right); rotates counterclockwise.
+    /// HIG default = -45° (upper-left quadrant).
+    pub light_angle: Radians,
     /// Intensity of the Fresnel edge highlight, 0..1.
     pub light_intensity: f32,
     /// Colour overlay applied after refraction.
@@ -6031,7 +6033,7 @@ impl Default for LensEffect {
             depth: 16.0,
             dispersion: 0.0,
             splay: px(6.0),
-            light_angle_radians: -std::f32::consts::FRAC_PI_4,
+            light_angle: radians(-std::f32::consts::FRAC_PI_4),
             light_intensity: 0.67,
             tint: transparent_black(),
         }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3448,9 +3448,9 @@ impl Window {
             content_mask: content_mask.scale(scale_factor),
             corner_radii: corner_radii.scale(scale_factor),
             blur_radius: effect.radius.scale(scale_factor),
-            refraction: effect.refraction,
-            depth: effect.depth,
-            dispersion: effect.dispersion,
+            refraction: effect.refraction * 100.0,
+            depth: effect.depth * 100.0,
+            dispersion: effect.dispersion * 100.0,
             splay: effect.splay.scale(scale_factor),
             light_angle_radians: effect.light_angle.0,
             pad_light: 0.0,
@@ -5979,6 +5979,11 @@ pub struct BlurEffect {
     pub radius: Pixels,
     /// Number of Kawase downsample/upsample passes. Higher = wider blur,
     /// lower = sharper. Clamped to 1..=5 by the renderer. Typical: 3.
+    ///
+    /// Independent of render-pass break cost: each primitive always forces
+    /// exactly one pass break regardless of `kernel_levels` — this only
+    /// controls post-process depth. See [`Window::paint_blur_rect`] for
+    /// the pass-break caveat.
     pub kernel_levels: u32,
     /// Colour layered on top of the blurred backdrop.
     pub tint: Hsla,
@@ -5994,24 +5999,43 @@ impl Default for BlurEffect {
     }
 }
 
+impl BlurEffect {
+    /// Construct a blur with HIG defaults (3 Kawase levels, no tint) at the
+    /// given radius.
+    pub fn new(radius: Pixels) -> Self {
+        Self {
+            radius,
+            ..Default::default()
+        }
+    }
+}
+
 /// A Liquid Glass composite (backdrop blur + refraction + chromatic
 /// aberration + Fresnel edge glow), applied to a rounded rectangle. Passed
 /// to [`Window::paint_lens_rect`].
 ///
-/// HIG defaults: refraction 100, depth 16, dispersion 0, splay 6 pt, light
-/// angle -45°, light intensity 67%.
+/// HIG defaults: refraction 1.0, depth 0.16, dispersion 0.0, splay 6 pt,
+/// light angle -45°, light intensity 0.67.
 #[derive(Clone, Copy, Debug)]
 pub struct LensEffect {
     /// Backdrop-blur radius, in window pixels.
     pub radius: Pixels,
-    /// Number of Kawase downsample/upsample passes.
+    /// Number of Kawase downsample/upsample passes. Higher = wider blur,
+    /// lower = sharper. Clamped to 1..=5 by the renderer. Typical: 3.
+    ///
+    /// Independent of render-pass break cost: each primitive always forces
+    /// exactly one pass break regardless of `kernel_levels` — this only
+    /// controls post-process depth. See [`Window::paint_lens_rect`] for
+    /// the pass-break caveat.
     pub kernel_levels: u32,
-    /// Parabolic refraction strength (Figma 0..100).
+    /// Parabolic refraction strength, normalized 0..1 (1.0 = HIG full
+    /// strength).
     pub refraction: f32,
-    /// Glass thickness (Figma 0..100). Modulates the refraction envelope —
-    /// thicker glass bends more.
+    /// Glass thickness, normalized 0..1. Modulates the refraction envelope
+    /// — thicker glass bends more.
     pub depth: f32,
-    /// Chromatic aberration amount. 0 = disabled.
+    /// Chromatic aberration amount, normalized 0..1 (1.0 ≈ max CA shift).
+    /// 0 = disabled.
     pub dispersion: f32,
     /// Fresnel edge-highlight band width, in window pixels.
     pub splay: Pixels,
@@ -6029,13 +6053,25 @@ impl Default for LensEffect {
         Self {
             radius: px(20.0),
             kernel_levels: 3,
-            refraction: 100.0,
-            depth: 16.0,
+            refraction: 1.0,
+            depth: 0.16,
             dispersion: 0.0,
             splay: px(6.0),
             light_angle: radians(-std::f32::consts::FRAC_PI_4),
             light_intensity: 0.67,
             tint: transparent_black(),
+        }
+    }
+}
+
+impl LensEffect {
+    /// Construct a lens with HIG defaults (3 Kawase levels, full refraction,
+    /// no dispersion, -45° light at 0.67 intensity, no tint) at the given
+    /// blur radius.
+    pub fn new(radius: Pixels) -> Self {
+        Self {
+            radius,
+            ..Default::default()
         }
     }
 }

--- a/crates/gpui_macos/build.rs
+++ b/crates/gpui_macos/build.rs
@@ -62,6 +62,11 @@ mod macos_build {
             "SurfaceInputIndex".into(),
             "SurfaceBounds".into(),
             "TransformationMatrix".into(),
+            "BlurRect".into(),
+            "LensRect".into(),
+            "BlurIoInputIndex".into(),
+            "BlurRectInputIndex".into(),
+            "LensRectInputIndex".into(),
         ]);
         config.no_includes = true;
         config.enumeration.prefix_with_name = true;

--- a/crates/gpui_macos/build.rs
+++ b/crates/gpui_macos/build.rs
@@ -64,9 +64,13 @@ mod macos_build {
             "TransformationMatrix".into(),
             "BlurRect".into(),
             "LensRect".into(),
+            "LensShape".into(),
+            "MirrorRect".into(),
+            "SceneBlurParams".into(),
             "BlurIoInputIndex".into(),
             "BlurRectInputIndex".into(),
             "LensRectInputIndex".into(),
+            "MirrorRectInputIndex".into(),
         ]);
         config.no_includes = true;
         config.enumeration.prefix_with_name = true;

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -7,9 +7,9 @@ use cocoa::{
     quartzcore::AutoresizingMask,
 };
 use gpui::{
-    AtlasTextureId, Background, Bounds, ContentMask, DevicePixels, MonochromeSprite, PaintSurface,
-    Path, Point, PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size,
-    Surface, Underline, point, size,
+    AtlasTextureId, Background, BlurRect, Bounds, ContentMask, DevicePixels, LensRect,
+    MonochromeSprite, PaintSurface, Path, Point, PolychromeSprite, PrimitiveBatch, Quad,
+    ScaledPixels, Scene, Shadow, Size, Surface, Underline, point, size,
 };
 #[cfg(any(test, feature = "test-support"))]
 use image::RgbaImage;
@@ -133,6 +133,21 @@ pub(crate) struct MetalRenderer {
     path_intermediate_texture: Option<metal::Texture>,
     path_intermediate_msaa_texture: Option<metal::Texture>,
     path_sample_count: u32,
+    blur_downsample_pipeline_state: metal::RenderPipelineState,
+    blur_upsample_pipeline_state: metal::RenderPipelineState,
+    blur_rect_pipeline_state: metal::RenderPipelineState,
+    lens_rect_pipeline_state: metal::RenderPipelineState,
+    blur_sampler: metal::SamplerState,
+    blur_snapshot_texture: Option<metal::Texture>,
+    blur_half_texture: Option<metal::Texture>,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct BlurParams {
+    viewport_size: [f32; 2],
+    offset_multiplier: f32,
+    _pad: f32,
 }
 
 #[repr(C)]
@@ -155,8 +170,9 @@ impl MetalRenderer {
         // https://developer.apple.com/documentation/metal/managing-your-game-window-for-metal-in-macos
         layer.set_opaque(!transparent);
         layer.set_maximum_drawable_count(3);
-        // Allow texture reading for visual tests (captures screenshots without ScreenCaptureKit)
-        #[cfg(any(test, feature = "test-support"))]
+        // Disabled so the blit encoder can read the drawable as the input of
+        // the BlurRect/LensRect dual-Kawase snapshot (`snapshot_and_blur_frame`).
+        // Also enables visual tests to capture screenshots without ScreenCaptureKit.
         layer.set_framebuffer_only(false);
         unsafe {
             let _: () = msg_send![&*layer, setAllowsNextDrawableTimeout: NO];
@@ -319,6 +335,48 @@ impl MetalRenderer {
             MTLPixelFormat::BGRA8Unorm,
         );
 
+        let blur_downsample_pipeline_state = build_blur_io_pipeline_state(
+            &device,
+            &library,
+            "blur_downsample",
+            "blur_fullscreen_vertex",
+            "blur_downsample_fragment",
+            MTLPixelFormat::BGRA8Unorm,
+        );
+        let blur_upsample_pipeline_state = build_blur_io_pipeline_state(
+            &device,
+            &library,
+            "blur_upsample",
+            "blur_fullscreen_vertex",
+            "blur_upsample_fragment",
+            MTLPixelFormat::BGRA8Unorm,
+        );
+        let blur_rect_pipeline_state = build_pipeline_state(
+            &device,
+            &library,
+            "blur_rect",
+            "blur_rect_vertex",
+            "blur_rect_fragment",
+            MTLPixelFormat::BGRA8Unorm,
+        );
+        let lens_rect_pipeline_state = build_pipeline_state(
+            &device,
+            &library,
+            "lens_rect",
+            "lens_rect_vertex",
+            "lens_rect_fragment",
+            MTLPixelFormat::BGRA8Unorm,
+        );
+
+        let blur_sampler = {
+            let desc = metal::SamplerDescriptor::new();
+            desc.set_min_filter(metal::MTLSamplerMinMagFilter::Linear);
+            desc.set_mag_filter(metal::MTLSamplerMinMagFilter::Linear);
+            desc.set_address_mode_s(metal::MTLSamplerAddressMode::ClampToEdge);
+            desc.set_address_mode_t(metal::MTLSamplerAddressMode::ClampToEdge);
+            device.new_sampler(&desc)
+        };
+
         let command_queue = device.new_command_queue();
         let sprite_atlas = Arc::new(MetalAtlas::new(device.clone(), is_apple_gpu));
         let core_video_texture_cache =
@@ -347,6 +405,13 @@ impl MetalRenderer {
             path_intermediate_texture: None,
             path_intermediate_msaa_texture: None,
             path_sample_count: PATH_SAMPLE_COUNT,
+            blur_downsample_pipeline_state,
+            blur_upsample_pipeline_state,
+            blur_rect_pipeline_state,
+            lens_rect_pipeline_state,
+            blur_sampler,
+            blur_snapshot_texture: None,
+            blur_half_texture: None,
         }
     }
 
@@ -395,6 +460,8 @@ impl MetalRenderer {
         if size.width.0 <= 0 || size.height.0 <= 0 {
             self.path_intermediate_texture = None;
             self.path_intermediate_msaa_texture = None;
+            self.blur_snapshot_texture = None;
+            self.blur_half_texture = None;
             return;
         }
 
@@ -424,6 +491,26 @@ impl MetalRenderer {
         } else {
             self.path_intermediate_msaa_texture = None;
         }
+
+        let full_descriptor = metal::TextureDescriptor::new();
+        full_descriptor.set_width(size.width.0 as u64);
+        full_descriptor.set_height(size.height.0 as u64);
+        full_descriptor.set_pixel_format(metal::MTLPixelFormat::BGRA8Unorm);
+        full_descriptor.set_storage_mode(metal::MTLStorageMode::Private);
+        full_descriptor.set_usage(
+            metal::MTLTextureUsage::RenderTarget | metal::MTLTextureUsage::ShaderRead,
+        );
+        self.blur_snapshot_texture = Some(self.device.new_texture(&full_descriptor));
+
+        let half_descriptor = metal::TextureDescriptor::new();
+        half_descriptor.set_width((size.width.0 as u64).max(1) / 2);
+        half_descriptor.set_height((size.height.0 as u64).max(1) / 2);
+        half_descriptor.set_pixel_format(metal::MTLPixelFormat::BGRA8Unorm);
+        half_descriptor.set_storage_mode(metal::MTLStorageMode::Private);
+        half_descriptor.set_usage(
+            metal::MTLTextureUsage::RenderTarget | metal::MTLTextureUsage::ShaderRead,
+        );
+        self.blur_half_texture = Some(self.device.new_texture(&half_descriptor));
     }
 
     pub fn update_transparency(&mut self, transparent: bool) {
@@ -843,6 +930,64 @@ impl MetalRenderer {
                     command_encoder,
                 ),
                 PrimitiveBatch::SubpixelSprites { .. } => unreachable!(),
+                PrimitiveBatch::BlurRects(range) => {
+                    let rects = &scene.blur_rects[range];
+                    if rects.is_empty() {
+                        true
+                    } else {
+                        command_encoder.end_encoding();
+                        let did_snapshot = self
+                            .snapshot_and_blur_frame(texture, viewport_size, command_buffer);
+                        command_encoder = new_command_encoder_for_texture(
+                            command_buffer,
+                            texture,
+                            viewport_size,
+                            |color_attachment| {
+                                color_attachment.set_load_action(metal::MTLLoadAction::Load);
+                            },
+                        );
+                        if did_snapshot {
+                            self.draw_blur_rects(
+                                rects,
+                                instance_buffer,
+                                &mut instance_offset,
+                                viewport_size,
+                                command_encoder,
+                            )
+                        } else {
+                            true
+                        }
+                    }
+                }
+                PrimitiveBatch::LensRects(range) => {
+                    let rects = &scene.lens_rects[range];
+                    if rects.is_empty() {
+                        true
+                    } else {
+                        command_encoder.end_encoding();
+                        let did_snapshot = self
+                            .snapshot_and_blur_frame(texture, viewport_size, command_buffer);
+                        command_encoder = new_command_encoder_for_texture(
+                            command_buffer,
+                            texture,
+                            viewport_size,
+                            |color_attachment| {
+                                color_attachment.set_load_action(metal::MTLLoadAction::Load);
+                            },
+                        );
+                        if did_snapshot {
+                            self.draw_lens_rects(
+                                rects,
+                                instance_buffer,
+                                &mut instance_offset,
+                                viewport_size,
+                                command_encoder,
+                            )
+                        } else {
+                            true
+                        }
+                    }
+                }
             };
             if !ok {
                 command_encoder.end_encoding();
@@ -1167,6 +1312,245 @@ impl MetalRenderer {
         );
         *instance_offset = next_offset;
 
+        true
+    }
+
+    fn snapshot_and_blur_frame(
+        &self,
+        texture: &metal::TextureRef,
+        viewport_size: Size<DevicePixels>,
+        command_buffer: &metal::CommandBufferRef,
+    ) -> bool {
+        let (Some(snapshot), Some(half)) = (
+            self.blur_snapshot_texture.as_ref(),
+            self.blur_half_texture.as_ref(),
+        ) else {
+            return false;
+        };
+        if viewport_size.width.0 <= 0 || viewport_size.height.0 <= 0 {
+            return false;
+        }
+
+        let blit = command_buffer.new_blit_command_encoder();
+        blit.copy_from_texture(
+            texture,
+            0,
+            0,
+            metal::MTLOrigin { x: 0, y: 0, z: 0 },
+            metal::MTLSize {
+                width: texture.width(),
+                height: texture.height(),
+                depth: 1,
+            },
+            snapshot,
+            0,
+            0,
+            metal::MTLOrigin { x: 0, y: 0, z: 0 },
+        );
+        blit.end_encoding();
+
+        // Downsample snapshot (full) -> half.
+        let full_size = [
+            viewport_size.width.0 as f32,
+            viewport_size.height.0 as f32,
+        ];
+        let half_size = [
+            (viewport_size.width.0 as f32) * 0.5,
+            (viewport_size.height.0 as f32) * 0.5,
+        ];
+
+        self.run_blur_pass(
+            command_buffer,
+            snapshot,
+            half,
+            &self.blur_downsample_pipeline_state,
+            BlurParams {
+                viewport_size: full_size,
+                offset_multiplier: 1.0,
+                _pad: 0.0,
+            },
+        );
+        self.run_blur_pass(
+            command_buffer,
+            half,
+            snapshot,
+            &self.blur_upsample_pipeline_state,
+            BlurParams {
+                viewport_size: half_size,
+                offset_multiplier: 1.0,
+                _pad: 0.0,
+            },
+        );
+        true
+    }
+
+    fn run_blur_pass(
+        &self,
+        command_buffer: &metal::CommandBufferRef,
+        input: &metal::TextureRef,
+        output: &metal::TextureRef,
+        pipeline: &metal::RenderPipelineStateRef,
+        params: BlurParams,
+    ) {
+        let descriptor = metal::RenderPassDescriptor::new();
+        let color_attachment = descriptor.color_attachments().object_at(0).unwrap();
+        color_attachment.set_texture(Some(output));
+        color_attachment.set_load_action(metal::MTLLoadAction::DontCare);
+        color_attachment.set_store_action(metal::MTLStoreAction::Store);
+
+        let encoder = command_buffer.new_render_command_encoder(descriptor);
+        encoder.set_render_pipeline_state(pipeline);
+        encoder.set_fragment_texture(BlurIoInputIndex::InputTexture as u64, Some(input));
+        encoder.set_fragment_sampler_state(
+            BlurIoInputIndex::InputSampler as u64,
+            Some(&self.blur_sampler),
+        );
+        encoder.set_fragment_bytes(
+            BlurIoInputIndex::Params as u64,
+            mem::size_of::<BlurParams>() as u64,
+            &params as *const BlurParams as *const _,
+        );
+        encoder.draw_primitives(metal::MTLPrimitiveType::Triangle, 0, 3);
+        encoder.end_encoding();
+    }
+
+    fn draw_blur_rects(
+        &self,
+        rects: &[BlurRect],
+        instance_buffer: &mut InstanceBuffer,
+        instance_offset: &mut usize,
+        viewport_size: Size<DevicePixels>,
+        command_encoder: &metal::RenderCommandEncoderRef,
+    ) -> bool {
+        if rects.is_empty() {
+            return true;
+        }
+        let Some(ref snapshot) = self.blur_snapshot_texture else {
+            return false;
+        };
+        align_offset(instance_offset);
+
+        command_encoder.set_render_pipeline_state(&self.blur_rect_pipeline_state);
+        command_encoder.set_vertex_buffer(
+            BlurRectInputIndex::Vertices as u64,
+            Some(&self.unit_vertices),
+            0,
+        );
+        command_encoder.set_vertex_buffer(
+            BlurRectInputIndex::Rects as u64,
+            Some(&instance_buffer.metal_buffer),
+            *instance_offset as u64,
+        );
+        command_encoder.set_fragment_buffer(
+            BlurRectInputIndex::Rects as u64,
+            Some(&instance_buffer.metal_buffer),
+            *instance_offset as u64,
+        );
+        command_encoder.set_vertex_bytes(
+            BlurRectInputIndex::ViewportSize as u64,
+            mem::size_of_val(&viewport_size) as u64,
+            &viewport_size as *const Size<DevicePixels> as *const _,
+        );
+        command_encoder.set_fragment_bytes(
+            BlurRectInputIndex::ViewportSize as u64,
+            mem::size_of_val(&viewport_size) as u64,
+            &viewport_size as *const Size<DevicePixels> as *const _,
+        );
+        command_encoder
+            .set_fragment_texture(BlurRectInputIndex::BlurTexture as u64, Some(snapshot));
+        command_encoder.set_fragment_sampler_state(
+            BlurRectInputIndex::BlurSampler as u64,
+            Some(&self.blur_sampler),
+        );
+
+        let bytes_len = mem::size_of_val(rects);
+        let next_offset = *instance_offset + bytes_len;
+        if next_offset > instance_buffer.size {
+            return false;
+        }
+        let buffer_contents =
+            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
+        unsafe {
+            ptr::copy_nonoverlapping(rects.as_ptr() as *const u8, buffer_contents, bytes_len);
+        }
+
+        command_encoder.draw_primitives_instanced(
+            metal::MTLPrimitiveType::Triangle,
+            0,
+            6,
+            rects.len() as u64,
+        );
+        *instance_offset = next_offset;
+        true
+    }
+
+    fn draw_lens_rects(
+        &self,
+        rects: &[LensRect],
+        instance_buffer: &mut InstanceBuffer,
+        instance_offset: &mut usize,
+        viewport_size: Size<DevicePixels>,
+        command_encoder: &metal::RenderCommandEncoderRef,
+    ) -> bool {
+        if rects.is_empty() {
+            return true;
+        }
+        let Some(ref snapshot) = self.blur_snapshot_texture else {
+            return false;
+        };
+        align_offset(instance_offset);
+
+        command_encoder.set_render_pipeline_state(&self.lens_rect_pipeline_state);
+        command_encoder.set_vertex_buffer(
+            LensRectInputIndex::Vertices as u64,
+            Some(&self.unit_vertices),
+            0,
+        );
+        command_encoder.set_vertex_buffer(
+            LensRectInputIndex::Rects as u64,
+            Some(&instance_buffer.metal_buffer),
+            *instance_offset as u64,
+        );
+        command_encoder.set_fragment_buffer(
+            LensRectInputIndex::Rects as u64,
+            Some(&instance_buffer.metal_buffer),
+            *instance_offset as u64,
+        );
+        command_encoder.set_vertex_bytes(
+            LensRectInputIndex::ViewportSize as u64,
+            mem::size_of_val(&viewport_size) as u64,
+            &viewport_size as *const Size<DevicePixels> as *const _,
+        );
+        command_encoder.set_fragment_bytes(
+            LensRectInputIndex::ViewportSize as u64,
+            mem::size_of_val(&viewport_size) as u64,
+            &viewport_size as *const Size<DevicePixels> as *const _,
+        );
+        command_encoder
+            .set_fragment_texture(LensRectInputIndex::BlurTexture as u64, Some(snapshot));
+        command_encoder.set_fragment_sampler_state(
+            LensRectInputIndex::BlurSampler as u64,
+            Some(&self.blur_sampler),
+        );
+
+        let bytes_len = mem::size_of_val(rects);
+        let next_offset = *instance_offset + bytes_len;
+        if next_offset > instance_buffer.size {
+            return false;
+        }
+        let buffer_contents =
+            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
+        unsafe {
+            ptr::copy_nonoverlapping(rects.as_ptr() as *const u8, buffer_contents, bytes_len);
+        }
+
+        command_encoder.draw_primitives_instanced(
+            metal::MTLPrimitiveType::Triangle,
+            0,
+            6,
+            rects.len() as u64,
+        );
+        *instance_offset = next_offset;
         true
     }
 
@@ -1576,6 +1960,34 @@ fn build_path_sprite_pipeline_state(
         .expect("could not create render pipeline state")
 }
 
+fn build_blur_io_pipeline_state(
+    device: &metal::DeviceRef,
+    library: &metal::LibraryRef,
+    label: &str,
+    vertex_fn_name: &str,
+    fragment_fn_name: &str,
+    pixel_format: metal::MTLPixelFormat,
+) -> metal::RenderPipelineState {
+    let vertex_fn = library
+        .get_function(vertex_fn_name, None)
+        .expect("error locating blur-io vertex function");
+    let fragment_fn = library
+        .get_function(fragment_fn_name, None)
+        .expect("error locating blur-io fragment function");
+
+    let descriptor = metal::RenderPipelineDescriptor::new();
+    descriptor.set_label(label);
+    descriptor.set_vertex_function(Some(vertex_fn.as_ref()));
+    descriptor.set_fragment_function(Some(fragment_fn.as_ref()));
+    let color_attachment = descriptor.color_attachments().object_at(0).unwrap();
+    color_attachment.set_pixel_format(pixel_format);
+    color_attachment.set_blending_enabled(false);
+
+    device
+        .new_render_pipeline_state(&descriptor)
+        .expect("could not create blur-io pipeline state")
+}
+
 fn build_path_rasterization_pipeline_state(
     device: &metal::DeviceRef,
     library: &metal::LibraryRef,
@@ -1664,6 +2076,31 @@ enum SurfaceInputIndex {
 enum PathRasterizationInputIndex {
     Vertices = 0,
     ViewportSize = 1,
+}
+
+#[repr(C)]
+enum BlurIoInputIndex {
+    Params = 0,
+    InputTexture = 1,
+    InputSampler = 2,
+}
+
+#[repr(C)]
+enum BlurRectInputIndex {
+    Vertices = 0,
+    Rects = 1,
+    ViewportSize = 2,
+    BlurTexture = 3,
+    BlurSampler = 4,
+}
+
+#[repr(C)]
+enum LensRectInputIndex {
+    Vertices = 0,
+    Rects = 1,
+    ViewportSize = 2,
+    BlurTexture = 3,
+    BlurSampler = 4,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -143,9 +143,18 @@ pub(crate) struct MetalRenderer {
     blur_rect_pipeline_state: metal::RenderPipelineState,
     lens_rect_pipeline_state: metal::RenderPipelineState,
     blur_sampler: metal::SamplerState,
-    blur_snapshot_texture: Option<metal::Texture>,
-    blur_half_texture: Option<metal::Texture>,
+    /// Dual-Kawase scratch chain. `blur_chain_textures[0]` is surface-sized
+    /// and receives the framebuffer snapshot; each subsequent level is
+    /// half-sized. `BlurEffect::kernel_levels` selects the depth used per
+    /// frame (1..=5).
+    blur_chain_textures: [Option<metal::Texture>; BLUR_CHAIN_LEVELS],
 }
+
+/// Maximum blur chain depth (`kernel_levels` is clamped to this).
+const BLUR_CHAIN_LEVELS: usize = 6;
+/// Reference blur radius. `BlurEffect::radius` scales the Kawase offset
+/// multiplier linearly relative to this.
+const BLUR_REFERENCE_RADIUS_PX: f32 = 20.0;
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -440,8 +449,7 @@ impl MetalRenderer {
             blur_rect_pipeline_state,
             lens_rect_pipeline_state,
             blur_sampler,
-            blur_snapshot_texture: None,
-            blur_half_texture: None,
+            blur_chain_textures: Default::default(),
         }
     }
 
@@ -490,8 +498,9 @@ impl MetalRenderer {
         if size.width.0 <= 0 || size.height.0 <= 0 {
             self.path_intermediate_texture = None;
             self.path_intermediate_msaa_texture = None;
-            self.blur_snapshot_texture = None;
-            self.blur_half_texture = None;
+            for slot in &mut self.blur_chain_textures {
+                *slot = None;
+            }
             return;
         }
 
@@ -522,25 +531,28 @@ impl MetalRenderer {
             self.path_intermediate_msaa_texture = None;
         }
 
-        let full_descriptor = metal::TextureDescriptor::new();
-        full_descriptor.set_width(size.width.0 as u64);
-        full_descriptor.set_height(size.height.0 as u64);
-        full_descriptor.set_pixel_format(metal::MTLPixelFormat::BGRA8Unorm);
-        full_descriptor.set_storage_mode(metal::MTLStorageMode::Private);
-        full_descriptor.set_usage(
-            metal::MTLTextureUsage::RenderTarget | metal::MTLTextureUsage::ShaderRead,
-        );
-        self.blur_snapshot_texture = Some(self.device.new_texture(&full_descriptor));
+        if self.frame_sampling_enabled {
+            for level in 0..BLUR_CHAIN_LEVELS {
+                let width = (size.width.0 as u64).max(1) >> level;
+                let height = (size.height.0 as u64).max(1) >> level;
+                let width = width.max(1);
+                let height = height.max(1);
 
-        let half_descriptor = metal::TextureDescriptor::new();
-        half_descriptor.set_width((size.width.0 as u64).max(1) / 2);
-        half_descriptor.set_height((size.height.0 as u64).max(1) / 2);
-        half_descriptor.set_pixel_format(metal::MTLPixelFormat::BGRA8Unorm);
-        half_descriptor.set_storage_mode(metal::MTLStorageMode::Private);
-        half_descriptor.set_usage(
-            metal::MTLTextureUsage::RenderTarget | metal::MTLTextureUsage::ShaderRead,
-        );
-        self.blur_half_texture = Some(self.device.new_texture(&half_descriptor));
+                let descriptor = metal::TextureDescriptor::new();
+                descriptor.set_width(width);
+                descriptor.set_height(height);
+                descriptor.set_pixel_format(metal::MTLPixelFormat::BGRA8Unorm);
+                descriptor.set_storage_mode(metal::MTLStorageMode::Private);
+                descriptor.set_usage(
+                    metal::MTLTextureUsage::RenderTarget | metal::MTLTextureUsage::ShaderRead,
+                );
+                self.blur_chain_textures[level] = Some(self.device.new_texture(&descriptor));
+            }
+        } else {
+            for slot in &mut self.blur_chain_textures {
+                *slot = None;
+            }
+        }
     }
 
     pub fn update_transparency(&mut self, transparent: bool) {
@@ -868,6 +880,10 @@ impl MetalRenderer {
         let alpha = if self.opaque { 1. } else { 0. };
         let mut instance_offset = 0;
 
+        let blur_kernel_levels = scene.max_blur_kernel_levels();
+        let blur_offset_multiplier =
+            (scene.max_blur_radius().0 / BLUR_REFERENCE_RADIUS_PX).clamp(0.1, 4.0);
+
         let mut command_encoder = new_command_encoder_for_texture(
             command_buffer,
             texture,
@@ -966,8 +982,13 @@ impl MetalRenderer {
                         true
                     } else {
                         command_encoder.end_encoding();
-                        let did_snapshot = self
-                            .snapshot_and_blur_frame(texture, viewport_size, command_buffer);
+                        let did_snapshot = self.snapshot_and_blur_frame(
+                            texture,
+                            viewport_size,
+                            blur_kernel_levels,
+                            blur_offset_multiplier,
+                            command_buffer,
+                        );
                         command_encoder = new_command_encoder_for_texture(
                             command_buffer,
                             texture,
@@ -995,8 +1016,13 @@ impl MetalRenderer {
                         true
                     } else {
                         command_encoder.end_encoding();
-                        let did_snapshot = self
-                            .snapshot_and_blur_frame(texture, viewport_size, command_buffer);
+                        let did_snapshot = self.snapshot_and_blur_frame(
+                            texture,
+                            viewport_size,
+                            blur_kernel_levels,
+                            blur_offset_multiplier,
+                            command_buffer,
+                        );
                         command_encoder = new_command_encoder_for_texture(
                             command_buffer,
                             texture,
@@ -1351,17 +1377,26 @@ impl MetalRenderer {
         &self,
         texture: &metal::TextureRef,
         viewport_size: Size<DevicePixels>,
+        kernel_levels: u32,
+        offset_multiplier: f32,
         command_buffer: &metal::CommandBufferRef,
     ) -> bool {
-        let (Some(snapshot), Some(half)) = (
-            self.blur_snapshot_texture.as_ref(),
-            self.blur_half_texture.as_ref(),
-        ) else {
-            return false;
-        };
         if viewport_size.width.0 <= 0 || viewport_size.height.0 <= 0 {
             return false;
         }
+        let kernel_levels = kernel_levels.clamp(1, (BLUR_CHAIN_LEVELS - 1) as u32) as usize;
+
+        // All chain levels we need must be populated. Any None means the
+        // renderer was initialized without `enable_frame_sampling`.
+        for level in 0..=kernel_levels {
+            if self.blur_chain_textures[level].is_none() {
+                return false;
+            }
+        }
+
+        let snapshot = self.blur_chain_textures[0]
+            .as_ref()
+            .expect("chain level 0 checked above");
 
         let blit = command_buffer.new_blit_command_encoder();
         blit.copy_from_texture(
@@ -1381,38 +1416,51 @@ impl MetalRenderer {
         );
         blit.end_encoding();
 
-        // Downsample snapshot (full) -> half.
-        let full_size = [
-            viewport_size.width.0 as f32,
-            viewport_size.height.0 as f32,
-        ];
-        let half_size = [
-            (viewport_size.width.0 as f32) * 0.5,
-            (viewport_size.height.0 as f32) * 0.5,
-        ];
+        for i in 0..kernel_levels {
+            let src = self.blur_chain_textures[i]
+                .as_ref()
+                .expect("chain level checked above");
+            let dst = self.blur_chain_textures[i + 1]
+                .as_ref()
+                .expect("chain level checked above");
+            let src_w = ((viewport_size.width.0 as f32) * 0.5f32.powi(i as i32)).max(1.0);
+            let src_h = ((viewport_size.height.0 as f32) * 0.5f32.powi(i as i32)).max(1.0);
+            self.run_blur_pass(
+                command_buffer,
+                src,
+                dst,
+                &self.blur_downsample_pipeline_state,
+                BlurParams {
+                    viewport_size: [src_w, src_h],
+                    offset_multiplier,
+                    pad: 0.0,
+                },
+            );
+        }
 
-        self.run_blur_pass(
-            command_buffer,
-            snapshot,
-            half,
-            &self.blur_downsample_pipeline_state,
-            BlurParams {
-                viewport_size: full_size,
-                offset_multiplier: 1.0,
-                pad: 0.0,
-            },
-        );
-        self.run_blur_pass(
-            command_buffer,
-            half,
-            snapshot,
-            &self.blur_upsample_pipeline_state,
-            BlurParams {
-                viewport_size: half_size,
-                offset_multiplier: 1.0,
-                pad: 0.0,
-            },
-        );
+        for step in 0..kernel_levels {
+            let src_level = kernel_levels - step;
+            let dst_level = src_level - 1;
+            let src = self.blur_chain_textures[src_level]
+                .as_ref()
+                .expect("chain level checked above");
+            let dst = self.blur_chain_textures[dst_level]
+                .as_ref()
+                .expect("chain level checked above");
+            let src_w = ((viewport_size.width.0 as f32) * 0.5f32.powi(src_level as i32)).max(1.0);
+            let src_h = ((viewport_size.height.0 as f32) * 0.5f32.powi(src_level as i32)).max(1.0);
+            self.run_blur_pass(
+                command_buffer,
+                src,
+                dst,
+                &self.blur_upsample_pipeline_state,
+                BlurParams {
+                    viewport_size: [src_w, src_h],
+                    offset_multiplier,
+                    pad: 0.0,
+                },
+            );
+        }
         true
     }
 
@@ -1457,7 +1505,7 @@ impl MetalRenderer {
         if rects.is_empty() {
             return true;
         }
-        let Some(ref snapshot) = self.blur_snapshot_texture else {
+        let Some(ref snapshot) = self.blur_chain_textures[0] else {
             return false;
         };
         align_offset(instance_offset);
@@ -1527,7 +1575,7 @@ impl MetalRenderer {
         if rects.is_empty() {
             return true;
         }
-        let Some(ref snapshot) = self.blur_snapshot_texture else {
+        let Some(ref snapshot) = self.blur_chain_textures[0] else {
             return false;
         };
         align_offset(instance_offset);

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -7,9 +7,9 @@ use cocoa::{
     quartzcore::AutoresizingMask,
 };
 use gpui::{
-    AtlasTextureId, Background, BlurRect, Bounds, ContentMask, DevicePixels, LensRect,
-    MonochromeSprite, PaintSurface, Path, Point, PolychromeSprite, PrimitiveBatch, Quad,
-    ScaledPixels, Scene, Shadow, Size, Surface, Underline, point, size,
+    AtlasTextureId, Background, BlurRect, Bounds, ContentMask, DevicePixels, LensRect, LensShape,
+    MirrorRect, MonochromeSprite, PaintSurface, Path, Point, PolychromeSprite, PrimitiveBatch,
+    Quad, ScaledPixels, Scene, Shadow, Size, Surface, Underline, point, size,
 };
 #[cfg(any(test, feature = "test-support"))]
 use image::RgbaImage;
@@ -142,12 +142,23 @@ pub(crate) struct MetalRenderer {
     blur_upsample_pipeline_state: metal::RenderPipelineState,
     blur_rect_pipeline_state: metal::RenderPipelineState,
     lens_rect_pipeline_state: metal::RenderPipelineState,
+    mirror_rect_pipeline_state: metal::RenderPipelineState,
     blur_sampler: metal::SamplerState,
     /// Dual-Kawase scratch chain. `blur_chain_textures[0]` is surface-sized
     /// and receives the framebuffer snapshot; each subsequent level is
     /// half-sized. `BlurEffect::kernel_levels` selects the depth used per
-    /// frame (1..=5).
+    /// frame (1..=5). The upsample phase overwrites `chain[0..N-1]`, so
+    /// fragment shaders sample `blur_pyramid_texture` for intermediate
+    /// blur radii, not the chain.
     blur_chain_textures: [Option<metal::Texture>; BLUR_CHAIN_LEVELS],
+    /// Preserved downsample pyramid: a single mipmapped texture where mip
+    /// 0 is the un-blurred framebuffer snapshot and each subsequent mip is
+    /// the Kawase-downsample result of the previous level. Written once
+    /// per frame after the Kawase downsample loop (before upsample would
+    /// overwrite the chain). Fragment shaders sample this with
+    /// `textureSampleLevel` at fractional LOD to produce a per-pixel
+    /// variable-radius blur.
+    blur_pyramid_texture: Option<metal::Texture>,
 }
 
 /// Maximum blur chain depth (`kernel_levels` is clamped to this).
@@ -405,11 +416,22 @@ impl MetalRenderer {
             "lens_rect_fragment",
             MTLPixelFormat::BGRA8Unorm,
         );
+        let mirror_rect_pipeline_state = build_pipeline_state(
+            &device,
+            &library,
+            "mirror_rect",
+            "mirror_rect_vertex",
+            "mirror_rect_fragment",
+            MTLPixelFormat::BGRA8Unorm,
+        );
 
         let blur_sampler = {
             let desc = metal::SamplerDescriptor::new();
             desc.set_min_filter(metal::MTLSamplerMinMagFilter::Linear);
             desc.set_mag_filter(metal::MTLSamplerMinMagFilter::Linear);
+            // Trilinear filtering between pyramid mip levels is what makes
+            // the per-pixel variable-radius blur smooth.
+            desc.set_mip_filter(metal::MTLSamplerMipFilter::Linear);
             desc.set_address_mode_s(metal::MTLSamplerAddressMode::ClampToEdge);
             desc.set_address_mode_t(metal::MTLSamplerAddressMode::ClampToEdge);
             device.new_sampler(&desc)
@@ -448,8 +470,10 @@ impl MetalRenderer {
             blur_upsample_pipeline_state,
             blur_rect_pipeline_state,
             lens_rect_pipeline_state,
+            mirror_rect_pipeline_state,
             blur_sampler,
             blur_chain_textures: Default::default(),
+            blur_pyramid_texture: None,
         }
     }
 
@@ -548,10 +572,22 @@ impl MetalRenderer {
                 );
                 self.blur_chain_textures[level] = Some(self.device.new_texture(&descriptor));
             }
+
+            let width = (size.width.0 as u64).max(1);
+            let height = (size.height.0 as u64).max(1);
+            let descriptor = metal::TextureDescriptor::new();
+            descriptor.set_width(width);
+            descriptor.set_height(height);
+            descriptor.set_pixel_format(metal::MTLPixelFormat::BGRA8Unorm);
+            descriptor.set_mipmap_level_count(BLUR_CHAIN_LEVELS as u64);
+            descriptor.set_storage_mode(metal::MTLStorageMode::Private);
+            descriptor.set_usage(metal::MTLTextureUsage::ShaderRead);
+            self.blur_pyramid_texture = Some(self.device.new_texture(&descriptor));
         } else {
             for slot in &mut self.blur_chain_textures {
                 *slot = None;
             }
+            self.blur_pyramid_texture = None;
         }
     }
 
@@ -881,8 +917,14 @@ impl MetalRenderer {
         let mut instance_offset = 0;
 
         let blur_kernel_levels = scene.max_blur_kernel_levels();
+        let scene_max_blur_radius = scene.max_blur_radius().0;
         let blur_offset_multiplier =
-            (scene.max_blur_radius().0 / BLUR_REFERENCE_RADIUS_PX).clamp(0.1, 4.0);
+            (scene_max_blur_radius / BLUR_REFERENCE_RADIUS_PX).clamp(0.1, 4.0);
+        let scene_blur_params = SceneBlurParams {
+            max_blur_radius: scene_max_blur_radius,
+            kernel_levels: blur_kernel_levels as f32,
+            _pad: [0.0; 2],
+        };
         // Tracks whether the Kawase chain already reflects the drawable
         // contents since the last non-blur batch. Reset to `false` at
         // frame start and whenever any other primitive writes to the
@@ -902,7 +944,9 @@ impl MetalRenderer {
         for batch in scene.batches() {
             let is_blur_batch = matches!(
                 batch,
-                PrimitiveBatch::BlurRects(_) | PrimitiveBatch::LensRects(_)
+                PrimitiveBatch::BlurRects(_)
+                    | PrimitiveBatch::LensRects(_)
+                    | PrimitiveBatch::MirrorRects(_)
             );
             let ok = match batch {
                 PrimitiveBatch::Shadows(range) => self.draw_shadows(
@@ -1017,6 +1061,7 @@ impl MetalRenderer {
                         if did_snapshot {
                             self.draw_blur_rects(
                                 rects,
+                                scene_blur_params,
                                 instance_buffer,
                                 &mut instance_offset,
                                 viewport_size,
@@ -1059,6 +1104,55 @@ impl MetalRenderer {
                         if did_snapshot {
                             self.draw_lens_rects(
                                 rects,
+                                &scene.lens_shapes,
+                                scene_blur_params,
+                                instance_buffer,
+                                &mut instance_offset,
+                                viewport_size,
+                                command_encoder,
+                            )
+                        } else {
+                            true
+                        }
+                    }
+                }
+                PrimitiveBatch::MirrorRects(range) => {
+                    let rects = &scene.mirror_rects[range];
+                    if rects.is_empty() || !self.frame_sampling_enabled {
+                        true
+                    } else {
+                        command_encoder.end_encoding();
+                        // Mirror always needs the un-blurred snapshot;
+                        // also run the Kawase chain so blur-enabled mirror
+                        // rects have a source to mix against.
+                        let did_snapshot = if blur_snapshot_valid {
+                            true
+                        } else {
+                            let levels = blur_kernel_levels.max(1);
+                            let ok = self.snapshot_and_blur_frame(
+                                texture,
+                                viewport_size,
+                                levels,
+                                blur_offset_multiplier,
+                                command_buffer,
+                            );
+                            if ok {
+                                blur_snapshot_valid = true;
+                            }
+                            ok
+                        };
+                        command_encoder = new_command_encoder_for_texture(
+                            command_buffer,
+                            texture,
+                            viewport_size,
+                            |color_attachment| {
+                                color_attachment.set_load_action(metal::MTLLoadAction::Load);
+                            },
+                        );
+                        if did_snapshot {
+                            self.draw_mirror_rects(
+                                rects,
+                                scene_blur_params,
                                 instance_buffer,
                                 &mut instance_offset,
                                 viewport_size,
@@ -1073,7 +1167,7 @@ impl MetalRenderer {
             if !ok {
                 command_encoder.end_encoding();
                 anyhow::bail!(
-                    "scene too large: {} paths, {} shadows, {} quads, {} underlines, {} mono, {} poly, {} surfaces, {} blur rects, {} lens rects",
+                    "scene too large: {} paths, {} shadows, {} quads, {} underlines, {} mono, {} poly, {} surfaces, {} blur rects, {} lens rects, {} mirror rects",
                     scene.paths.len(),
                     scene.shadows.len(),
                     scene.quads.len(),
@@ -1083,6 +1177,7 @@ impl MetalRenderer {
                     scene.surfaces.len(),
                     scene.blur_rects.len(),
                     scene.lens_rects.len(),
+                    scene.mirror_rects.len(),
                 );
             }
             if !is_blur_batch {
@@ -1426,18 +1521,35 @@ impl MetalRenderer {
         let snapshot = self.blur_chain_textures[0]
             .as_ref()
             .expect("chain level 0 checked above");
+        let Some(ref pyramid) = self.blur_pyramid_texture else {
+            return false;
+        };
 
         let blit = command_buffer.new_blit_command_encoder();
+        let full_size = metal::MTLSize {
+            width: texture.width(),
+            height: texture.height(),
+            depth: 1,
+        };
+        // Mip 0 of the pyramid is the un-blurred framebuffer; the Kawase
+        // chain runs in parallel on `blur_chain_textures`.
         blit.copy_from_texture(
             texture,
             0,
             0,
             metal::MTLOrigin { x: 0, y: 0, z: 0 },
-            metal::MTLSize {
-                width: texture.width(),
-                height: texture.height(),
-                depth: 1,
-            },
+            full_size,
+            pyramid,
+            0,
+            0,
+            metal::MTLOrigin { x: 0, y: 0, z: 0 },
+        );
+        blit.copy_from_texture(
+            texture,
+            0,
+            0,
+            metal::MTLOrigin { x: 0, y: 0, z: 0 },
+            full_size,
             snapshot,
             0,
             0,
@@ -1466,6 +1578,35 @@ impl MetalRenderer {
                 },
             );
         }
+
+        // Preserve the downsample chain into pyramid mip levels before the
+        // upsample loop overwrites `chain[0..N-1]`. Each `chain[i]` is the
+        // /2^i-sized result of `i` Kawase downsample passes, which maps to
+        // pyramid mip level `i`.
+        let preserve_blit = command_buffer.new_blit_command_encoder();
+        for i in 1..=kernel_levels {
+            let src = self.blur_chain_textures[i]
+                .as_ref()
+                .expect("chain level checked above");
+            let width = ((viewport_size.width.0 as u64) >> i).max(1);
+            let height = ((viewport_size.height.0 as u64) >> i).max(1);
+            preserve_blit.copy_from_texture(
+                src,
+                0,
+                0,
+                metal::MTLOrigin { x: 0, y: 0, z: 0 },
+                metal::MTLSize {
+                    width,
+                    height,
+                    depth: 1,
+                },
+                pyramid,
+                0,
+                i as u64,
+                metal::MTLOrigin { x: 0, y: 0, z: 0 },
+            );
+        }
+        preserve_blit.end_encoding();
 
         for step in 0..kernel_levels {
             let src_level = kernel_levels - step;
@@ -1526,6 +1667,7 @@ impl MetalRenderer {
     fn draw_blur_rects(
         &self,
         rects: &[BlurRect],
+        scene_blur_params: SceneBlurParams,
         instance_buffer: &mut InstanceBuffer,
         instance_offset: &mut usize,
         viewport_size: Size<DevicePixels>,
@@ -1534,7 +1676,7 @@ impl MetalRenderer {
         if rects.is_empty() {
             return true;
         }
-        let Some(ref snapshot) = self.blur_chain_textures[0] else {
+        let Some(ref pyramid) = self.blur_pyramid_texture else {
             return false;
         };
         align_offset(instance_offset);
@@ -1565,8 +1707,13 @@ impl MetalRenderer {
             mem::size_of_val(&viewport_size) as u64,
             &viewport_size as *const Size<DevicePixels> as *const _,
         );
+        command_encoder.set_fragment_bytes(
+            BlurRectInputIndex::SceneBlurParams as u64,
+            mem::size_of::<SceneBlurParams>() as u64,
+            &scene_blur_params as *const SceneBlurParams as *const _,
+        );
         command_encoder
-            .set_fragment_texture(BlurRectInputIndex::BlurTexture as u64, Some(snapshot));
+            .set_fragment_texture(BlurRectInputIndex::BlurPyramid as u64, Some(pyramid));
         command_encoder.set_fragment_sampler_state(
             BlurRectInputIndex::BlurSampler as u64,
             Some(&self.blur_sampler),
@@ -1596,6 +1743,8 @@ impl MetalRenderer {
     fn draw_lens_rects(
         &self,
         rects: &[LensRect],
+        shapes: &[LensShape],
+        scene_blur_params: SceneBlurParams,
         instance_buffer: &mut InstanceBuffer,
         instance_offset: &mut usize,
         viewport_size: Size<DevicePixels>,
@@ -1604,10 +1753,39 @@ impl MetalRenderer {
         if rects.is_empty() {
             return true;
         }
-        let Some(ref snapshot) = self.blur_chain_textures[0] else {
+        // Shapes cannot be empty if any rect references them; fail rather
+        // than bind a zero-length buffer (Metal doesn't accept that).
+        if shapes.is_empty() {
+            return false;
+        }
+        let Some(ref pyramid) = self.blur_pyramid_texture else {
             return false;
         };
         align_offset(instance_offset);
+        let rects_offset = *instance_offset;
+        let rects_bytes = mem::size_of_val(rects);
+        let after_rects = rects_offset + rects_bytes;
+        if after_rects > instance_buffer.size {
+            return false;
+        }
+        unsafe {
+            let dst =
+                (instance_buffer.metal_buffer.contents() as *mut u8).add(rects_offset);
+            ptr::copy_nonoverlapping(rects.as_ptr() as *const u8, dst, rects_bytes);
+        }
+
+        let mut shapes_offset = after_rects;
+        align_offset(&mut shapes_offset);
+        let shapes_bytes = mem::size_of_val(shapes);
+        let after_shapes = shapes_offset + shapes_bytes;
+        if after_shapes > instance_buffer.size {
+            return false;
+        }
+        unsafe {
+            let dst =
+                (instance_buffer.metal_buffer.contents() as *mut u8).add(shapes_offset);
+            ptr::copy_nonoverlapping(shapes.as_ptr() as *const u8, dst, shapes_bytes);
+        }
 
         command_encoder.set_render_pipeline_state(&self.lens_rect_pipeline_state);
         command_encoder.set_vertex_buffer(
@@ -1618,12 +1796,22 @@ impl MetalRenderer {
         command_encoder.set_vertex_buffer(
             LensRectInputIndex::Rects as u64,
             Some(&instance_buffer.metal_buffer),
-            *instance_offset as u64,
+            rects_offset as u64,
         );
         command_encoder.set_fragment_buffer(
             LensRectInputIndex::Rects as u64,
             Some(&instance_buffer.metal_buffer),
-            *instance_offset as u64,
+            rects_offset as u64,
+        );
+        command_encoder.set_vertex_buffer(
+            LensRectInputIndex::Shapes as u64,
+            Some(&instance_buffer.metal_buffer),
+            shapes_offset as u64,
+        );
+        command_encoder.set_fragment_buffer(
+            LensRectInputIndex::Shapes as u64,
+            Some(&instance_buffer.metal_buffer),
+            shapes_offset as u64,
         );
         command_encoder.set_vertex_bytes(
             LensRectInputIndex::ViewportSize as u64,
@@ -1635,10 +1823,80 @@ impl MetalRenderer {
             mem::size_of_val(&viewport_size) as u64,
             &viewport_size as *const Size<DevicePixels> as *const _,
         );
+        command_encoder.set_fragment_bytes(
+            LensRectInputIndex::SceneBlurParams as u64,
+            mem::size_of::<SceneBlurParams>() as u64,
+            &scene_blur_params as *const SceneBlurParams as *const _,
+        );
         command_encoder
-            .set_fragment_texture(LensRectInputIndex::BlurTexture as u64, Some(snapshot));
+            .set_fragment_texture(LensRectInputIndex::BlurPyramid as u64, Some(pyramid));
         command_encoder.set_fragment_sampler_state(
             LensRectInputIndex::BlurSampler as u64,
+            Some(&self.blur_sampler),
+        );
+
+        command_encoder.draw_primitives_instanced(
+            metal::MTLPrimitiveType::Triangle,
+            0,
+            6,
+            rects.len() as u64,
+        );
+        *instance_offset = after_shapes;
+        true
+    }
+
+    fn draw_mirror_rects(
+        &self,
+        rects: &[MirrorRect],
+        scene_blur_params: SceneBlurParams,
+        instance_buffer: &mut InstanceBuffer,
+        instance_offset: &mut usize,
+        viewport_size: Size<DevicePixels>,
+        command_encoder: &metal::RenderCommandEncoderRef,
+    ) -> bool {
+        if rects.is_empty() {
+            return true;
+        }
+        let Some(ref pyramid) = self.blur_pyramid_texture else {
+            return false;
+        };
+        align_offset(instance_offset);
+
+        command_encoder.set_render_pipeline_state(&self.mirror_rect_pipeline_state);
+        command_encoder.set_vertex_buffer(
+            MirrorRectInputIndex::Vertices as u64,
+            Some(&self.unit_vertices),
+            0,
+        );
+        command_encoder.set_vertex_buffer(
+            MirrorRectInputIndex::Rects as u64,
+            Some(&instance_buffer.metal_buffer),
+            *instance_offset as u64,
+        );
+        command_encoder.set_fragment_buffer(
+            MirrorRectInputIndex::Rects as u64,
+            Some(&instance_buffer.metal_buffer),
+            *instance_offset as u64,
+        );
+        command_encoder.set_vertex_bytes(
+            MirrorRectInputIndex::ViewportSize as u64,
+            mem::size_of_val(&viewport_size) as u64,
+            &viewport_size as *const Size<DevicePixels> as *const _,
+        );
+        command_encoder.set_fragment_bytes(
+            MirrorRectInputIndex::ViewportSize as u64,
+            mem::size_of_val(&viewport_size) as u64,
+            &viewport_size as *const Size<DevicePixels> as *const _,
+        );
+        command_encoder.set_fragment_bytes(
+            MirrorRectInputIndex::SceneBlurParams as u64,
+            mem::size_of::<SceneBlurParams>() as u64,
+            &scene_blur_params as *const SceneBlurParams as *const _,
+        );
+        command_encoder
+            .set_fragment_texture(MirrorRectInputIndex::BlurPyramid as u64, Some(pyramid));
+        command_encoder.set_fragment_sampler_state(
+            MirrorRectInputIndex::BlurSampler as u64,
             Some(&self.blur_sampler),
         );
 
@@ -1647,10 +1905,9 @@ impl MetalRenderer {
         if next_offset > instance_buffer.size {
             return false;
         }
-        let buffer_contents =
-            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
         unsafe {
-            ptr::copy_nonoverlapping(rects.as_ptr() as *const u8, buffer_contents, bytes_len);
+            let dst = (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset);
+            ptr::copy_nonoverlapping(rects.as_ptr() as *const u8, dst, bytes_len);
         }
 
         command_encoder.draw_primitives_instanced(
@@ -2199,8 +2456,12 @@ enum BlurRectInputIndex {
     Vertices = 0,
     Rects = 1,
     ViewportSize = 2,
-    BlurTexture = 3,
+    /// Mipmapped pyramid: mip 0 is un-blurred, each subsequent mip is a
+    /// Kawase downsample step. The fragment shader picks a fractional
+    /// LOD based on per-pixel target blur radius.
+    BlurPyramid = 3,
     BlurSampler = 4,
+    SceneBlurParams = 5,
 }
 
 #[repr(C)]
@@ -2208,8 +2469,37 @@ enum LensRectInputIndex {
     Vertices = 0,
     Rects = 1,
     ViewportSize = 2,
-    BlurTexture = 3,
+    BlurPyramid = 3,
     BlurSampler = 4,
+    Shapes = 5,
+    SceneBlurParams = 6,
+}
+
+#[repr(C)]
+enum MirrorRectInputIndex {
+    Vertices = 0,
+    Rects = 1,
+    ViewportSize = 2,
+    BlurPyramid = 3,
+    BlurSampler = 4,
+    SceneBlurParams = 5,
+}
+
+/// Scene-wide blur parameters that the gradient-blur shaders use to
+/// compute a per-pixel mip level into the preserved downsample pyramid.
+/// Written once per frame and bound to every blur-consuming pipeline.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct SceneBlurParams {
+    /// Maximum `blur_radius` anywhere in the scene (see
+    /// `Scene::max_blur_radius`). The per-pixel `target_radius / max`
+    /// ratio becomes the `strength` input to the log2 mip-level formula.
+    max_blur_radius: f32,
+    /// Number of Kawase downsample passes actually run this frame, as an
+    /// `f32` for the shader's `log2(strength)` clamping math. Matches
+    /// `Scene::max_blur_kernel_levels`.
+    kernel_levels: f32,
+    _pad: [f32; 2],
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -2279,5 +2569,6 @@ mod tests {
         let _ = renderer.blur_upsample_pipeline_state.as_ptr();
         let _ = renderer.blur_rect_pipeline_state.as_ptr();
         let _ = renderer.lens_rect_pipeline_state.as_ptr();
+        let _ = renderer.mirror_rect_pipeline_state.as_ptr();
     }
 }

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -49,8 +49,9 @@ pub(crate) unsafe fn new_renderer(
     _native_view: *mut c_void,
     _bounds: gpui::Size<f32>,
     transparent: bool,
+    enable_frame_sampling: bool,
 ) -> Renderer {
-    MetalRenderer::new(context, transparent)
+    MetalRenderer::new(context, transparent, enable_frame_sampling)
 }
 
 pub(crate) struct InstanceBufferPool {
@@ -114,6 +115,10 @@ pub(crate) struct MetalRenderer {
     is_apple_gpu: bool,
     is_unified_memory: bool,
     presents_with_transaction: bool,
+    /// True when the layer was configured with `framebuffer_only(false)`,
+    /// which is required to sample the framebuffer inside BlurRect /
+    /// LensRect draws. When false those primitives skip rendering.
+    frame_sampling_enabled: bool,
     /// For headless rendering, tracks whether output should be opaque
     opaque: bool,
     command_queue: CommandQueue,
@@ -159,8 +164,21 @@ pub struct PathRasterizationVertex {
 }
 
 impl MetalRenderer {
-    /// Creates a new MetalRenderer with a CAMetalLayer for window-based rendering.
-    pub fn new(instance_buffer_pool: Arc<Mutex<InstanceBufferPool>>, transparent: bool) -> Self {
+    /// Creates a new MetalRenderer with a CAMetalLayer for window-based
+    /// rendering.
+    ///
+    /// `enable_frame_sampling` controls whether the drawable is configured
+    /// so the blit encoder can sample it as the input of the BlurRect /
+    /// LensRect dual-Kawase snapshot. It forces `framebuffer_only(false)`
+    /// for the lifetime of the layer, which disables tile-memory
+    /// optimizations and regresses per-frame cost for windows that never
+    /// paint a blur/lens primitive. Enable it only for windows that
+    /// actually use those primitives.
+    pub fn new(
+        instance_buffer_pool: Arc<Mutex<InstanceBufferPool>>,
+        transparent: bool,
+        enable_frame_sampling: bool,
+    ) -> Self {
         let device = Self::create_device();
 
         let layer = metal::MetalLayer::new();
@@ -170,10 +188,14 @@ impl MetalRenderer {
         // https://developer.apple.com/documentation/metal/managing-your-game-window-for-metal-in-macos
         layer.set_opaque(!transparent);
         layer.set_maximum_drawable_count(3);
-        // Disabled so the blit encoder can read the drawable as the input of
-        // the BlurRect/LensRect dual-Kawase snapshot (`snapshot_and_blur_frame`).
-        // Also enables visual tests to capture screenshots without ScreenCaptureKit.
-        layer.set_framebuffer_only(false);
+        let frame_sampling_enabled = enable_frame_sampling || cfg!(any(test, feature = "test-support"));
+        if frame_sampling_enabled {
+            // Required so `snapshot_and_blur_frame` can read the drawable
+            // (and so visual tests can capture screenshots without
+            // ScreenCaptureKit). Disables on-chip tile-memory
+            // optimizations for this layer.
+            layer.set_framebuffer_only(false);
+        }
         unsafe {
             let _: () = msg_send![&*layer, setAllowsNextDrawableTimeout: NO];
             let _: () = msg_send![&*layer, setNeedsDisplayOnBoundsChange: YES];
@@ -184,7 +206,13 @@ impl MetalRenderer {
             ];
         }
 
-        Self::new_internal(device, Some(layer), !transparent, instance_buffer_pool)
+        Self::new_internal(
+            device,
+            Some(layer),
+            !transparent,
+            frame_sampling_enabled,
+            instance_buffer_pool,
+        )
     }
 
     /// Creates a new headless MetalRenderer for offscreen rendering without a window.
@@ -194,7 +222,7 @@ impl MetalRenderer {
     #[cfg(any(test, feature = "test-support"))]
     pub fn new_headless(instance_buffer_pool: Arc<Mutex<InstanceBufferPool>>) -> Self {
         let device = Self::create_device();
-        Self::new_internal(device, None, true, instance_buffer_pool)
+        Self::new_internal(device, None, true, true, instance_buffer_pool)
     }
 
     fn create_device() -> metal::Device {
@@ -223,6 +251,7 @@ impl MetalRenderer {
         device: metal::Device,
         layer: Option<metal::MetalLayer>,
         opaque: bool,
+        frame_sampling_enabled: bool,
         instance_buffer_pool: Arc<Mutex<InstanceBufferPool>>,
     ) -> Self {
         #[cfg(feature = "runtime_shaders")]
@@ -386,6 +415,7 @@ impl MetalRenderer {
             device,
             layer,
             presents_with_transaction: false,
+            frame_sampling_enabled,
             is_apple_gpu,
             is_unified_memory,
             opaque,
@@ -932,7 +962,7 @@ impl MetalRenderer {
                 PrimitiveBatch::SubpixelSprites { .. } => unreachable!(),
                 PrimitiveBatch::BlurRects(range) => {
                     let rects = &scene.blur_rects[range];
-                    if rects.is_empty() {
+                    if rects.is_empty() || !self.frame_sampling_enabled {
                         true
                     } else {
                         command_encoder.end_encoding();
@@ -961,7 +991,7 @@ impl MetalRenderer {
                 }
                 PrimitiveBatch::LensRects(range) => {
                     let rects = &scene.lens_rects[range];
-                    if rects.is_empty() {
+                    if rects.is_empty() || !self.frame_sampling_enabled {
                         true
                     } else {
                         command_encoder.end_encoding();

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -27,7 +27,12 @@ use metal::{
 use objc::{self, msg_send, sel, sel_impl};
 use parking_lot::Mutex;
 
-use std::{cell::Cell, ffi::c_void, mem, ptr, sync::Arc};
+use std::{
+    cell::Cell,
+    ffi::c_void,
+    mem, ptr,
+    sync::{Arc, OnceLock},
+};
 
 // Exported to metal
 pub(crate) type PointF = gpui::Point<f32>;
@@ -39,6 +44,18 @@ const SHADERS_SOURCE_FILE: &str = include_str!(concat!(env!("OUT_DIR"), "/stitch
 // Use 4x MSAA, all devices support it.
 // https://developer.apple.com/documentation/metal/mtldevice/1433355-supportstexturesamplecount
 const PATH_SAMPLE_COUNT: u32 = 4;
+
+static FRAME_SAMPLING_DISABLED_WARNED: OnceLock<()> = OnceLock::new();
+
+fn warn_frame_sampling_disabled() {
+    if FRAME_SAMPLING_DISABLED_WARNED.set(()).is_ok() {
+        log::warn!(
+            "Skipping BlurRect/LensRect/MirrorRect: Metal renderer was constructed \
+             with enable_frame_sampling=false. Re-create the window with frame \
+             sampling enabled to paint these primitives."
+        );
+    }
+}
 
 pub(crate) type Context = Arc<Mutex<InstanceBufferPool>>;
 pub(crate) type Renderer = MetalRenderer;
@@ -139,30 +156,23 @@ pub(crate) struct MetalRenderer {
     path_intermediate_msaa_texture: Option<metal::Texture>,
     path_sample_count: u32,
     blur_downsample_pipeline_state: metal::RenderPipelineState,
-    blur_upsample_pipeline_state: metal::RenderPipelineState,
     blur_rect_pipeline_state: metal::RenderPipelineState,
     lens_rect_pipeline_state: metal::RenderPipelineState,
     mirror_rect_pipeline_state: metal::RenderPipelineState,
     blur_sampler: metal::SamplerState,
-    /// Dual-Kawase scratch chain. `blur_chain_textures[0]` is surface-sized
-    /// and receives the framebuffer snapshot; each subsequent level is
-    /// half-sized. `BlurEffect::kernel_levels` selects the depth used per
-    /// frame (1..=5). The upsample phase overwrites `chain[0..N-1]`, so
-    /// fragment shaders sample `blur_pyramid_texture` for intermediate
-    /// blur radii, not the chain.
-    blur_chain_textures: [Option<metal::Texture>; BLUR_CHAIN_LEVELS],
-    /// Preserved downsample pyramid: a single mipmapped texture where mip
-    /// 0 is the un-blurred framebuffer snapshot and each subsequent mip is
-    /// the Kawase-downsample result of the previous level. Written once
-    /// per frame after the Kawase downsample loop (before upsample would
-    /// overwrite the chain). Fragment shaders sample this with
+    /// Downsample pyramid: a single mipmapped texture where mip 0 is the
+    /// un-blurred framebuffer snapshot and each subsequent mip holds the
+    /// Kawase-downsample result of the previous level. Written in-place
+    /// by `snapshot_and_blur_frame` using per-mip texture views for the
+    /// sampled input and `RenderPassColorAttachmentDescriptor::set_level`
+    /// for the output. Fragment shaders sample this with
     /// `textureSampleLevel` at fractional LOD to produce a per-pixel
     /// variable-radius blur.
     blur_pyramid_texture: Option<metal::Texture>,
 }
 
-/// Maximum blur chain depth (`kernel_levels` is clamped to this).
-const BLUR_CHAIN_LEVELS: usize = 6;
+/// Maximum blur pyramid depth (`kernel_levels` is clamped to this).
+const BLUR_PYRAMID_LEVELS: usize = 6;
 /// Reference blur radius. `BlurEffect::radius` scales the Kawase offset
 /// multiplier linearly relative to this.
 const BLUR_REFERENCE_RADIUS_PX: f32 = 20.0;
@@ -392,14 +402,6 @@ impl MetalRenderer {
             "blur_downsample_fragment",
             MTLPixelFormat::BGRA8Unorm,
         );
-        let blur_upsample_pipeline_state = build_blur_io_pipeline_state(
-            &device,
-            &library,
-            "blur_upsample",
-            "blur_fullscreen_vertex",
-            "blur_upsample_fragment",
-            MTLPixelFormat::BGRA8Unorm,
-        );
         let blur_rect_pipeline_state = build_pipeline_state(
             &device,
             &library,
@@ -467,12 +469,10 @@ impl MetalRenderer {
             path_intermediate_msaa_texture: None,
             path_sample_count: PATH_SAMPLE_COUNT,
             blur_downsample_pipeline_state,
-            blur_upsample_pipeline_state,
             blur_rect_pipeline_state,
             lens_rect_pipeline_state,
             mirror_rect_pipeline_state,
             blur_sampler,
-            blur_chain_textures: Default::default(),
             blur_pyramid_texture: None,
         }
     }
@@ -522,9 +522,7 @@ impl MetalRenderer {
         if size.width.0 <= 0 || size.height.0 <= 0 {
             self.path_intermediate_texture = None;
             self.path_intermediate_msaa_texture = None;
-            for slot in &mut self.blur_chain_textures {
-                *slot = None;
-            }
+            self.blur_pyramid_texture = None;
             return;
         }
 
@@ -556,37 +554,31 @@ impl MetalRenderer {
         }
 
         if self.frame_sampling_enabled {
-            for level in 0..BLUR_CHAIN_LEVELS {
-                let width = (size.width.0 as u64).max(1) >> level;
-                let height = (size.height.0 as u64).max(1) >> level;
-                let width = width.max(1);
-                let height = height.max(1);
-
-                let descriptor = metal::TextureDescriptor::new();
-                descriptor.set_width(width);
-                descriptor.set_height(height);
-                descriptor.set_pixel_format(metal::MTLPixelFormat::BGRA8Unorm);
-                descriptor.set_storage_mode(metal::MTLStorageMode::Private);
-                descriptor.set_usage(
-                    metal::MTLTextureUsage::RenderTarget | metal::MTLTextureUsage::ShaderRead,
-                );
-                self.blur_chain_textures[level] = Some(self.device.new_texture(&descriptor));
-            }
-
             let width = (size.width.0 as u64).max(1);
             let height = (size.height.0 as u64).max(1);
+            // Clamp the mip count to what the surface size actually supports:
+            // a 16x16 surface can only host 5 mips, not 6. Metal rejects the
+            // descriptor if we ask for more than min(log2(width), log2(height))
+            // mip levels and returns nil, which subsequent blit / shader
+            // binds then dereference.
+            let min_dim = width.min(height);
+            let max_mips = 64 - min_dim.leading_zeros() as u64;
+            let pyramid_mip_count = (BLUR_PYRAMID_LEVELS as u64).min(max_mips);
             let descriptor = metal::TextureDescriptor::new();
             descriptor.set_width(width);
             descriptor.set_height(height);
             descriptor.set_pixel_format(metal::MTLPixelFormat::BGRA8Unorm);
-            descriptor.set_mipmap_level_count(BLUR_CHAIN_LEVELS as u64);
+            descriptor.set_mipmap_level_count(pyramid_mip_count);
             descriptor.set_storage_mode(metal::MTLStorageMode::Private);
-            descriptor.set_usage(metal::MTLTextureUsage::ShaderRead);
+            // `RenderTarget` so the downsample render passes can write mips
+            // 1..N directly via `color_attachment.set_level`. `ShaderRead`
+            // for both the per-pass input view and the fragment shaders'
+            // fractional-LOD sampling.
+            descriptor.set_usage(
+                metal::MTLTextureUsage::RenderTarget | metal::MTLTextureUsage::ShaderRead,
+            );
             self.blur_pyramid_texture = Some(self.device.new_texture(&descriptor));
         } else {
-            for slot in &mut self.blur_chain_textures {
-                *slot = None;
-            }
             self.blur_pyramid_texture = None;
         }
     }
@@ -1031,7 +1023,10 @@ impl MetalRenderer {
                 PrimitiveBatch::SubpixelSprites { .. } => unreachable!(),
                 PrimitiveBatch::BlurRects(range) => {
                     let rects = &scene.blur_rects[range];
-                    if rects.is_empty() || !self.frame_sampling_enabled {
+                    if rects.is_empty() {
+                        true
+                    } else if !self.frame_sampling_enabled {
+                        warn_frame_sampling_disabled();
                         true
                     } else {
                         command_encoder.end_encoding();
@@ -1074,7 +1069,10 @@ impl MetalRenderer {
                 }
                 PrimitiveBatch::LensRects(range) => {
                     let rects = &scene.lens_rects[range];
-                    if rects.is_empty() || !self.frame_sampling_enabled {
+                    if rects.is_empty() {
+                        true
+                    } else if !self.frame_sampling_enabled {
+                        warn_frame_sampling_disabled();
                         true
                     } else {
                         command_encoder.end_encoding();
@@ -1118,7 +1116,10 @@ impl MetalRenderer {
                 }
                 PrimitiveBatch::MirrorRects(range) => {
                     let rects = &scene.mirror_rects[range];
-                    if rects.is_empty() || !self.frame_sampling_enabled {
+                    if rects.is_empty() {
+                        true
+                    } else if !self.frame_sampling_enabled {
+                        warn_frame_sampling_disabled();
                         true
                     } else {
                         command_encoder.end_encoding();
@@ -1128,11 +1129,14 @@ impl MetalRenderer {
                         let did_snapshot = if blur_snapshot_valid {
                             true
                         } else {
-                            let levels = blur_kernel_levels.max(1);
+                            // `snapshot_and_blur_frame` accepts `levels == 0`
+                            // and skips the Kawase passes; use that fast path
+                            // when no blur-consuming primitive in the scene
+                            // asked for a blur radius.
                             let ok = self.snapshot_and_blur_frame(
                                 texture,
                                 viewport_size,
-                                levels,
+                                blur_kernel_levels,
                                 blur_offset_multiplier,
                                 command_buffer,
                             );
@@ -1508,31 +1512,28 @@ impl MetalRenderer {
         if viewport_size.width.0 <= 0 || viewport_size.height.0 <= 0 {
             return false;
         }
-        let kernel_levels = kernel_levels.clamp(1, (BLUR_CHAIN_LEVELS - 1) as u32) as usize;
-
-        // All chain levels we need must be populated. Any None means the
-        // renderer was initialized without `enable_frame_sampling`.
-        for level in 0..=kernel_levels {
-            if self.blur_chain_textures[level].is_none() {
-                return false;
-            }
-        }
-
-        let snapshot = self.blur_chain_textures[0]
-            .as_ref()
-            .expect("chain level 0 checked above");
         let Some(ref pyramid) = self.blur_pyramid_texture else {
             return false;
         };
+        let pyramid_mip_count = pyramid.mipmap_level_count() as usize;
 
+        // `kernel_levels == 0` means no primitive in the scene actually
+        // requested blur (e.g., mirror-only batches with zero radius);
+        // skip the Kawase passes entirely and just snapshot mip 0. The
+        // pyramid may have fewer mips than requested on small surfaces
+        // (see `update_path_intermediate_textures`'s clamp), so also cap
+        // to what the pyramid can host.
+        let kernel_levels = (kernel_levels as usize)
+            .min(BLUR_PYRAMID_LEVELS - 1)
+            .min(pyramid_mip_count.saturating_sub(1));
+
+        // Initial snapshot: swapchain → pyramid mip 0.
         let blit = command_buffer.new_blit_command_encoder();
         let full_size = metal::MTLSize {
             width: texture.width(),
             height: texture.height(),
             depth: 1,
         };
-        // Mip 0 of the pyramid is the un-blurred framebuffer; the Kawase
-        // chain runs in parallel on `blur_chain_textures`.
         blit.copy_from_texture(
             texture,
             0,
@@ -1544,32 +1545,27 @@ impl MetalRenderer {
             0,
             metal::MTLOrigin { x: 0, y: 0, z: 0 },
         );
-        blit.copy_from_texture(
-            texture,
-            0,
-            0,
-            metal::MTLOrigin { x: 0, y: 0, z: 0 },
-            full_size,
-            snapshot,
-            0,
-            0,
-            metal::MTLOrigin { x: 0, y: 0, z: 0 },
-        );
         blit.end_encoding();
 
+        // Kawase downsample: each pass samples pyramid mip `i` (via a
+        // single-mip texture view) and renders into pyramid mip `i + 1`
+        // (via `color_attachment.set_level`). Different subresources of
+        // the same texture, which Metal sequences with the implicit
+        // dependency barriers between render command encoders.
         for i in 0..kernel_levels {
-            let src = self.blur_chain_textures[i]
-                .as_ref()
-                .expect("chain level checked above");
-            let dst = self.blur_chain_textures[i + 1]
-                .as_ref()
-                .expect("chain level checked above");
+            let src_view = pyramid.new_texture_view_from_slice(
+                pyramid.pixel_format(),
+                metal::MTLTextureType::D2,
+                NSRange::new(i as u64, 1),
+                NSRange::new(0, 1),
+            );
             let src_w = ((viewport_size.width.0 as f32) * 0.5f32.powi(i as i32)).max(1.0);
             let src_h = ((viewport_size.height.0 as f32) * 0.5f32.powi(i as i32)).max(1.0);
             self.run_blur_pass(
                 command_buffer,
-                src,
-                dst,
+                &src_view,
+                pyramid,
+                (i + 1) as u64,
                 &self.blur_downsample_pipeline_state,
                 BlurParams {
                     viewport_size: [src_w, src_h],
@@ -1579,58 +1575,6 @@ impl MetalRenderer {
             );
         }
 
-        // Preserve the downsample chain into pyramid mip levels before the
-        // upsample loop overwrites `chain[0..N-1]`. Each `chain[i]` is the
-        // /2^i-sized result of `i` Kawase downsample passes, which maps to
-        // pyramid mip level `i`.
-        let preserve_blit = command_buffer.new_blit_command_encoder();
-        for i in 1..=kernel_levels {
-            let src = self.blur_chain_textures[i]
-                .as_ref()
-                .expect("chain level checked above");
-            let width = ((viewport_size.width.0 as u64) >> i).max(1);
-            let height = ((viewport_size.height.0 as u64) >> i).max(1);
-            preserve_blit.copy_from_texture(
-                src,
-                0,
-                0,
-                metal::MTLOrigin { x: 0, y: 0, z: 0 },
-                metal::MTLSize {
-                    width,
-                    height,
-                    depth: 1,
-                },
-                pyramid,
-                0,
-                i as u64,
-                metal::MTLOrigin { x: 0, y: 0, z: 0 },
-            );
-        }
-        preserve_blit.end_encoding();
-
-        for step in 0..kernel_levels {
-            let src_level = kernel_levels - step;
-            let dst_level = src_level - 1;
-            let src = self.blur_chain_textures[src_level]
-                .as_ref()
-                .expect("chain level checked above");
-            let dst = self.blur_chain_textures[dst_level]
-                .as_ref()
-                .expect("chain level checked above");
-            let src_w = ((viewport_size.width.0 as f32) * 0.5f32.powi(src_level as i32)).max(1.0);
-            let src_h = ((viewport_size.height.0 as f32) * 0.5f32.powi(src_level as i32)).max(1.0);
-            self.run_blur_pass(
-                command_buffer,
-                src,
-                dst,
-                &self.blur_upsample_pipeline_state,
-                BlurParams {
-                    viewport_size: [src_w, src_h],
-                    offset_multiplier,
-                    pad: 0.0,
-                },
-            );
-        }
         true
     }
 
@@ -1639,12 +1583,14 @@ impl MetalRenderer {
         command_buffer: &metal::CommandBufferRef,
         input: &metal::TextureRef,
         output: &metal::TextureRef,
+        output_mip_level: u64,
         pipeline: &metal::RenderPipelineStateRef,
         params: BlurParams,
     ) {
         let descriptor = metal::RenderPassDescriptor::new();
         let color_attachment = descriptor.color_attachments().object_at(0).unwrap();
         color_attachment.set_texture(Some(output));
+        color_attachment.set_level(output_mip_level);
         color_attachment.set_load_action(metal::MTLLoadAction::DontCare);
         color_attachment.set_store_action(metal::MTLStoreAction::Store);
 
@@ -1680,6 +1626,20 @@ impl MetalRenderer {
             return false;
         };
         align_offset(instance_offset);
+
+        // Bounds-check and copy the instance data before mutating the
+        // encoder: an overflow early-return otherwise leaves pipeline /
+        // buffer / texture state dirtied for a draw that never runs.
+        let bytes_len = mem::size_of_val(rects);
+        let next_offset = *instance_offset + bytes_len;
+        if next_offset > instance_buffer.size {
+            return false;
+        }
+        let buffer_contents =
+            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
+        unsafe {
+            ptr::copy_nonoverlapping(rects.as_ptr() as *const u8, buffer_contents, bytes_len);
+        }
 
         command_encoder.set_render_pipeline_state(&self.blur_rect_pipeline_state);
         command_encoder.set_vertex_buffer(
@@ -1718,17 +1678,6 @@ impl MetalRenderer {
             BlurRectInputIndex::BlurSampler as u64,
             Some(&self.blur_sampler),
         );
-
-        let bytes_len = mem::size_of_val(rects);
-        let next_offset = *instance_offset + bytes_len;
-        if next_offset > instance_buffer.size {
-            return false;
-        }
-        let buffer_contents =
-            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
-        unsafe {
-            ptr::copy_nonoverlapping(rects.as_ptr() as *const u8, buffer_contents, bytes_len);
-        }
 
         command_encoder.draw_primitives_instanced(
             metal::MTLPrimitiveType::Triangle,
@@ -1862,6 +1811,17 @@ impl MetalRenderer {
         };
         align_offset(instance_offset);
 
+        // Bounds-check and copy before touching the encoder state.
+        let bytes_len = mem::size_of_val(rects);
+        let next_offset = *instance_offset + bytes_len;
+        if next_offset > instance_buffer.size {
+            return false;
+        }
+        unsafe {
+            let dst = (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset);
+            ptr::copy_nonoverlapping(rects.as_ptr() as *const u8, dst, bytes_len);
+        }
+
         command_encoder.set_render_pipeline_state(&self.mirror_rect_pipeline_state);
         command_encoder.set_vertex_buffer(
             MirrorRectInputIndex::Vertices as u64,
@@ -1899,16 +1859,6 @@ impl MetalRenderer {
             MirrorRectInputIndex::BlurSampler as u64,
             Some(&self.blur_sampler),
         );
-
-        let bytes_len = mem::size_of_val(rects);
-        let next_offset = *instance_offset + bytes_len;
-        if next_offset > instance_buffer.size {
-            return false;
-        }
-        unsafe {
-            let dst = (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset);
-            ptr::copy_nonoverlapping(rects.as_ptr() as *const u8, dst, bytes_len);
-        }
 
         command_encoder.draw_primitives_instanced(
             metal::MTLPrimitiveType::Triangle,
@@ -2557,7 +2507,10 @@ mod tests {
     #[test]
     fn pipeline_creation_smoke() {
         if metal::Device::system_default().is_none() {
-            // No Metal device (some CI runners). Nothing to verify here.
+            if std::env::var("CI").is_ok() {
+                panic!("pipeline_creation_smoke requires a Metal device on CI");
+            }
+            eprintln!("skipping pipeline_creation_smoke: no Metal device available");
             return;
         }
         let instance_buffer_pool = Arc::new(Mutex::new(InstanceBufferPool::default()));
@@ -2566,7 +2519,6 @@ mod tests {
         // Touch each new pipeline field so a missing entry point or a
         // linker failure surfaces here rather than on the first draw.
         let _ = renderer.blur_downsample_pipeline_state.as_ptr();
-        let _ = renderer.blur_upsample_pipeline_state.as_ptr();
         let _ = renderer.blur_rect_pipeline_state.as_ptr();
         let _ = renderer.lens_rect_pipeline_state.as_ptr();
         let _ = renderer.mirror_rect_pipeline_state.as_ptr();

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -992,7 +992,7 @@ impl MetalRenderer {
             if !ok {
                 command_encoder.end_encoding();
                 anyhow::bail!(
-                    "scene too large: {} paths, {} shadows, {} quads, {} underlines, {} mono, {} poly, {} surfaces",
+                    "scene too large: {} paths, {} shadows, {} quads, {} underlines, {} mono, {} poly, {} surfaces, {} blur rects, {} lens rects",
                     scene.paths.len(),
                     scene.shadows.len(),
                     scene.quads.len(),
@@ -1000,6 +1000,8 @@ impl MetalRenderer {
                     scene.monochrome_sprites.len(),
                     scene.polychrome_sprites.len(),
                     scene.surfaces.len(),
+                    scene.blur_rects.len(),
+                    scene.lens_rects.len(),
                 );
             }
         }

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -2253,3 +2253,31 @@ impl gpui::PlatformHeadlessRenderer for MetalHeadlessRenderer {
         self.renderer.sprite_atlas().clone()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Constructs a headless `MetalRenderer` and asserts every pipeline
+    /// state allocated during `new_internal` is non-null. This is the
+    /// Metal-side analogue of `pipeline_creation_smoke` in the wgpu
+    /// crate: a broken entry-point name in `shaders.metal` (or missing
+    /// `LensRectInputIndex` binding slot) fails the test at construct
+    /// time rather than the first real draw.
+    #[test]
+    fn pipeline_creation_smoke() {
+        if metal::Device::system_default().is_none() {
+            // No Metal device (some CI runners). Nothing to verify here.
+            return;
+        }
+        let instance_buffer_pool = Arc::new(Mutex::new(InstanceBufferPool::default()));
+        let renderer = MetalRenderer::new_headless(instance_buffer_pool);
+
+        // Touch each new pipeline field so a missing entry point or a
+        // linker failure surfaces here rather than on the first draw.
+        let _ = renderer.blur_downsample_pipeline_state.as_ptr();
+        let _ = renderer.blur_upsample_pipeline_state.as_ptr();
+        let _ = renderer.blur_rect_pipeline_state.as_ptr();
+        let _ = renderer.lens_rect_pipeline_state.as_ptr();
+    }
+}

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -883,6 +883,11 @@ impl MetalRenderer {
         let blur_kernel_levels = scene.max_blur_kernel_levels();
         let blur_offset_multiplier =
             (scene.max_blur_radius().0 / BLUR_REFERENCE_RADIUS_PX).clamp(0.1, 4.0);
+        // Tracks whether the Kawase chain already reflects the drawable
+        // contents since the last non-blur batch. Reset to `false` at
+        // frame start and whenever any other primitive writes to the
+        // drawable.
+        let mut blur_snapshot_valid = false;
 
         let mut command_encoder = new_command_encoder_for_texture(
             command_buffer,
@@ -895,6 +900,10 @@ impl MetalRenderer {
         );
 
         for batch in scene.batches() {
+            let is_blur_batch = matches!(
+                batch,
+                PrimitiveBatch::BlurRects(_) | PrimitiveBatch::LensRects(_)
+            );
             let ok = match batch {
                 PrimitiveBatch::Shadows(range) => self.draw_shadows(
                     &scene.shadows[range],
@@ -982,13 +991,21 @@ impl MetalRenderer {
                         true
                     } else {
                         command_encoder.end_encoding();
-                        let did_snapshot = self.snapshot_and_blur_frame(
-                            texture,
-                            viewport_size,
-                            blur_kernel_levels,
-                            blur_offset_multiplier,
-                            command_buffer,
-                        );
+                        let did_snapshot = if blur_snapshot_valid {
+                            true
+                        } else {
+                            let ok = self.snapshot_and_blur_frame(
+                                texture,
+                                viewport_size,
+                                blur_kernel_levels,
+                                blur_offset_multiplier,
+                                command_buffer,
+                            );
+                            if ok {
+                                blur_snapshot_valid = true;
+                            }
+                            ok
+                        };
                         command_encoder = new_command_encoder_for_texture(
                             command_buffer,
                             texture,
@@ -1016,13 +1033,21 @@ impl MetalRenderer {
                         true
                     } else {
                         command_encoder.end_encoding();
-                        let did_snapshot = self.snapshot_and_blur_frame(
-                            texture,
-                            viewport_size,
-                            blur_kernel_levels,
-                            blur_offset_multiplier,
-                            command_buffer,
-                        );
+                        let did_snapshot = if blur_snapshot_valid {
+                            true
+                        } else {
+                            let ok = self.snapshot_and_blur_frame(
+                                texture,
+                                viewport_size,
+                                blur_kernel_levels,
+                                blur_offset_multiplier,
+                                command_buffer,
+                            );
+                            if ok {
+                                blur_snapshot_valid = true;
+                            }
+                            ok
+                        };
                         command_encoder = new_command_encoder_for_texture(
                             command_buffer,
                             texture,
@@ -1059,6 +1084,10 @@ impl MetalRenderer {
                     scene.blur_rects.len(),
                     scene.lens_rects.len(),
                 );
+            }
+            if !is_blur_batch {
+                // Drawing to the drawable invalidates the cached snapshot.
+                blur_snapshot_valid = false;
             }
         }
 

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -147,7 +147,7 @@ pub(crate) struct MetalRenderer {
 struct BlurParams {
     viewport_size: [f32; 2],
     offset_multiplier: f32,
-    _pad: f32,
+    pad: f32,
 }
 
 #[repr(C)]
@@ -1367,7 +1367,7 @@ impl MetalRenderer {
             BlurParams {
                 viewport_size: full_size,
                 offset_multiplier: 1.0,
-                _pad: 0.0,
+                pad: 0.0,
             },
         );
         self.run_blur_pass(
@@ -1378,7 +1378,7 @@ impl MetalRenderer {
             BlurParams {
                 viewport_size: half_size,
                 offset_multiplier: 1.0,
-                _pad: 0.0,
+                pad: 0.0,
             },
         );
         true

--- a/crates/gpui_macos/src/shaders.metal
+++ b/crates/gpui_macos/src/shaders.metal
@@ -1398,12 +1398,14 @@ fragment float4 blur_rect_fragment(
 struct LensRectVarying {
   uint rect_id [[flat]];
   float4 position [[position]];
+  float2 light_dir [[flat]];
   float clip_distance [[clip_distance]][4];
 };
 
 struct LensRectFragmentInput {
   uint rect_id [[flat]];
   float4 position [[position]];
+  float2 light_dir [[flat]];
 };
 
 vertex LensRectVarying lens_rect_vertex(
@@ -1418,6 +1420,7 @@ vertex LensRectVarying lens_rect_vertex(
   LensRectVarying out;
   out.position = to_device_position(unit_vertex, rect.bounds, viewport_size);
   out.rect_id = rect_id;
+  out.light_dir = float2(cos(rect.light_angle_radians), sin(rect.light_angle_radians));
   float4 clip = distance_from_clip_rect(unit_vertex, rect.bounds, rect.content_mask.bounds);
   out.clip_distance[0] = clip.x;
   out.clip_distance[1] = clip.y;
@@ -1463,7 +1466,7 @@ fragment float4 lens_rect_fragment(
   float4 tint_rgba = hsla_to_rgba(rect.tint);
   color = float4(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
 
-  float2 light_dir = float2(rect.light_dir.x, rect.light_dir.y);
+  float2 light_dir = input.light_dir;
   float sdf = quad_sdf(input.position.xy, rect.bounds, rect.corner_radii);
   float edge_dist = fabs(sdf);
   float splay_px = max(rect.splay, 1.0);

--- a/crates/gpui_macos/src/shaders.metal
+++ b/crates/gpui_macos/src/shaders.metal
@@ -1321,25 +1321,6 @@ fragment float4 blur_downsample_fragment(
   return float4(blur_encode_srgb(averaged.rgb), averaged.a);
 }
 
-fragment float4 blur_upsample_fragment(
-  BlurFullscreenVarying input [[stage_in]],
-  texture2d<float> blur_input [[texture(BlurIoInputIndex_InputTexture)]],
-  sampler blur_sampler [[sampler(BlurIoInputIndex_InputSampler)]],
-  constant BlurParams *params [[buffer(BlurIoInputIndex_Params)]]
-) {
-  float2 o = 0.5 / params->viewport_size * params->offset_multiplier;
-  float4 color = blur_sample_linear(blur_input, blur_sampler, input.uv + float2(-o.x,  o.y)) * 2.0;
-  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2( o.x,  o.y)) * 2.0;
-  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2(-o.x, -o.y)) * 2.0;
-  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2( o.x, -o.y)) * 2.0;
-  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2(-o.x * 2.0, 0.0));
-  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2( o.x * 2.0, 0.0));
-  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2(0.0, -o.y * 2.0));
-  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2(0.0,  o.y * 2.0));
-  float4 averaged = color / 12.0;
-  return float4(blur_encode_srgb(averaged.rgb), averaged.a);
-}
-
 // --- BlurRect: rounded rect that samples the blurred framebuffer ---
 
 struct BlurRectVarying {
@@ -1386,10 +1367,13 @@ float gradient_target_radius(
   if (dir_len2 < 1e-6) {
     return radius_start;
   }
+  // Normalize inside so the mapping is magnitude-invariant in
+  // `gradient_direction`; keeps the MSL side bit-identical with WGSL.
+  float2 dir = gradient_direction * rsqrt(dir_len2);
   float2 local = frag_pos - float2(bounds.origin.x, bounds.origin.y);
   float2 size_v = float2(bounds.size.width, bounds.size.height);
-  float extent = max(dot(size_v, gradient_direction), 1.0);
-  float t = clamp(dot(local, gradient_direction) / extent, 0.0, 1.0);
+  float extent = max(dot(size_v, dir), 1.0);
+  float t = clamp(dot(local, dir) / extent, 0.0, 1.0);
   return mix(radius_start, radius_end, t);
 }
 
@@ -1518,7 +1502,7 @@ fragment float4 lens_rect_fragment(
   float2 frag_pos = input.position.xy;
   uint shape_count = rect.shape_count;
   if (shape_count == 0u) {
-    discard_fragment();
+    return float4(0.0, 0.0, 0.0, 0.0);
   }
   float blend_k = max(rect.edge_blend_distance, 0.0);
   bool blend_shapes = blend_k > 0.0 && shape_count > 1u;
@@ -1527,11 +1511,14 @@ fragment float4 lens_rect_fragment(
   // attenuation (0 outside the shape's own `content_mask`, 1 inside,
   // with a ~1-pixel feather).
   const float antialias_threshold = 0.5;
+  // Mirror of `MAX_LENS_SHAPES` in shaders.wgsl / MAX_LENS_SHAPES_PER_GROUP
+  // in window.rs; bumping either requires bumping the others in lockstep.
+  constexpr uint MAX_LENS_SHAPES = 8u;
   Corners_ScaledPixels zero_corners = {0.0, 0.0, 0.0, 0.0};
-  float per_shape_sdf[8];
-  float per_shape_mask_attn[8];
-  float2 per_shape_dir[8];
-  float per_shape_norm_dist[8];
+  float per_shape_sdf[MAX_LENS_SHAPES];
+  float per_shape_mask_attn[MAX_LENS_SHAPES];
+  float2 per_shape_dir[MAX_LENS_SHAPES];
+  float per_shape_norm_dist[MAX_LENS_SHAPES];
   float min_sdf = 1e20;
   for (uint i = 0u; i < shape_count; ++i) {
     LensShape s = shapes[rect.shape_offset + i];
@@ -1554,7 +1541,7 @@ fragment float4 lens_rect_fragment(
   }
 
   float union_sdf;
-  float weights[8];
+  float weights[MAX_LENS_SHAPES];
   // Scales the final fragment alpha to fade at per-shape mask boundaries.
   // 1 when every shape is fully inside its own mask (or no mask in play);
   // smoothly decreases as shapes' mask edges cross the fragment.
@@ -1575,7 +1562,7 @@ fragment float4 lens_rect_fragment(
       total_masked += masked;
     }
     if (total_masked < 1e-6) {
-      discard_fragment();
+      return float4(0.0, 0.0, 0.0, 0.0);
     }
     // Softmin value: -k * log(Σ exp(-d_i / k)), shifted by min_d to avoid
     // overflow. Unmasked sum preserves the geometric union outline even
@@ -1583,8 +1570,11 @@ fragment float4 lens_rect_fragment(
     // refraction weights, not the shape boundary itself.
     union_sdf = min_d - blend_k * log(max(total_pre, 1e-6));
     float inv_masked = 1.0 / max(total_masked, 1e-6);
+    // Clamp to [0, 1]: when `total_masked` approaches the 1e-6 floor,
+    // individual weights can scale past 1.0 and blow up the refraction
+    // accumulator. Matches the WGSL side.
     for (uint i = 0u; i < shape_count; ++i) {
-      weights[i] *= inv_masked;
+      weights[i] = clamp(weights[i] * inv_masked, 0.0, 1.0);
     }
     coverage_factor = clamp(total_masked / max(total_pre, 1e-6), 0.0, 1.0);
   } else {
@@ -1603,13 +1593,13 @@ fragment float4 lens_rect_fragment(
     }
     coverage_factor = per_shape_mask_attn[winner];
     if (coverage_factor < 1e-3) {
-      discard_fragment();
+      return float4(0.0, 0.0, 0.0, 0.0);
     }
   }
 
   float aa = saturate(antialias_threshold - union_sdf) * coverage_factor;
   if (aa <= 0.0) {
-    discard_fragment();
+    return float4(0.0, 0.0, 0.0, 0.0);
   }
 
   // Pass 2: weighted refraction offset. The per-shape parabolic distortion
@@ -1618,6 +1608,10 @@ fragment float4 lens_rect_fragment(
   float depth_scale = clamp(rect.depth * 0.01, 0.0, 1.0);
   float2 offset_px = float2(0.0, 0.0);
   float weighted_norm_dist = 0.0;
+  // `weighted_dir` is a weighted *sum* of unit directions, not a unit
+  // vector. Between shapes with opposing centers it shrinks toward zero,
+  // which fades chromatic dispersion in inter-shape seams. Do not
+  // renormalize — matches WGSL.
   float2 weighted_dir = float2(0.0, 0.0);
   for (uint i = 0u; i < shape_count; ++i) {
     float nd = per_shape_norm_dist[i];
@@ -1627,7 +1621,14 @@ fragment float4 lens_rect_fragment(
     weighted_dir += weights[i] * per_shape_dir[i];
   }
   float2 base_uv = frag_pos / viewport_f;
-  float2 refracted_uv = base_uv - offset_px / viewport_f;
+  // Clamp to [0,1]: strong `refraction` on lens rims can push UVs past
+  // the edge. The pyramid sampler is ClampToEdge, but clamp here too so
+  // a future sampler-state change can't silently wrap across the frame.
+  float2 refracted_uv = clamp(
+      base_uv - offset_px / viewport_f,
+      float2(0.0, 0.0),
+      float2(1.0, 1.0)
+  );
   float target_radius = gradient_target_radius(
     frag_pos,
     rect.bounds,
@@ -1719,7 +1720,7 @@ fragment float4 mirror_rect_fragment(
   // Normalized position within the destination rect.
   float2 dest_origin = float2(rect.bounds.origin.x, rect.bounds.origin.y);
   float2 dest_size = max(float2(rect.bounds.size.width, rect.bounds.size.height), float2(1.0));
-  float2 u = clamp((input.position.xy - dest_origin) / dest_size, 0.0, 1.0);
+  float2 u = clamp((input.position.xy - dest_origin) / dest_size, float2(0.0), float2(1.0));
 
   // Flip per axis. MIRROR_AXIS_HORIZONTAL = bit 0, VERTICAL = bit 1.
   if ((rect.mirror_axis & 1u) != 0u) {
@@ -1736,7 +1737,7 @@ fragment float4 mirror_rect_fragment(
   float2 src_uv = src_pos / viewport_f;
   // Reject out-of-viewport samples to transparent.
   if (src_uv.x < 0.0 || src_uv.x > 1.0 || src_uv.y < 0.0 || src_uv.y > 1.0) {
-    return float4(0.0);
+    return float4(0.0, 0.0, 0.0, 0.0);
   }
 
   float target_radius = gradient_target_radius(

--- a/crates/gpui_macos/src/shaders.metal
+++ b/crates/gpui_macos/src/shaders.metal
@@ -1399,6 +1399,7 @@ struct LensRectVarying {
   uint rect_id [[flat]];
   float4 position [[position]];
   float2 light_dir [[flat]];
+  float edge_band [[flat]];
   float clip_distance [[clip_distance]][4];
 };
 
@@ -1406,6 +1407,7 @@ struct LensRectFragmentInput {
   uint rect_id [[flat]];
   float4 position [[position]];
   float2 light_dir [[flat]];
+  float edge_band [[flat]];
 };
 
 vertex LensRectVarying lens_rect_vertex(
@@ -1421,6 +1423,14 @@ vertex LensRectVarying lens_rect_vertex(
   out.position = to_device_position(unit_vertex, rect.bounds, viewport_size);
   out.rect_id = rect_id;
   out.light_dir = float2(cos(rect.light_angle_radians), sin(rect.light_angle_radians));
+  float corner_avg = 0.25 * (
+    rect.corner_radii.top_left
+    + rect.corner_radii.top_right
+    + rect.corner_radii.bottom_right
+    + rect.corner_radii.bottom_left
+  );
+  float splay_px = max(rect.splay, 1.0);
+  out.edge_band = max(corner_avg * 0.5, splay_px);
   float4 clip = distance_from_clip_rect(unit_vertex, rect.bounds, rect.content_mask.bounds);
   out.clip_distance[0] = clip.x;
   out.clip_distance[1] = clip.y;
@@ -1439,6 +1449,13 @@ fragment float4 lens_rect_fragment(
   LensRect rect = rects[input.rect_id];
   float2 viewport_f = float2((float)viewport_size->width, (float)viewport_size->height);
 
+  float sdf = quad_sdf(input.position.xy, rect.bounds, rect.corner_radii);
+  const float antialias_threshold = 0.5;
+  float aa = saturate(antialias_threshold - sdf);
+  if (aa <= 0.0) {
+    discard_fragment();
+  }
+
   float2 origin = float2(rect.bounds.origin.x, rect.bounds.origin.y);
   float2 size = float2(rect.bounds.size.width, rect.bounds.size.height);
   float2 center = origin + size * 0.5;
@@ -1455,34 +1472,28 @@ fragment float4 lens_rect_fragment(
   float2 base_uv = input.position.xy / viewport_f;
   float2 refracted_uv = base_uv - offset_px / viewport_f;
 
-  float ca_shift = normalized_dist * rect.dispersion;
-  float2 ca_dir = direction / viewport_f;
   float4 color;
-  color.r = blur_input.sample(blur_sampler, refracted_uv - ca_dir * ca_shift).r;
-  color.g = blur_input.sample(blur_sampler, refracted_uv).g;
-  color.b = blur_input.sample(blur_sampler, refracted_uv + ca_dir * ca_shift).b;
+  if (rect.dispersion > 0.0) {
+    float ca_shift = normalized_dist * rect.dispersion;
+    float2 ca_dir = direction / viewport_f;
+    color.r = blur_input.sample(blur_sampler, refracted_uv - ca_dir * ca_shift).r;
+    color.g = blur_input.sample(blur_sampler, refracted_uv).g;
+    color.b = blur_input.sample(blur_sampler, refracted_uv + ca_dir * ca_shift).b;
+  } else {
+    color = blur_input.sample(blur_sampler, refracted_uv);
+  }
   color.a = 1.0;
 
   float4 tint_rgba = hsla_to_rgba(rect.tint);
   color = float4(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
 
-  float2 light_dir = input.light_dir;
-  float sdf = quad_sdf(input.position.xy, rect.bounds, rect.corner_radii);
-  float edge_dist = fabs(sdf);
-  float splay_px = max(rect.splay, 1.0);
-  float corner_avg = 0.25 * (
-    rect.corner_radii.top_left
-    + rect.corner_radii.top_right
-    + rect.corner_radii.bottom_right
-    + rect.corner_radii.bottom_left
-  );
-  float edge_band = max(corner_avg * 0.5, splay_px);
-  float edge_falloff = smoothstep(edge_band, 0.0, edge_dist);
-  float facing = local_len > 0.001 ? clamp(dot(direction, light_dir), 0.0, 1.0) : 1.0;
-  float edge_glow = edge_falloff * facing * rect.light_intensity;
-  color = color + float4(edge_glow, edge_glow, edge_glow, 0.0);
+  if (rect.light_intensity > 0.0) {
+    float edge_dist = fabs(sdf);
+    float edge_falloff = smoothstep(input.edge_band, 0.0, edge_dist);
+    float facing = local_len > 0.001 ? clamp(dot(direction, input.light_dir), 0.0, 1.0) : 1.0;
+    float edge_glow = edge_falloff * facing * rect.light_intensity;
+    color = color + float4(edge_glow, edge_glow, edge_glow, 0.0);
+  }
 
-  const float antialias_threshold = 0.5;
-  float aa = saturate(antialias_threshold - sdf);
   return float4(color.rgb, color.a * aa);
 }

--- a/crates/gpui_macos/src/shaders.metal
+++ b/crates/gpui_macos/src/shaders.metal
@@ -1258,9 +1258,228 @@ float4 fill_color(Background background,
         
         color = solid_color;
         color.a *= saturate(should_be_colored);
-        break; 
+        break;
     }
   }
 
   return color;
+}
+
+// ============================================================================
+// Dual-Kawase blur inner passes (Marius Bjorge, ARM, SIGGRAPH 2015) and the
+// BlurRect / LensRect composite pipelines. Mirrors the WGSL implementation in
+// `gpui_wgpu/src/blur_io_shaders.wgsl` and the blur/lens entry points in
+// `gpui_wgpu/src/shaders.wgsl`.
+// ============================================================================
+
+struct BlurParams {
+  float2 viewport_size;
+  float offset_multiplier;
+  float pad;
+};
+
+struct BlurFullscreenVarying {
+  float4 position [[position]];
+  float2 uv;
+};
+
+// Fullscreen-triangle vertex shader (3 vertices cover the NDC [-1,1] square).
+vertex BlurFullscreenVarying blur_fullscreen_vertex(uint vertex_id [[vertex_id]]) {
+  BlurFullscreenVarying out;
+  float2 uv = float2(float((vertex_id << 1u) & 2u), float(vertex_id & 2u));
+  out.uv = float2(uv.x, 1.0 - uv.y);
+  out.position = float4(uv * 2.0 - float2(1.0, 1.0), 0.0, 1.0);
+  return out;
+}
+
+static float3 blur_linearize(float3 c) {
+  return pow(c, float3(2.2));
+}
+
+static float3 blur_encode_srgb(float3 c) {
+  return pow(c, float3(1.0 / 2.2));
+}
+
+static float4 blur_sample_linear(texture2d<float> tex, sampler smp, float2 uv) {
+  float4 s = tex.sample(smp, uv);
+  return float4(blur_linearize(s.rgb), s.a);
+}
+
+fragment float4 blur_downsample_fragment(
+  BlurFullscreenVarying input [[stage_in]],
+  texture2d<float> blur_input [[texture(BlurIoInputIndex_InputTexture)]],
+  sampler blur_sampler [[sampler(BlurIoInputIndex_InputSampler)]],
+  constant BlurParams *params [[buffer(BlurIoInputIndex_Params)]]
+) {
+  float2 o = 0.5 / params->viewport_size * params->offset_multiplier;
+  float4 color = blur_sample_linear(blur_input, blur_sampler, input.uv) * 4.0;
+  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2(-o.x, -o.y));
+  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2( o.x, -o.y));
+  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2(-o.x,  o.y));
+  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2( o.x,  o.y));
+  float4 averaged = color / 8.0;
+  return float4(blur_encode_srgb(averaged.rgb), averaged.a);
+}
+
+fragment float4 blur_upsample_fragment(
+  BlurFullscreenVarying input [[stage_in]],
+  texture2d<float> blur_input [[texture(BlurIoInputIndex_InputTexture)]],
+  sampler blur_sampler [[sampler(BlurIoInputIndex_InputSampler)]],
+  constant BlurParams *params [[buffer(BlurIoInputIndex_Params)]]
+) {
+  float2 o = 0.5 / params->viewport_size * params->offset_multiplier;
+  float4 color = blur_sample_linear(blur_input, blur_sampler, input.uv + float2(-o.x,  o.y)) * 2.0;
+  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2( o.x,  o.y)) * 2.0;
+  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2(-o.x, -o.y)) * 2.0;
+  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2( o.x, -o.y)) * 2.0;
+  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2(-o.x * 2.0, 0.0));
+  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2( o.x * 2.0, 0.0));
+  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2(0.0, -o.y * 2.0));
+  color += blur_sample_linear(blur_input, blur_sampler, input.uv + float2(0.0,  o.y * 2.0));
+  float4 averaged = color / 12.0;
+  return float4(blur_encode_srgb(averaged.rgb), averaged.a);
+}
+
+// --- BlurRect: rounded rect that samples the blurred framebuffer ---
+
+struct BlurRectVarying {
+  uint rect_id [[flat]];
+  float4 position [[position]];
+  float clip_distance [[clip_distance]][4];
+};
+
+struct BlurRectFragmentInput {
+  uint rect_id [[flat]];
+  float4 position [[position]];
+};
+
+vertex BlurRectVarying blur_rect_vertex(
+  uint unit_vertex_id [[vertex_id]],
+  uint rect_id [[instance_id]],
+  constant float2 *unit_vertices [[buffer(BlurRectInputIndex_Vertices)]],
+  constant BlurRect *rects [[buffer(BlurRectInputIndex_Rects)]],
+  constant Size_DevicePixels *viewport_size [[buffer(BlurRectInputIndex_ViewportSize)]]
+) {
+  float2 unit_vertex = unit_vertices[unit_vertex_id];
+  BlurRect rect = rects[rect_id];
+  BlurRectVarying out;
+  out.position = to_device_position(unit_vertex, rect.bounds, viewport_size);
+  out.rect_id = rect_id;
+  float4 clip = distance_from_clip_rect(unit_vertex, rect.bounds, rect.content_mask.bounds);
+  out.clip_distance[0] = clip.x;
+  out.clip_distance[1] = clip.y;
+  out.clip_distance[2] = clip.z;
+  out.clip_distance[3] = clip.w;
+  return out;
+}
+
+fragment float4 blur_rect_fragment(
+  BlurRectFragmentInput input [[stage_in]],
+  constant BlurRect *rects [[buffer(BlurRectInputIndex_Rects)]],
+  constant Size_DevicePixels *viewport_size [[buffer(BlurRectInputIndex_ViewportSize)]],
+  texture2d<float> blur_input [[texture(BlurRectInputIndex_BlurTexture)]],
+  sampler blur_sampler [[sampler(BlurRectInputIndex_BlurSampler)]]
+) {
+  BlurRect rect = rects[input.rect_id];
+  float2 viewport_f = float2((float)viewport_size->width, (float)viewport_size->height);
+  float2 fb_uv = input.position.xy / viewport_f;
+  float4 color = blur_input.sample(blur_sampler, fb_uv);
+  float4 tint_rgba = hsla_to_rgba(rect.tint);
+  color = float4(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
+
+  float sdf = quad_sdf(input.position.xy, rect.bounds, rect.corner_radii);
+  const float antialias_threshold = 0.5;
+  float aa = saturate(antialias_threshold - sdf);
+  return float4(color.rgb, color.a * aa);
+}
+
+// --- LensRect: Liquid Glass composite (refraction + CA + Fresnel) ---
+
+struct LensRectVarying {
+  uint rect_id [[flat]];
+  float4 position [[position]];
+  float clip_distance [[clip_distance]][4];
+};
+
+struct LensRectFragmentInput {
+  uint rect_id [[flat]];
+  float4 position [[position]];
+};
+
+vertex LensRectVarying lens_rect_vertex(
+  uint unit_vertex_id [[vertex_id]],
+  uint rect_id [[instance_id]],
+  constant float2 *unit_vertices [[buffer(LensRectInputIndex_Vertices)]],
+  constant LensRect *rects [[buffer(LensRectInputIndex_Rects)]],
+  constant Size_DevicePixels *viewport_size [[buffer(LensRectInputIndex_ViewportSize)]]
+) {
+  float2 unit_vertex = unit_vertices[unit_vertex_id];
+  LensRect rect = rects[rect_id];
+  LensRectVarying out;
+  out.position = to_device_position(unit_vertex, rect.bounds, viewport_size);
+  out.rect_id = rect_id;
+  float4 clip = distance_from_clip_rect(unit_vertex, rect.bounds, rect.content_mask.bounds);
+  out.clip_distance[0] = clip.x;
+  out.clip_distance[1] = clip.y;
+  out.clip_distance[2] = clip.z;
+  out.clip_distance[3] = clip.w;
+  return out;
+}
+
+fragment float4 lens_rect_fragment(
+  LensRectFragmentInput input [[stage_in]],
+  constant LensRect *rects [[buffer(LensRectInputIndex_Rects)]],
+  constant Size_DevicePixels *viewport_size [[buffer(LensRectInputIndex_ViewportSize)]],
+  texture2d<float> blur_input [[texture(LensRectInputIndex_BlurTexture)]],
+  sampler blur_sampler [[sampler(LensRectInputIndex_BlurSampler)]]
+) {
+  LensRect rect = rects[input.rect_id];
+  float2 viewport_f = float2((float)viewport_size->width, (float)viewport_size->height);
+
+  float2 origin = float2(rect.bounds.origin.x, rect.bounds.origin.y);
+  float2 size = float2(rect.bounds.size.width, rect.bounds.size.height);
+  float2 center = origin + size * 0.5;
+  float2 half_size = size * 0.5;
+  float2 local_pos = input.position.xy - center;
+  float local_len = length(local_pos);
+  float2 direction = local_len > 0.001 ? local_pos / max(local_len, 0.0001) : float2(0.0, 0.0);
+  float2 safe_half = max(half_size, float2(1.0, 1.0));
+  float normalized_dist = clamp(length(local_pos / safe_half), 0.0, 1.0);
+
+  float depth_scale = clamp(rect.depth * 0.01, 0.0, 1.0);
+  float distortion = (1.0 - normalized_dist * normalized_dist) * (1.0 + depth_scale);
+  float2 offset_px = distortion * direction * rect.refraction * 0.5;
+  float2 base_uv = input.position.xy / viewport_f;
+  float2 refracted_uv = base_uv - offset_px / viewport_f;
+
+  float ca_shift = normalized_dist * rect.dispersion;
+  float2 ca_dir = direction / viewport_f;
+  float4 color;
+  color.r = blur_input.sample(blur_sampler, refracted_uv - ca_dir * ca_shift).r;
+  color.g = blur_input.sample(blur_sampler, refracted_uv).g;
+  color.b = blur_input.sample(blur_sampler, refracted_uv + ca_dir * ca_shift).b;
+  color.a = 1.0;
+
+  float4 tint_rgba = hsla_to_rgba(rect.tint);
+  color = float4(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
+
+  float2 light_dir = float2(rect.light_dir.x, rect.light_dir.y);
+  float sdf = quad_sdf(input.position.xy, rect.bounds, rect.corner_radii);
+  float edge_dist = fabs(sdf);
+  float splay_px = max(rect.splay, 1.0);
+  float corner_avg = 0.25 * (
+    rect.corner_radii.top_left
+    + rect.corner_radii.top_right
+    + rect.corner_radii.bottom_right
+    + rect.corner_radii.bottom_left
+  );
+  float edge_band = max(corner_avg * 0.5, splay_px);
+  float edge_falloff = smoothstep(edge_band, 0.0, edge_dist);
+  float facing = local_len > 0.001 ? clamp(dot(direction, light_dir), 0.0, 1.0) : 1.0;
+  float edge_glow = edge_falloff * facing * rect.light_intensity;
+  color = color + float4(edge_glow, edge_glow, edge_glow, 0.0);
+
+  const float antialias_threshold = 0.5;
+  float aa = saturate(antialias_threshold - sdf);
+  return float4(color.rgb, color.a * aa);
 }

--- a/crates/gpui_macos/src/shaders.metal
+++ b/crates/gpui_macos/src/shaders.metal
@@ -1373,17 +1373,69 @@ vertex BlurRectVarying blur_rect_vertex(
   return out;
 }
 
+// Compute the per-pixel target blur radius for a linear-gradient blur.
+// Uniform-blur paths (gradient_direction == 0) return `radius_start`.
+float gradient_target_radius(
+    float2 frag_pos,
+    Bounds_ScaledPixels bounds,
+    float radius_start,
+    float radius_end,
+    float2 gradient_direction
+) {
+  float dir_len2 = dot(gradient_direction, gradient_direction);
+  if (dir_len2 < 1e-6) {
+    return radius_start;
+  }
+  float2 local = frag_pos - float2(bounds.origin.x, bounds.origin.y);
+  float2 size_v = float2(bounds.size.width, bounds.size.height);
+  float extent = max(dot(size_v, gradient_direction), 1.0);
+  float t = clamp(dot(local, gradient_direction) / extent, 0.0, 1.0);
+  return mix(radius_start, radius_end, t);
+}
+
+// Sample the preserved Kawase downsample pyramid at a per-pixel blur
+// radius. Mip level 0 is the un-blurred framebuffer; each subsequent mip
+// is a /2-sized Kawase downsample of the previous, so the effective
+// Gaussian sigma roughly doubles per level. Choosing
+// `level = kernel_levels + log2(strength)` matches this exponential
+// spacing — doubling the target radius bumps level by 1 — and trilinear
+// filtering between mips produces a smooth per-pixel variable-radius
+// blur.
+float4 sample_blur_pyramid(
+    texture2d<float> pyramid,
+    sampler pyramid_sampler,
+    float2 uv,
+    float target_radius,
+    constant SceneBlurParams *scene_blur
+) {
+  if (scene_blur->max_blur_radius <= 0.0) {
+    return pyramid.sample(pyramid_sampler, uv, level(0.0));
+  }
+  float strength = clamp(target_radius / scene_blur->max_blur_radius, 0.0, 1.0);
+  float level_f = scene_blur->kernel_levels + log2(max(strength, 1e-6));
+  level_f = clamp(level_f, 0.0, scene_blur->kernel_levels);
+  return pyramid.sample(pyramid_sampler, uv, level(level_f));
+}
+
 fragment float4 blur_rect_fragment(
   BlurRectFragmentInput input [[stage_in]],
   constant BlurRect *rects [[buffer(BlurRectInputIndex_Rects)]],
   constant Size_DevicePixels *viewport_size [[buffer(BlurRectInputIndex_ViewportSize)]],
-  texture2d<float> blur_input [[texture(BlurRectInputIndex_BlurTexture)]],
-  sampler blur_sampler [[sampler(BlurRectInputIndex_BlurSampler)]]
+  texture2d<float> blur_pyramid [[texture(BlurRectInputIndex_BlurPyramid)]],
+  sampler blur_sampler [[sampler(BlurRectInputIndex_BlurSampler)]],
+  constant SceneBlurParams *scene_blur [[buffer(BlurRectInputIndex_SceneBlurParams)]]
 ) {
   BlurRect rect = rects[input.rect_id];
   float2 viewport_f = float2((float)viewport_size->width, (float)viewport_size->height);
   float2 fb_uv = input.position.xy / viewport_f;
-  float4 color = blur_input.sample(blur_sampler, fb_uv);
+  float target_radius = gradient_target_radius(
+    input.position.xy,
+    rect.bounds,
+    rect.blur_radius,
+    rect.blur_radius_end,
+    float2(rect.gradient_direction[0], rect.gradient_direction[1])
+  );
+  float4 color = sample_blur_pyramid(blur_pyramid, blur_sampler, fb_uv, target_radius, scene_blur);
   float4 tint_rgba = hsla_to_rgba(rect.tint);
   color = float4(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
 
@@ -1394,6 +1446,12 @@ fragment float4 blur_rect_fragment(
 }
 
 // --- LensRect: Liquid Glass composite (refraction + CA + Fresnel) ---
+//
+// Multi-shape lens: the fragment loops over
+// `rect.shape_offset..shape_offset + shape_count` in the `shapes` storage
+// buffer, computing a per-shape SDF + parabolic refraction direction, then
+// smooth-min-blends them by `rect.edge_blend_distance` so overlapping shapes
+// morph into one continuous lens.
 
 struct LensRectVarying {
   uint rect_id [[flat]];
@@ -1415,7 +1473,8 @@ vertex LensRectVarying lens_rect_vertex(
   uint rect_id [[instance_id]],
   constant float2 *unit_vertices [[buffer(LensRectInputIndex_Vertices)]],
   constant LensRect *rects [[buffer(LensRectInputIndex_Rects)]],
-  constant Size_DevicePixels *viewport_size [[buffer(LensRectInputIndex_ViewportSize)]]
+  constant Size_DevicePixels *viewport_size [[buffer(LensRectInputIndex_ViewportSize)]],
+  constant LensShape *shapes [[buffer(LensRectInputIndex_Shapes)]]
 ) {
   float2 unit_vertex = unit_vertices[unit_vertex_id];
   LensRect rect = rects[rect_id];
@@ -1423,11 +1482,16 @@ vertex LensRectVarying lens_rect_vertex(
   out.position = to_device_position(unit_vertex, rect.bounds, viewport_size);
   out.rect_id = rect_id;
   out.light_dir = float2(cos(rect.light_angle_radians), sin(rect.light_angle_radians));
+  // Use the first shape's corner radii as the edge-band reference. Shapes
+  // in a union typically share a radius; if they don't, the visible
+  // difference in the Fresnel band width is minor compared to the other
+  // shader outputs.
+  LensShape shape0 = shapes[rect.shape_offset];
   float corner_avg = 0.25 * (
-    rect.corner_radii.top_left
-    + rect.corner_radii.top_right
-    + rect.corner_radii.bottom_right
-    + rect.corner_radii.bottom_left
+    shape0.corner_radii.top_left
+    + shape0.corner_radii.top_right
+    + shape0.corner_radii.bottom_right
+    + shape0.corner_radii.bottom_left
   );
   float splay_px = max(rect.splay, 1.0);
   out.edge_band = max(corner_avg * 0.5, splay_px);
@@ -1443,44 +1507,146 @@ fragment float4 lens_rect_fragment(
   LensRectFragmentInput input [[stage_in]],
   constant LensRect *rects [[buffer(LensRectInputIndex_Rects)]],
   constant Size_DevicePixels *viewport_size [[buffer(LensRectInputIndex_ViewportSize)]],
-  texture2d<float> blur_input [[texture(LensRectInputIndex_BlurTexture)]],
-  sampler blur_sampler [[sampler(LensRectInputIndex_BlurSampler)]]
+  texture2d<float> blur_pyramid [[texture(LensRectInputIndex_BlurPyramid)]],
+  sampler blur_sampler [[sampler(LensRectInputIndex_BlurSampler)]],
+  constant LensShape *shapes [[buffer(LensRectInputIndex_Shapes)]],
+  constant SceneBlurParams *scene_blur [[buffer(LensRectInputIndex_SceneBlurParams)]]
 ) {
   LensRect rect = rects[input.rect_id];
   float2 viewport_f = float2((float)viewport_size->width, (float)viewport_size->height);
 
-  float sdf = quad_sdf(input.position.xy, rect.bounds, rect.corner_radii);
+  float2 frag_pos = input.position.xy;
+  uint shape_count = rect.shape_count;
+  if (shape_count == 0u) {
+    discard_fragment();
+  }
+  float blend_k = max(rect.edge_blend_distance, 0.0);
+  bool blend_shapes = blend_k > 0.0 && shape_count > 1u;
+
+  // Pass 1: accumulate per-shape SDFs plus a soft per-shape mask
+  // attenuation (0 outside the shape's own `content_mask`, 1 inside,
+  // with a ~1-pixel feather).
   const float antialias_threshold = 0.5;
-  float aa = saturate(antialias_threshold - sdf);
+  Corners_ScaledPixels zero_corners = {0.0, 0.0, 0.0, 0.0};
+  float per_shape_sdf[8];
+  float per_shape_mask_attn[8];
+  float2 per_shape_dir[8];
+  float per_shape_norm_dist[8];
+  float min_sdf = 1e20;
+  for (uint i = 0u; i < shape_count; ++i) {
+    LensShape s = shapes[rect.shape_offset + i];
+    float d = quad_sdf(frag_pos, s.bounds, s.corner_radii);
+    per_shape_sdf[i] = d;
+    min_sdf = min(min_sdf, d);
+
+    float mask_sdf = quad_sdf(frag_pos, s.content_mask, zero_corners);
+    per_shape_mask_attn[i] = saturate(antialias_threshold - mask_sdf);
+
+    float2 origin = float2(s.bounds.origin.x, s.bounds.origin.y);
+    float2 size = float2(s.bounds.size.width, s.bounds.size.height);
+    float2 center = origin + size * 0.5;
+    float2 half_size = size * 0.5;
+    float2 local_pos = frag_pos - center;
+    float local_len = length(local_pos);
+    per_shape_dir[i] = local_len > 0.001 ? local_pos / max(local_len, 0.0001) : float2(0.0, 0.0);
+    float2 safe_half = max(half_size, float2(1.0, 1.0));
+    per_shape_norm_dist[i] = clamp(length(local_pos / safe_half), 0.0, 1.0);
+  }
+
+  float union_sdf;
+  float weights[8];
+  // Scales the final fragment alpha to fade at per-shape mask boundaries.
+  // 1 when every shape is fully inside its own mask (or no mask in play);
+  // smoothly decreases as shapes' mask edges cross the fragment.
+  float coverage_factor;
+  if (blend_shapes) {
+    // Exponential smooth-minimum. Each shape contributes a weight
+    // `mask_attn[i] * exp(-(d_i - min_d) / k)` — masked-out shapes are
+    // pulled toward zero weight, so their neighbors dominate the
+    // refraction / Fresnel blend naturally.
+    float min_d = min_sdf;
+    float total_pre = 0.0;
+    float total_masked = 0.0;
+    for (uint i = 0u; i < shape_count; ++i) {
+      float pre = exp(-(per_shape_sdf[i] - min_d) / blend_k);
+      float masked = per_shape_mask_attn[i] * pre;
+      weights[i] = masked;
+      total_pre += pre;
+      total_masked += masked;
+    }
+    if (total_masked < 1e-6) {
+      discard_fragment();
+    }
+    // Softmin value: -k * log(Σ exp(-d_i / k)), shifted by min_d to avoid
+    // overflow. Unmasked sum preserves the geometric union outline even
+    // when one shape is masked out — we only attenuate the alpha and
+    // refraction weights, not the shape boundary itself.
+    union_sdf = min_d - blend_k * log(max(total_pre, 1e-6));
+    float inv_masked = 1.0 / max(total_masked, 1e-6);
+    for (uint i = 0u; i < shape_count; ++i) {
+      weights[i] *= inv_masked;
+    }
+    coverage_factor = clamp(total_masked / max(total_pre, 1e-6), 0.0, 1.0);
+  } else {
+    // Single shape or hard union: pick the min-SDF shape deterministically.
+    uint winner = 0u;
+    float min_d = per_shape_sdf[0];
+    for (uint i = 1u; i < shape_count; ++i) {
+      if (per_shape_sdf[i] < min_d) {
+        min_d = per_shape_sdf[i];
+        winner = i;
+      }
+    }
+    union_sdf = min_d;
+    for (uint i = 0u; i < shape_count; ++i) {
+      weights[i] = (i == winner) ? 1.0 : 0.0;
+    }
+    coverage_factor = per_shape_mask_attn[winner];
+    if (coverage_factor < 1e-3) {
+      discard_fragment();
+    }
+  }
+
+  float aa = saturate(antialias_threshold - union_sdf) * coverage_factor;
   if (aa <= 0.0) {
     discard_fragment();
   }
 
-  float2 origin = float2(rect.bounds.origin.x, rect.bounds.origin.y);
-  float2 size = float2(rect.bounds.size.width, rect.bounds.size.height);
-  float2 center = origin + size * 0.5;
-  float2 half_size = size * 0.5;
-  float2 local_pos = input.position.xy - center;
-  float local_len = length(local_pos);
-  float2 direction = local_len > 0.001 ? local_pos / max(local_len, 0.0001) : float2(0.0, 0.0);
-  float2 safe_half = max(half_size, float2(1.0, 1.0));
-  float normalized_dist = clamp(length(local_pos / safe_half), 0.0, 1.0);
-
+  // Pass 2: weighted refraction offset. The per-shape parabolic distortion
+  // (`(1 - r^2) * direction * refraction / 2`) is softmin-weighted so fields
+  // from merging shapes blend instead of clipping.
   float depth_scale = clamp(rect.depth * 0.01, 0.0, 1.0);
-  float distortion = (1.0 - normalized_dist * normalized_dist) * (1.0 + depth_scale);
-  float2 offset_px = distortion * direction * rect.refraction * 0.5;
-  float2 base_uv = input.position.xy / viewport_f;
+  float2 offset_px = float2(0.0, 0.0);
+  float weighted_norm_dist = 0.0;
+  float2 weighted_dir = float2(0.0, 0.0);
+  for (uint i = 0u; i < shape_count; ++i) {
+    float nd = per_shape_norm_dist[i];
+    float distortion = (1.0 - nd * nd) * (1.0 + depth_scale);
+    offset_px += weights[i] * (distortion * per_shape_dir[i] * rect.refraction * 0.5);
+    weighted_norm_dist += weights[i] * nd;
+    weighted_dir += weights[i] * per_shape_dir[i];
+  }
+  float2 base_uv = frag_pos / viewport_f;
   float2 refracted_uv = base_uv - offset_px / viewport_f;
+  float target_radius = gradient_target_radius(
+    frag_pos,
+    rect.bounds,
+    rect.blur_radius,
+    rect.blur_radius_end,
+    float2(rect.gradient_direction[0], rect.gradient_direction[1])
+  );
 
   float4 color;
   if (rect.dispersion > 0.0) {
-    float ca_shift = normalized_dist * rect.dispersion;
-    float2 ca_dir = direction / viewport_f;
-    color.r = blur_input.sample(blur_sampler, refracted_uv - ca_dir * ca_shift).r;
-    color.g = blur_input.sample(blur_sampler, refracted_uv).g;
-    color.b = blur_input.sample(blur_sampler, refracted_uv + ca_dir * ca_shift).b;
+    float ca_shift = weighted_norm_dist * rect.dispersion;
+    float2 ca_dir = weighted_dir / viewport_f;
+    float2 uv_r = refracted_uv - ca_dir * ca_shift;
+    float2 uv_b = refracted_uv + ca_dir * ca_shift;
+    color.r = sample_blur_pyramid(blur_pyramid, blur_sampler, uv_r, target_radius, scene_blur).r;
+    color.g = sample_blur_pyramid(blur_pyramid, blur_sampler, refracted_uv, target_radius, scene_blur).g;
+    color.b = sample_blur_pyramid(blur_pyramid, blur_sampler, uv_b, target_radius, scene_blur).b;
   } else {
-    color = blur_input.sample(blur_sampler, refracted_uv);
+    color = sample_blur_pyramid(blur_pyramid, blur_sampler, refracted_uv, target_radius, scene_blur);
   }
   color.a = 1.0;
 
@@ -1488,12 +1654,109 @@ fragment float4 lens_rect_fragment(
   color = float4(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
 
   if (rect.light_intensity > 0.0) {
-    float edge_dist = fabs(sdf);
+    float edge_dist = fabs(union_sdf);
     float edge_falloff = smoothstep(input.edge_band, 0.0, edge_dist);
-    float facing = local_len > 0.001 ? clamp(dot(direction, input.light_dir), 0.0, 1.0) : 1.0;
+    float weighted_len = length(weighted_dir);
+    float facing = weighted_len > 0.001
+      ? clamp(dot(weighted_dir / weighted_len, input.light_dir), 0.0, 1.0)
+      : 1.0;
     float edge_glow = edge_falloff * facing * rect.light_intensity;
     color = color + float4(edge_glow, edge_glow, edge_glow, 0.0);
   }
 
   return float4(color.rgb, color.a * aa);
+}
+
+// --- MirrorRect: sampled+flipped framebuffer region ---
+//
+// Samples `source_bounds` from either the un-blurred or Kawase-blurred
+// snapshot (gradient blur supported the same way `BlurRect` / `LensRect`
+// do), applies the horizontal/vertical flips encoded in `mirror_axis`,
+// composites into `bounds` with a rounded-rect SDF clip and tint.
+
+struct MirrorRectVarying {
+  uint rect_id [[flat]];
+  float4 position [[position]];
+  float clip_distance [[clip_distance]][4];
+};
+
+struct MirrorRectFragmentInput {
+  uint rect_id [[flat]];
+  float4 position [[position]];
+};
+
+vertex MirrorRectVarying mirror_rect_vertex(
+  uint unit_vertex_id [[vertex_id]],
+  uint rect_id [[instance_id]],
+  constant float2 *unit_vertices [[buffer(MirrorRectInputIndex_Vertices)]],
+  constant MirrorRect *rects [[buffer(MirrorRectInputIndex_Rects)]],
+  constant Size_DevicePixels *viewport_size [[buffer(MirrorRectInputIndex_ViewportSize)]]
+) {
+  float2 unit_vertex = unit_vertices[unit_vertex_id];
+  MirrorRect rect = rects[rect_id];
+  MirrorRectVarying out;
+  out.position = to_device_position(unit_vertex, rect.bounds, viewport_size);
+  out.rect_id = rect_id;
+  float4 clip = distance_from_clip_rect(unit_vertex, rect.bounds, rect.content_mask.bounds);
+  out.clip_distance[0] = clip.x;
+  out.clip_distance[1] = clip.y;
+  out.clip_distance[2] = clip.z;
+  out.clip_distance[3] = clip.w;
+  return out;
+}
+
+fragment float4 mirror_rect_fragment(
+  MirrorRectFragmentInput input [[stage_in]],
+  constant MirrorRect *rects [[buffer(MirrorRectInputIndex_Rects)]],
+  constant Size_DevicePixels *viewport_size [[buffer(MirrorRectInputIndex_ViewportSize)]],
+  texture2d<float> blur_pyramid [[texture(MirrorRectInputIndex_BlurPyramid)]],
+  sampler blur_sampler [[sampler(MirrorRectInputIndex_BlurSampler)]],
+  constant SceneBlurParams *scene_blur [[buffer(MirrorRectInputIndex_SceneBlurParams)]]
+) {
+  MirrorRect rect = rects[input.rect_id];
+  float2 viewport_f = float2((float)viewport_size->width, (float)viewport_size->height);
+
+  // Normalized position within the destination rect.
+  float2 dest_origin = float2(rect.bounds.origin.x, rect.bounds.origin.y);
+  float2 dest_size = max(float2(rect.bounds.size.width, rect.bounds.size.height), float2(1.0));
+  float2 u = clamp((input.position.xy - dest_origin) / dest_size, 0.0, 1.0);
+
+  // Flip per axis. MIRROR_AXIS_HORIZONTAL = bit 0, VERTICAL = bit 1.
+  if ((rect.mirror_axis & 1u) != 0u) {
+    u.x = 1.0 - u.x;
+  }
+  if ((rect.mirror_axis & 2u) != 0u) {
+    u.y = 1.0 - u.y;
+  }
+
+  // Map back to source rect, then to viewport UV.
+  float2 src_origin = float2(rect.source_bounds.origin.x, rect.source_bounds.origin.y);
+  float2 src_size = float2(rect.source_bounds.size.width, rect.source_bounds.size.height);
+  float2 src_pos = src_origin + u * src_size;
+  float2 src_uv = src_pos / viewport_f;
+  // Reject out-of-viewport samples to transparent.
+  if (src_uv.x < 0.0 || src_uv.x > 1.0 || src_uv.y < 0.0 || src_uv.y > 1.0) {
+    return float4(0.0);
+  }
+
+  float target_radius = gradient_target_radius(
+    input.position.xy,
+    rect.bounds,
+    rect.blur_radius,
+    rect.blur_radius_end,
+    float2(rect.gradient_direction[0], rect.gradient_direction[1])
+  );
+  float4 color = sample_blur_pyramid(blur_pyramid, blur_sampler, src_uv, target_radius, scene_blur);
+
+  float4 tint_rgba = hsla_to_rgba(rect.tint);
+  color = float4(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
+
+  float alpha = color.a;
+  if (rect.clip_to_destination != 0u) {
+    float sdf = quad_sdf(input.position.xy, rect.bounds, rect.corner_radii);
+    const float antialias_threshold = 0.5;
+    float aa = saturate(antialias_threshold - sdf);
+    alpha = color.a * aa;
+  }
+  return float4(color.rgb, alpha);
 }

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -753,7 +753,7 @@ impl MacWindow {
                     native_view as *mut _,
                     bounds.size.map(|pixels| pixels.as_f32()),
                     false,
-                    false,
+                    true,
                 ),
                 request_frame_callback: None,
                 event_callback: None,

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -753,6 +753,7 @@ impl MacWindow {
                     native_view as *mut _,
                     bounds.size.map(|pixels| pixels.as_f32()),
                     false,
+                    false,
                 ),
                 request_frame_callback: None,
                 event_callback: None,

--- a/crates/gpui_wgpu/Cargo.toml
+++ b/crates/gpui_wgpu/Cargo.toml
@@ -39,6 +39,9 @@ font-kit = { git = "https://github.com/zed-industries/font-kit", rev = "94b0f281
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 pollster.workspace = true
 
+[dev-dependencies]
+naga.workspace = true
+
 [target.'cfg(target_family = "wasm")'.dependencies]
 wasm-bindgen.workspace = true
 wasm-bindgen-futures = "0.4"

--- a/crates/gpui_wgpu/src/blur_io_shaders.wgsl
+++ b/crates/gpui_wgpu/src/blur_io_shaders.wgsl
@@ -1,11 +1,11 @@
 // Dual-Kawase blur inner passes (Marius Bjorge, ARM, SIGGRAPH 2015).
 //
-// These fragment entry points run on fullscreen triangles against
-// progressively smaller scratch textures. The driving renderer is
-// responsible for allocating the ping-pong mip chain and orchestrating
-// the down → up sequence. The final upsampled texture is bound into the
-// main shader module's `t_blur_input` slot for `fs_blur_rect` /
-// `fs_lens_rect` to sample.
+// Only the downsample half of the original down→up sequence runs here:
+// the renderer preserves every chain[i] into pyramid mip `i` after the
+// downsample loop, and `fs_blur_rect` / `fs_lens_rect` sample the pyramid
+// at a fractional LOD to produce variable-radius blur. The upsample
+// passes that the original Kawase paper describes are therefore dead
+// code for this renderer and are intentionally omitted.
 
 struct BlurParams {
     viewport_size: vec2<f32>,
@@ -22,6 +22,12 @@ struct BlurFullscreenVarying {
     @location(0) uv: vec2<f32>,
 }
 
+// Gamma conversion uses the fast γ=2.2 power-curve approximation rather
+// than the full piecewise sRGB transfer. The toe (c < 0.04045) is slightly
+// darker than the exact transfer, but downsample runs N passes per frame
+// and the piecewise branch costs more than the perceptual error is worth
+// for a backdrop blur. Keep in sync with any new gamma-sensitive sample
+// sites added here.
 fn linearize(c: vec3<f32>) -> vec3<f32> {
     return pow(c, vec3<f32>(2.2));
 }
@@ -57,17 +63,3 @@ fn fs_blur_downsample(input: BlurFullscreenVarying) -> @location(0) vec4<f32> {
     return vec4<f32>(encode_srgb(averaged.rgb), averaged.a);
 }
 
-@fragment
-fn fs_blur_upsample(input: BlurFullscreenVarying) -> @location(0) vec4<f32> {
-    let o = 0.5 / blur_params.viewport_size * blur_params.offset_multiplier;
-    var color = sample_linear(input.uv + vec2<f32>(-o.x,  o.y)) * 2.0;
-    color += sample_linear(input.uv + vec2<f32>( o.x,  o.y)) * 2.0;
-    color += sample_linear(input.uv + vec2<f32>(-o.x, -o.y)) * 2.0;
-    color += sample_linear(input.uv + vec2<f32>( o.x, -o.y)) * 2.0;
-    color += sample_linear(input.uv + vec2<f32>(-o.x * 2.0, 0.0));
-    color += sample_linear(input.uv + vec2<f32>( o.x * 2.0, 0.0));
-    color += sample_linear(input.uv + vec2<f32>(0.0, -o.y * 2.0));
-    color += sample_linear(input.uv + vec2<f32>(0.0,  o.y * 2.0));
-    let averaged = color / 12.0;
-    return vec4<f32>(encode_srgb(averaged.rgb), averaged.a);
-}

--- a/crates/gpui_wgpu/src/blur_io_shaders.wgsl
+++ b/crates/gpui_wgpu/src/blur_io_shaders.wgsl
@@ -1,0 +1,74 @@
+// Dual-Kawase blur inner passes (Marius Bjorge, ARM, SIGGRAPH 2015).
+// Reference: crates/tahoe-gpui/src/foundations/shaders/dual_kawase.wgsl
+//
+// These fragment entry points run on fullscreen triangles against
+// progressively smaller scratch textures. The driving renderer is
+// responsible for allocating the ping-pong mip chain and orchestrating
+// the down → up sequence. The final upsampled texture is bound into the
+// main shader module's `t_blur_input` slot for `fs_blur_rect` /
+// `fs_lens_rect` to sample.
+
+struct BlurParams {
+    viewport_size: vec2<f32>,
+    offset_multiplier: f32,
+    pad: f32,
+}
+
+@group(0) @binding(0) var t_blur_input: texture_2d<f32>;
+@group(0) @binding(1) var s_blur_input: sampler;
+@group(0) @binding(2) var<uniform> blur_params: BlurParams;
+
+struct BlurFullscreenVarying {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+fn linearize(c: vec3<f32>) -> vec3<f32> {
+    return pow(c, vec3<f32>(2.2));
+}
+
+fn encode_srgb(c: vec3<f32>) -> vec3<f32> {
+    return pow(c, vec3<f32>(1.0 / 2.2));
+}
+
+fn sample_linear(uv: vec2<f32>) -> vec4<f32> {
+    let s = textureSample(t_blur_input, s_blur_input, uv);
+    return vec4<f32>(linearize(s.rgb), s.a);
+}
+
+// Fullscreen-triangle vertex shader (3 vertices cover the NDC [-1,1] square).
+@vertex
+fn vs_blur_fullscreen(@builtin(vertex_index) vertex_id: u32) -> BlurFullscreenVarying {
+    var out = BlurFullscreenVarying();
+    let uv = vec2<f32>(f32((vertex_id << 1u) & 2u), f32(vertex_id & 2u));
+    out.uv = vec2<f32>(uv.x, 1.0 - uv.y);
+    out.position = vec4<f32>(uv * 2.0 - vec2<f32>(1.0, 1.0), 0.0, 1.0);
+    return out;
+}
+
+@fragment
+fn fs_blur_downsample(input: BlurFullscreenVarying) -> @location(0) vec4<f32> {
+    let o = 0.5 / blur_params.viewport_size * blur_params.offset_multiplier;
+    var color = sample_linear(input.uv) * 4.0;
+    color += sample_linear(input.uv + vec2<f32>(-o.x, -o.y));
+    color += sample_linear(input.uv + vec2<f32>( o.x, -o.y));
+    color += sample_linear(input.uv + vec2<f32>(-o.x,  o.y));
+    color += sample_linear(input.uv + vec2<f32>( o.x,  o.y));
+    let averaged = color / 8.0;
+    return vec4<f32>(encode_srgb(averaged.rgb), averaged.a);
+}
+
+@fragment
+fn fs_blur_upsample(input: BlurFullscreenVarying) -> @location(0) vec4<f32> {
+    let o = 0.5 / blur_params.viewport_size * blur_params.offset_multiplier;
+    var color = sample_linear(input.uv + vec2<f32>(-o.x,  o.y)) * 2.0;
+    color += sample_linear(input.uv + vec2<f32>( o.x,  o.y)) * 2.0;
+    color += sample_linear(input.uv + vec2<f32>(-o.x, -o.y)) * 2.0;
+    color += sample_linear(input.uv + vec2<f32>( o.x, -o.y)) * 2.0;
+    color += sample_linear(input.uv + vec2<f32>(-o.x * 2.0, 0.0));
+    color += sample_linear(input.uv + vec2<f32>( o.x * 2.0, 0.0));
+    color += sample_linear(input.uv + vec2<f32>(0.0, -o.y * 2.0));
+    color += sample_linear(input.uv + vec2<f32>(0.0,  o.y * 2.0));
+    let averaged = color / 12.0;
+    return vec4<f32>(encode_srgb(averaged.rgb), averaged.a);
+}

--- a/crates/gpui_wgpu/src/blur_io_shaders.wgsl
+++ b/crates/gpui_wgpu/src/blur_io_shaders.wgsl
@@ -1,5 +1,4 @@
 // Dual-Kawase blur inner passes (Marius Bjorge, ARM, SIGGRAPH 2015).
-// Reference: crates/tahoe-gpui/src/foundations/shaders/dual_kawase.wgsl
 //
 // These fragment entry points run on fullscreen triangles against
 // progressively smaller scratch textures. The driving renderer is

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -1339,15 +1339,17 @@ fn fs_surface(input: SurfaceVarying) -> @location(0) vec4<f32> {
 // framebuffer texture. The dual-Kawase blur that produces that input texture
 // runs through a separate, standalone shader module (`blur_io_shaders.wgsl`).
 //
-// These entry points fit the existing two-group pattern:
+// Bind group layout:
 //   @group(0) = globals (shared uniforms)
-//   @group(1) = instance storage buffer + blurred texture + sampler
+//   @group(1) = blurred texture + sampler + scene-blur params (frame-stable)
+//   @group(2) = instance storage buffers (per-batch)
 //
-// Each pipeline uses only a subset of group(1)'s bindings:
-//   blur_rect: binding 0 (b_blur_rects), binding 2 (t_blur_input), binding 3
-//   lens_rect: binding 1 (b_lens_rects), binding 2, binding 3
-// Declaring both storage buffers at distinct bindings lets a single shader
-// module host both pipelines without binding collisions.
+// Each pipeline uses only a subset of group(2)'s bindings:
+//   blur_rect:   binding 0 (b_blur_rects)
+//   lens_rect:   binding 1 (b_lens_rects), binding 4 (b_lens_shapes)
+//   mirror_rect: binding 5 (b_mirror_rects)
+// Declaring all storage buffers at distinct bindings lets a single shader
+// module host all pipelines without binding collisions.
 // ============================================================================
 
 struct BlurRect {
@@ -1418,15 +1420,15 @@ struct MirrorRect {
     tint: Hsla,
 }
 
-@group(1) @binding(0) var<storage, read> b_blur_rects: array<BlurRect>;
-@group(1) @binding(1) var<storage, read> b_lens_rects: array<LensRect>;
+@group(2) @binding(0) var<storage, read> b_blur_rects: array<BlurRect>;
+@group(2) @binding(1) var<storage, read> b_lens_rects: array<LensRect>;
 // Mipmapped pyramid: mip 0 = un-blurred framebuffer snapshot, each
 // subsequent mip = Kawase downsample result of the previous level.
 // Fragment shaders pick fractional LOD via `textureSampleLevel`.
 @group(1) @binding(2) var t_blur_pyramid: texture_2d<f32>;
 @group(1) @binding(3) var s_blur_input: sampler;
-@group(1) @binding(4) var<storage, read> b_lens_shapes: array<LensShape>;
-@group(1) @binding(5) var<storage, read> b_mirror_rects: array<MirrorRect>;
+@group(2) @binding(4) var<storage, read> b_lens_shapes: array<LensShape>;
+@group(2) @binding(5) var<storage, read> b_mirror_rects: array<MirrorRect>;
 @group(1) @binding(6) var<uniform> scene_blur: SceneBlurParams;
 
 // --- BlurRect: rounded rect that samples the blurred framebuffer ---

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -1357,8 +1357,11 @@ struct BlurRect {
     content_mask: Bounds,
     corner_radii: Corners,
     blur_radius: f32,
-    pad: f32,
+    blur_radius_end: f32,
+    gradient_direction: vec2<f32>,
     tint: Hsla,
+    // Aligns the struct stride to 96 bytes (matching the Rust side).
+    _pad_end: vec2<f32>,
 }
 
 struct LensRect {
@@ -1366,25 +1369,65 @@ struct LensRect {
     kernel_levels: u32,
     bounds: Bounds,
     content_mask: Bounds,
-    corner_radii: Corners,
+    shape_offset: u32,
+    shape_count: u32,
+    edge_blend_distance: f32,
     blur_radius: f32,
+    gradient_direction: vec2<f32>,
+    blur_radius_end: f32,
     refraction: f32,
     depth: f32,
     dispersion: f32,
     splay: f32,
     light_angle_radians: f32,
-    pad_light: f32,
     light_intensity: f32,
-    pad: f32,
     tint: Hsla,
     // Aligns the struct stride to 112 bytes (matching the Rust side).
     pad2: f32,
 }
 
+struct SceneBlurParams {
+    max_blur_radius: f32,
+    kernel_levels: f32,
+    _pad0: f32,
+    _pad1: f32,
+}
+
+struct LensShape {
+    bounds: Bounds,
+    corner_radii: Corners,
+    // Per-shape clip rectangle. Fragments outside this attenuate the
+    // shape's contribution to the SDF union instead of hard-clipping, so
+    // adjacent shapes in the same lens group don't develop a seam at the
+    // mask edge.
+    content_mask: Bounds,
+}
+
+struct MirrorRect {
+    order: u32,
+    kernel_levels: u32,
+    bounds: Bounds,
+    content_mask: Bounds,
+    corner_radii: Corners,
+    source_bounds: Bounds,
+    mirror_axis: u32,
+    clip_to_destination: u32,
+    blur_radius: f32,
+    blur_radius_end: f32,
+    gradient_direction: vec2<f32>,
+    tint: Hsla,
+}
+
 @group(1) @binding(0) var<storage, read> b_blur_rects: array<BlurRect>;
 @group(1) @binding(1) var<storage, read> b_lens_rects: array<LensRect>;
-@group(1) @binding(2) var t_blur_input: texture_2d<f32>;
+// Mipmapped pyramid: mip 0 = un-blurred framebuffer snapshot, each
+// subsequent mip = Kawase downsample result of the previous level.
+// Fragment shaders pick fractional LOD via `textureSampleLevel`.
+@group(1) @binding(2) var t_blur_pyramid: texture_2d<f32>;
 @group(1) @binding(3) var s_blur_input: sampler;
+@group(1) @binding(4) var<storage, read> b_lens_shapes: array<LensShape>;
+@group(1) @binding(6) var<uniform> scene_blur: SceneBlurParams;
+@group(1) @binding(7) var<storage, read> b_mirror_rects: array<MirrorRect>;
 
 // --- BlurRect: rounded rect that samples the blurred framebuffer ---
 
@@ -1408,6 +1451,39 @@ fn vs_blur_rect(
     return out;
 }
 
+// Compute the per-pixel target blur radius for a linear-gradient blur.
+// Uniform-blur paths (gradient_direction == 0) return `radius_start`.
+fn gradient_target_radius(
+    frag_pos: vec2<f32>,
+    bounds: Bounds,
+    radius_start: f32,
+    radius_end: f32,
+    gradient_direction: vec2<f32>,
+) -> f32 {
+    let dir_len2 = dot(gradient_direction, gradient_direction);
+    if (dir_len2 < 1e-6) {
+        return radius_start;
+    }
+    let local = frag_pos - bounds.origin;
+    let extent = max(dot(bounds.size, gradient_direction), 1.0);
+    let t = clamp(dot(local, gradient_direction) / extent, 0.0, 1.0);
+    return mix(radius_start, radius_end, t);
+}
+
+// Sample the preserved Kawase downsample pyramid at a per-pixel blur
+// radius. Mip 0 is un-blurred; each subsequent mip doubles the effective
+// Gaussian sigma, so `level = kernel_levels + log2(strength)` with
+// trilinear filtering produces a smooth per-pixel variable-radius blur.
+fn sample_blur_pyramid(uv: vec2<f32>, target_radius: f32) -> vec4<f32> {
+    if (scene_blur.max_blur_radius <= 0.0) {
+        return textureSampleLevel(t_blur_pyramid, s_blur_input, uv, 0.0);
+    }
+    let strength = clamp(target_radius / scene_blur.max_blur_radius, 0.0, 1.0);
+    let raw_level = scene_blur.kernel_levels + log2(max(strength, 1e-6));
+    let level = clamp(raw_level, 0.0, scene_blur.kernel_levels);
+    return textureSampleLevel(t_blur_pyramid, s_blur_input, uv, level);
+}
+
 @fragment
 fn fs_blur_rect(input: BlurRectVarying) -> @location(0) vec4<f32> {
     if (any(input.clip_distances < vec4<f32>(0.0))) {
@@ -1415,7 +1491,14 @@ fn fs_blur_rect(input: BlurRectVarying) -> @location(0) vec4<f32> {
     }
     let rect = b_blur_rects[input.rect_id];
     let fb_uv = input.position.xy / globals.viewport_size;
-    var color = textureSample(t_blur_input, s_blur_input, fb_uv);
+    let target_radius = gradient_target_radius(
+        input.position.xy,
+        rect.bounds,
+        rect.blur_radius,
+        rect.blur_radius_end,
+        rect.gradient_direction,
+    );
+    var color = sample_blur_pyramid(fb_uv, target_radius);
     let tint_rgba = hsla_to_rgba(rect.tint);
     color = vec4<f32>(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
 
@@ -1450,16 +1533,24 @@ fn vs_lens_rect(
         cos(rect.light_angle_radians),
         sin(rect.light_angle_radians),
     );
+    // Use the first shape's corner radii as the Fresnel edge-band reference;
+    // the difference when shapes differ is minor relative to the other
+    // shader outputs.
+    let shape0 = b_lens_shapes[rect.shape_offset];
     let corner_avg = 0.25 * (
-        rect.corner_radii.top_left
-        + rect.corner_radii.top_right
-        + rect.corner_radii.bottom_right
-        + rect.corner_radii.bottom_left
+        shape0.corner_radii.top_left
+        + shape0.corner_radii.top_right
+        + shape0.corner_radii.bottom_right
+        + shape0.corner_radii.bottom_left
     );
     let splay_px = max(rect.splay, 1.0);
     out.edge_band = max(corner_avg * 0.5, splay_px);
     return out;
 }
+
+// Max shapes per LensRect. Matches `MAX_LENS_SHAPES_PER_GROUP` in window.rs;
+// sized to keep the per-fragment loops cheap.
+const MAX_LENS_SHAPES: u32 = 8u;
 
 @fragment
 fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
@@ -1467,41 +1558,120 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
         return vec4<f32>(0.0);
     }
     let rect = b_lens_rects[input.rect_id];
+    let shape_count = min(rect.shape_count, MAX_LENS_SHAPES);
+    if (shape_count == 0u) {
+        return vec4<f32>(0.0);
+    }
+    let blend_k = max(rect.edge_blend_distance, 0.0);
+    let blend_shapes = blend_k > 0.0 && shape_count > 1u;
 
-    let sdf = quad_sdf(input.position.xy, rect.bounds, rect.corner_radii);
     let antialias_threshold = 0.5;
-    let aa = saturate(antialias_threshold - sdf);
+    let zero_corners = Corners(0.0, 0.0, 0.0, 0.0);
+    var per_shape_sdf: array<f32, 8>;
+    var per_shape_mask_attn: array<f32, 8>;
+    var per_shape_dir: array<vec2<f32>, 8>;
+    var per_shape_norm_dist: array<f32, 8>;
+    var min_sdf: f32 = 1e20;
+    for (var i: u32 = 0u; i < shape_count; i = i + 1u) {
+        let s = b_lens_shapes[rect.shape_offset + i];
+        let d = quad_sdf(input.position.xy, s.bounds, s.corner_radii);
+        per_shape_sdf[i] = d;
+        min_sdf = min(min_sdf, d);
+
+        let mask_sdf = quad_sdf(input.position.xy, s.content_mask, zero_corners);
+        per_shape_mask_attn[i] = saturate(antialias_threshold - mask_sdf);
+
+        let center = s.bounds.origin + s.bounds.size * 0.5;
+        let half_size = s.bounds.size * 0.5;
+        let local_pos = input.position.xy - center;
+        let local_len = length(local_pos);
+        per_shape_dir[i] = select(
+            vec2<f32>(0.0, 0.0),
+            local_pos / max(local_len, 0.0001),
+            local_len > 0.001,
+        );
+        let safe_half = max(half_size, vec2<f32>(1.0, 1.0));
+        per_shape_norm_dist[i] = clamp(length(local_pos / safe_half), 0.0, 1.0);
+    }
+
+    var union_sdf: f32;
+    var weights: array<f32, 8>;
+    var coverage_factor: f32;
+    if (blend_shapes) {
+        var total_pre: f32 = 0.0;
+        var total_masked: f32 = 0.0;
+        for (var i: u32 = 0u; i < shape_count; i = i + 1u) {
+            let pre = exp(-(per_shape_sdf[i] - min_sdf) / blend_k);
+            let masked = per_shape_mask_attn[i] * pre;
+            weights[i] = masked;
+            total_pre = total_pre + pre;
+            total_masked = total_masked + masked;
+        }
+        if (total_masked < 1e-6) {
+            return vec4<f32>(0.0);
+        }
+        union_sdf = min_sdf - blend_k * log(max(total_pre, 1e-6));
+        let inv_masked = 1.0 / max(total_masked, 1e-6);
+        for (var i: u32 = 0u; i < shape_count; i = i + 1u) {
+            weights[i] = weights[i] * inv_masked;
+        }
+        coverage_factor = clamp(total_masked / max(total_pre, 1e-6), 0.0, 1.0);
+    } else {
+        var winner: u32 = 0u;
+        var min_d: f32 = per_shape_sdf[0];
+        for (var i: u32 = 1u; i < shape_count; i = i + 1u) {
+            if (per_shape_sdf[i] < min_d) {
+                min_d = per_shape_sdf[i];
+                winner = i;
+            }
+        }
+        union_sdf = min_d;
+        for (var i: u32 = 0u; i < shape_count; i = i + 1u) {
+            weights[i] = select(0.0, 1.0, i == winner);
+        }
+        coverage_factor = per_shape_mask_attn[winner];
+        if (coverage_factor < 1e-3) {
+            return vec4<f32>(0.0);
+        }
+    }
+
+    let aa = saturate(antialias_threshold - union_sdf) * coverage_factor;
     if (aa <= 0.0) {
         return vec4<f32>(0.0);
     }
 
-    let center = rect.bounds.origin + rect.bounds.size * 0.5;
-    let half_size = rect.bounds.size * 0.5;
-    let local_pos = input.position.xy - center;
-    let local_len = length(local_pos);
-    let direction = select(
-        vec2<f32>(0.0, 0.0),
-        local_pos / max(local_len, 0.0001),
-        local_len > 0.001,
-    );
-    let safe_half = max(half_size, vec2<f32>(1.0, 1.0));
-    let normalized_dist = clamp(length(local_pos / safe_half), 0.0, 1.0);
-
     let depth_scale = clamp(rect.depth * 0.01, 0.0, 1.0);
-    let distortion = (1.0 - normalized_dist * normalized_dist) * (1.0 + depth_scale);
-    let offset_px = distortion * direction * rect.refraction * 0.5;
+    var offset_px = vec2<f32>(0.0, 0.0);
+    var weighted_norm_dist: f32 = 0.0;
+    var weighted_dir = vec2<f32>(0.0, 0.0);
+    for (var i: u32 = 0u; i < shape_count; i = i + 1u) {
+        let nd = per_shape_norm_dist[i];
+        let distortion = (1.0 - nd * nd) * (1.0 + depth_scale);
+        offset_px = offset_px + weights[i] * (distortion * per_shape_dir[i] * rect.refraction * 0.5);
+        weighted_norm_dist = weighted_norm_dist + weights[i] * nd;
+        weighted_dir = weighted_dir + weights[i] * per_shape_dir[i];
+    }
     let base_uv = input.position.xy / globals.viewport_size;
     let refracted_uv = base_uv - offset_px / globals.viewport_size;
+    let target_radius = gradient_target_radius(
+        input.position.xy,
+        rect.bounds,
+        rect.blur_radius,
+        rect.blur_radius_end,
+        rect.gradient_direction,
+    );
 
     var color: vec4<f32>;
     if (rect.dispersion > 0.0) {
-        let ca_shift = normalized_dist * rect.dispersion;
-        let ca_dir = direction / globals.viewport_size;
-        color.r = textureSample(t_blur_input, s_blur_input, refracted_uv - ca_dir * ca_shift).r;
-        color.g = textureSample(t_blur_input, s_blur_input, refracted_uv).g;
-        color.b = textureSample(t_blur_input, s_blur_input, refracted_uv + ca_dir * ca_shift).b;
+        let ca_shift = weighted_norm_dist * rect.dispersion;
+        let ca_dir = weighted_dir / globals.viewport_size;
+        let uv_r = refracted_uv - ca_dir * ca_shift;
+        let uv_b = refracted_uv + ca_dir * ca_shift;
+        color.r = sample_blur_pyramid(uv_r, target_radius).r;
+        color.g = sample_blur_pyramid(refracted_uv, target_radius).g;
+        color.b = sample_blur_pyramid(uv_b, target_radius).b;
     } else {
-        color = textureSample(t_blur_input, s_blur_input, refracted_uv);
+        color = sample_blur_pyramid(refracted_uv, target_radius);
     }
     color.a = 1.0;
 
@@ -1509,16 +1679,85 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
     color = vec4<f32>(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
 
     if (rect.light_intensity > 0.0) {
-        let edge_dist = abs(sdf);
+        let edge_dist = abs(union_sdf);
         let edge_falloff = smoothstep(input.edge_band, 0.0, edge_dist);
+        let weighted_len = length(weighted_dir);
         let facing = select(
             1.0,
-            clamp(dot(direction, input.light_dir), 0.0, 1.0),
-            local_len > 0.001,
+            clamp(dot(weighted_dir / weighted_len, input.light_dir), 0.0, 1.0),
+            weighted_len > 0.001,
         );
         let edge_glow = edge_falloff * facing * rect.light_intensity;
         color = color + vec4<f32>(edge_glow, edge_glow, edge_glow, 0.0);
     }
 
     return blend_color(color, aa);
+}
+
+// --- MirrorRect: sampled+flipped framebuffer region ---
+
+struct MirrorRectVarying {
+    @builtin(position) position: vec4<f32>,
+    @location(0) @interpolate(flat) rect_id: u32,
+    @location(1) clip_distances: vec4<f32>,
+}
+
+@vertex
+fn vs_mirror_rect(
+    @builtin(vertex_index) vertex_id: u32,
+    @builtin(instance_index) instance_id: u32,
+) -> MirrorRectVarying {
+    let unit_vertex = vec2<f32>(f32(vertex_id & 1u), 0.5 * f32(vertex_id & 2u));
+    let rect = b_mirror_rects[instance_id];
+    var out = MirrorRectVarying();
+    out.position = to_device_position(unit_vertex, rect.bounds);
+    out.rect_id = instance_id;
+    out.clip_distances = distance_from_clip_rect(unit_vertex, rect.bounds, rect.content_mask);
+    return out;
+}
+
+@fragment
+fn fs_mirror_rect(input: MirrorRectVarying) -> @location(0) vec4<f32> {
+    if (any(input.clip_distances < vec4<f32>(0.0))) {
+        return vec4<f32>(0.0);
+    }
+    let rect = b_mirror_rects[input.rect_id];
+
+    let dest_origin = rect.bounds.origin;
+    let dest_size = max(rect.bounds.size, vec2<f32>(1.0));
+    var u = clamp((input.position.xy - dest_origin) / dest_size, vec2<f32>(0.0), vec2<f32>(1.0));
+
+    if ((rect.mirror_axis & 1u) != 0u) {
+        u.x = 1.0 - u.x;
+    }
+    if ((rect.mirror_axis & 2u) != 0u) {
+        u.y = 1.0 - u.y;
+    }
+
+    let src_pos = rect.source_bounds.origin + u * rect.source_bounds.size;
+    let src_uv = src_pos / globals.viewport_size;
+    if (src_uv.x < 0.0 || src_uv.x > 1.0 || src_uv.y < 0.0 || src_uv.y > 1.0) {
+        return vec4<f32>(0.0);
+    }
+
+    let target_radius = gradient_target_radius(
+        input.position.xy,
+        rect.bounds,
+        rect.blur_radius,
+        rect.blur_radius_end,
+        rect.gradient_direction,
+    );
+    var color = sample_blur_pyramid(src_uv, target_radius);
+
+    let tint_rgba = hsla_to_rgba(rect.tint);
+    color = vec4<f32>(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
+
+    var alpha = color.a;
+    if (rect.clip_to_destination != 0u) {
+        let sdf = quad_sdf(input.position.xy, rect.bounds, rect.corner_radii);
+        let antialias_threshold = 0.5;
+        let aa = saturate(antialias_threshold - sdf);
+        alpha = color.a * aa;
+    }
+    return vec4<f32>(color.rgb, alpha);
 }

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -1432,6 +1432,7 @@ struct LensRectVarying {
     @location(0) @interpolate(flat) rect_id: u32,
     @location(1) clip_distances: vec4<f32>,
     @location(2) @interpolate(flat) light_dir: vec2<f32>,
+    @location(3) @interpolate(flat) edge_band: f32,
 }
 
 @vertex
@@ -1449,6 +1450,14 @@ fn vs_lens_rect(
         cos(rect.light_angle_radians),
         sin(rect.light_angle_radians),
     );
+    let corner_avg = 0.25 * (
+        rect.corner_radii.top_left
+        + rect.corner_radii.top_right
+        + rect.corner_radii.bottom_right
+        + rect.corner_radii.bottom_left
+    );
+    let splay_px = max(rect.splay, 1.0);
+    out.edge_band = max(corner_avg * 0.5, splay_px);
     return out;
 }
 
@@ -1458,6 +1467,13 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
         return vec4<f32>(0.0);
     }
     let rect = b_lens_rects[input.rect_id];
+
+    let sdf = quad_sdf(input.position.xy, rect.bounds, rect.corner_radii);
+    let antialias_threshold = 0.5;
+    let aa = saturate(antialias_threshold - sdf);
+    if (aa <= 0.0) {
+        return vec4<f32>(0.0);
+    }
 
     let center = rect.bounds.origin + rect.bounds.size * 0.5;
     let half_size = rect.bounds.size * 0.5;
@@ -1477,38 +1493,32 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
     let base_uv = input.position.xy / globals.viewport_size;
     let refracted_uv = base_uv - offset_px / globals.viewport_size;
 
-    let ca_shift = normalized_dist * rect.dispersion;
-    let ca_dir = direction / globals.viewport_size;
     var color: vec4<f32>;
-    color.r = textureSample(t_blur_input, s_blur_input, refracted_uv - ca_dir * ca_shift).r;
-    color.g = textureSample(t_blur_input, s_blur_input, refracted_uv).g;
-    color.b = textureSample(t_blur_input, s_blur_input, refracted_uv + ca_dir * ca_shift).b;
+    if (rect.dispersion > 0.0) {
+        let ca_shift = normalized_dist * rect.dispersion;
+        let ca_dir = direction / globals.viewport_size;
+        color.r = textureSample(t_blur_input, s_blur_input, refracted_uv - ca_dir * ca_shift).r;
+        color.g = textureSample(t_blur_input, s_blur_input, refracted_uv).g;
+        color.b = textureSample(t_blur_input, s_blur_input, refracted_uv + ca_dir * ca_shift).b;
+    } else {
+        color = textureSample(t_blur_input, s_blur_input, refracted_uv);
+    }
     color.a = 1.0;
 
     let tint_rgba = hsla_to_rgba(rect.tint);
     color = vec4<f32>(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
 
-    let light_dir = input.light_dir;
-    let sdf = quad_sdf(input.position.xy, rect.bounds, rect.corner_radii);
-    let edge_dist = abs(sdf);
-    let splay_px = max(rect.splay, 1.0);
-    let corner_avg = 0.25 * (
-        rect.corner_radii.top_left
-        + rect.corner_radii.top_right
-        + rect.corner_radii.bottom_right
-        + rect.corner_radii.bottom_left
-    );
-    let edge_band = max(corner_avg * 0.5, splay_px);
-    let edge_falloff = smoothstep(edge_band, 0.0, edge_dist);
-    let facing = select(
-        1.0,
-        clamp(dot(direction, light_dir), 0.0, 1.0),
-        local_len > 0.001,
-    );
-    let edge_glow = edge_falloff * facing * rect.light_intensity;
-    color = color + vec4<f32>(edge_glow, edge_glow, edge_glow, 0.0);
+    if (rect.light_intensity > 0.0) {
+        let edge_dist = abs(sdf);
+        let edge_falloff = smoothstep(input.edge_band, 0.0, edge_dist);
+        let facing = select(
+            1.0,
+            clamp(dot(direction, input.light_dir), 0.0, 1.0),
+            local_len > 0.001,
+        );
+        let edge_glow = edge_falloff * facing * rect.light_intensity;
+        color = color + vec4<f32>(edge_glow, edge_glow, edge_glow, 0.0);
+    }
 
-    let antialias_threshold = 0.5;
-    let aa = saturate(antialias_threshold - sdf);
     return blend_color(color, aa);
 }

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -1361,7 +1361,7 @@ struct BlurRect {
     gradient_direction: vec2<f32>,
     tint: Hsla,
     // Aligns the struct stride to 96 bytes (matching the Rust side).
-    _pad_end: vec2<f32>,
+    pad_end: vec2<f32>,
 }
 
 struct LensRect {
@@ -1426,8 +1426,8 @@ struct MirrorRect {
 @group(1) @binding(2) var t_blur_pyramid: texture_2d<f32>;
 @group(1) @binding(3) var s_blur_input: sampler;
 @group(1) @binding(4) var<storage, read> b_lens_shapes: array<LensShape>;
+@group(1) @binding(5) var<storage, read> b_mirror_rects: array<MirrorRect>;
 @group(1) @binding(6) var<uniform> scene_blur: SceneBlurParams;
-@group(1) @binding(7) var<storage, read> b_mirror_rects: array<MirrorRect>;
 
 // --- BlurRect: rounded rect that samples the blurred framebuffer ---
 
@@ -1464,9 +1464,15 @@ fn gradient_target_radius(
     if (dir_len2 < 1e-6) {
         return radius_start;
     }
+    // Normalize the direction inside the function so the mapping is
+    // magnitude-invariant in `gradient_direction`. Callers already pass a
+    // unit vector today, but clamping the denominator to 1 px while leaving
+    // the numerator unscaled otherwise gives different `t` for scaled
+    // inputs.
+    let dir = gradient_direction * inverseSqrt(dir_len2);
     let local = frag_pos - bounds.origin;
-    let extent = max(dot(bounds.size, gradient_direction), 1.0);
-    let t = clamp(dot(local, gradient_direction) / extent, 0.0, 1.0);
+    let extent = max(dot(bounds.size, dir), 1.0);
+    let t = clamp(dot(local, dir) / extent, 0.0, 1.0);
     return mix(radius_start, radius_end, t);
 }
 
@@ -1567,10 +1573,10 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
 
     let antialias_threshold = 0.5;
     let zero_corners = Corners(0.0, 0.0, 0.0, 0.0);
-    var per_shape_sdf: array<f32, 8>;
-    var per_shape_mask_attn: array<f32, 8>;
-    var per_shape_dir: array<vec2<f32>, 8>;
-    var per_shape_norm_dist: array<f32, 8>;
+    var per_shape_sdf: array<f32, MAX_LENS_SHAPES>;
+    var per_shape_mask_attn: array<f32, MAX_LENS_SHAPES>;
+    var per_shape_dir: array<vec2<f32>, MAX_LENS_SHAPES>;
+    var per_shape_norm_dist: array<f32, MAX_LENS_SHAPES>;
     var min_sdf: f32 = 1e20;
     for (var i: u32 = 0u; i < shape_count; i = i + 1u) {
         let s = b_lens_shapes[rect.shape_offset + i];
@@ -1595,7 +1601,7 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
     }
 
     var union_sdf: f32;
-    var weights: array<f32, 8>;
+    var weights: array<f32, MAX_LENS_SHAPES>;
     var coverage_factor: f32;
     if (blend_shapes) {
         var total_pre: f32 = 0.0;
@@ -1612,8 +1618,11 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
         }
         union_sdf = min_sdf - blend_k * log(max(total_pre, 1e-6));
         let inv_masked = 1.0 / max(total_masked, 1e-6);
+        // Clamp to [0, 1]: when `total_masked` approaches the 1e-6 floor,
+        // individual masked weights can scale past 1.0 and blow up the
+        // downstream refraction / dispersion vectors.
         for (var i: u32 = 0u; i < shape_count; i = i + 1u) {
-            weights[i] = weights[i] * inv_masked;
+            weights[i] = clamp(weights[i] * inv_masked, 0.0, 1.0);
         }
         coverage_factor = clamp(total_masked / max(total_pre, 1e-6), 0.0, 1.0);
     } else {
@@ -1643,6 +1652,11 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
     let depth_scale = clamp(rect.depth * 0.01, 0.0, 1.0);
     var offset_px = vec2<f32>(0.0, 0.0);
     var weighted_norm_dist: f32 = 0.0;
+    // `weighted_dir` is a weighted *sum* of unit directions, not a unit vector.
+    // For a fragment between two shapes whose centers oppose, the sum shrinks
+    // toward zero even when each contribution is strong — which is intentional:
+    // chromatic dispersion should fade in inter-shape seams so R/B collapse
+    // back onto G instead of streaking. Do not renormalize here.
     var weighted_dir = vec2<f32>(0.0, 0.0);
     for (var i: u32 = 0u; i < shape_count; i = i + 1u) {
         let nd = per_shape_norm_dist[i];
@@ -1652,7 +1666,16 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
         weighted_dir = weighted_dir + weights[i] * per_shape_dir[i];
     }
     let base_uv = input.position.xy / globals.viewport_size;
-    let refracted_uv = base_uv - offset_px / globals.viewport_size;
+    // Large `refraction` on lens rims can push UVs outside [0,1]. The
+    // pyramid sampler is created with ClampToEdge so stretched-edge pixels
+    // replicate the border rather than wrap across the framebuffer; clamp
+    // explicitly to make the contract visible and survive a future
+    // sampler-state change.
+    let refracted_uv = clamp(
+        base_uv - offset_px / globals.viewport_size,
+        vec2<f32>(0.0, 0.0),
+        vec2<f32>(1.0, 1.0),
+    );
     let target_radius = gradient_target_radius(
         input.position.xy,
         rect.bounds,
@@ -1682,9 +1705,12 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
         let edge_dist = abs(union_sdf);
         let edge_falloff = smoothstep(input.edge_band, 0.0, edge_dist);
         let weighted_len = length(weighted_dir);
+        // `select` evaluates both arms, so guard the division with `max`
+        // instead of relying on the predicate. Matches the MSL ?: path.
+        let safe_dir = weighted_dir / max(weighted_len, 1e-4);
         let facing = select(
             1.0,
-            clamp(dot(weighted_dir / weighted_len, input.light_dir), 0.0, 1.0),
+            clamp(dot(safe_dir, input.light_dir), 0.0, 1.0),
             weighted_len > 0.001,
         );
         let edge_glow = edge_falloff * facing * rect.light_intensity;
@@ -1752,12 +1778,11 @@ fn fs_mirror_rect(input: MirrorRectVarying) -> @location(0) vec4<f32> {
     let tint_rgba = hsla_to_rgba(rect.tint);
     color = vec4<f32>(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
 
-    var alpha = color.a;
+    var aa_factor = 1.0;
     if (rect.clip_to_destination != 0u) {
         let sdf = quad_sdf(input.position.xy, rect.bounds, rect.corner_radii);
         let antialias_threshold = 0.5;
-        let aa = saturate(antialias_threshold - sdf);
-        alpha = color.a * aa;
+        aa_factor = saturate(antialias_threshold - sdf);
     }
-    return vec4<f32>(color.rgb, alpha);
+    return blend_color(color, aa_factor);
 }

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -1333,3 +1333,178 @@ fn fs_surface(input: SurfaceVarying) -> @location(0) vec4<f32> {
 
     return ycbcr_to_RGB * y_cb_cr;
 }
+
+// ============================================================================
+// BlurRect / LensRect primitives — rect-shaped draws that sample a blurred
+// framebuffer texture. The dual-Kawase blur that produces that input texture
+// runs through a separate, standalone shader module (`blur_io_shaders.wgsl`).
+//
+// These entry points fit the existing two-group pattern:
+//   @group(0) = globals (shared uniforms)
+//   @group(1) = instance storage buffer + blurred texture + sampler
+//
+// Each pipeline uses only a subset of group(1)'s bindings:
+//   blur_rect: binding 0 (b_blur_rects), binding 2 (t_blur_input), binding 3
+//   lens_rect: binding 1 (b_lens_rects), binding 2, binding 3
+// Declaring both storage buffers at distinct bindings lets a single shader
+// module host both pipelines without binding collisions.
+// ============================================================================
+
+struct BlurRect {
+    order: u32,
+    kernel_levels: u32,
+    bounds: Bounds,
+    content_mask: Bounds,
+    corner_radii: Corners,
+    blur_radius: f32,
+    pad: f32,
+    tint: Hsla,
+}
+
+struct LensRect {
+    order: u32,
+    kernel_levels: u32,
+    bounds: Bounds,
+    content_mask: Bounds,
+    corner_radii: Corners,
+    blur_radius: f32,
+    refraction: f32,
+    depth: f32,
+    dispersion: f32,
+    splay: f32,
+    // Stored as two scalars to match Rust's `Point<f32>` natural alignment.
+    light_dir_x: f32,
+    light_dir_y: f32,
+    light_intensity: f32,
+    pad: f32,
+    tint: Hsla,
+    // Aligns the struct stride to 112 bytes (matching the Rust side).
+    pad2: f32,
+}
+
+@group(1) @binding(0) var<storage, read> b_blur_rects: array<BlurRect>;
+@group(1) @binding(1) var<storage, read> b_lens_rects: array<LensRect>;
+@group(1) @binding(2) var t_blur_input: texture_2d<f32>;
+@group(1) @binding(3) var s_blur_input: sampler;
+
+// --- BlurRect: rounded rect that samples the blurred framebuffer ---
+
+struct BlurRectVarying {
+    @builtin(position) position: vec4<f32>,
+    @location(0) @interpolate(flat) rect_id: u32,
+    @location(1) clip_distances: vec4<f32>,
+}
+
+@vertex
+fn vs_blur_rect(
+    @builtin(vertex_index) vertex_id: u32,
+    @builtin(instance_index) instance_id: u32,
+) -> BlurRectVarying {
+    let unit_vertex = vec2<f32>(f32(vertex_id & 1u), 0.5 * f32(vertex_id & 2u));
+    let rect = b_blur_rects[instance_id];
+    var out = BlurRectVarying();
+    out.position = to_device_position(unit_vertex, rect.bounds);
+    out.rect_id = instance_id;
+    out.clip_distances = distance_from_clip_rect(unit_vertex, rect.bounds, rect.content_mask);
+    return out;
+}
+
+@fragment
+fn fs_blur_rect(input: BlurRectVarying) -> @location(0) vec4<f32> {
+    if (any(input.clip_distances < vec4<f32>(0.0))) {
+        return vec4<f32>(0.0);
+    }
+    let rect = b_blur_rects[input.rect_id];
+    let fb_uv = input.position.xy / globals.viewport_size;
+    var color = textureSample(t_blur_input, s_blur_input, fb_uv);
+    let tint_rgba = hsla_to_rgba(rect.tint);
+    color = vec4<f32>(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
+
+    let sdf = quad_sdf(input.position.xy, rect.bounds, rect.corner_radii);
+    let antialias_threshold = 0.5;
+    let aa = saturate(antialias_threshold - sdf);
+    return blend_color(color, aa);
+}
+
+// --- LensRect: Liquid Glass composite (refraction + CA + Fresnel) ---
+
+struct LensRectVarying {
+    @builtin(position) position: vec4<f32>,
+    @location(0) @interpolate(flat) rect_id: u32,
+    @location(1) clip_distances: vec4<f32>,
+}
+
+@vertex
+fn vs_lens_rect(
+    @builtin(vertex_index) vertex_id: u32,
+    @builtin(instance_index) instance_id: u32,
+) -> LensRectVarying {
+    let unit_vertex = vec2<f32>(f32(vertex_id & 1u), 0.5 * f32(vertex_id & 2u));
+    let rect = b_lens_rects[instance_id];
+    var out = LensRectVarying();
+    out.position = to_device_position(unit_vertex, rect.bounds);
+    out.rect_id = instance_id;
+    out.clip_distances = distance_from_clip_rect(unit_vertex, rect.bounds, rect.content_mask);
+    return out;
+}
+
+@fragment
+fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
+    if (any(input.clip_distances < vec4<f32>(0.0))) {
+        return vec4<f32>(0.0);
+    }
+    let rect = b_lens_rects[input.rect_id];
+
+    let center = rect.bounds.origin + rect.bounds.size * 0.5;
+    let half_size = rect.bounds.size * 0.5;
+    let local_pos = input.position.xy - center;
+    let local_len = length(local_pos);
+    let direction = select(
+        vec2<f32>(0.0, 0.0),
+        local_pos / max(local_len, 0.0001),
+        local_len > 0.001,
+    );
+    let safe_half = max(half_size, vec2<f32>(1.0, 1.0));
+    let normalized_dist = clamp(length(local_pos / safe_half), 0.0, 1.0);
+
+    let depth_scale = clamp(rect.depth * 0.01, 0.0, 1.0);
+    let distortion = (1.0 - normalized_dist * normalized_dist) * (1.0 + depth_scale);
+    let offset_px = distortion * direction * rect.refraction * 0.5;
+    let base_uv = input.position.xy / globals.viewport_size;
+    let refracted_uv = base_uv - offset_px / globals.viewport_size;
+
+    let ca_shift = normalized_dist * rect.dispersion;
+    let ca_dir = direction / globals.viewport_size;
+    var color: vec4<f32>;
+    color.r = textureSample(t_blur_input, s_blur_input, refracted_uv - ca_dir * ca_shift).r;
+    color.g = textureSample(t_blur_input, s_blur_input, refracted_uv).g;
+    color.b = textureSample(t_blur_input, s_blur_input, refracted_uv + ca_dir * ca_shift).b;
+    color.a = 1.0;
+
+    let tint_rgba = hsla_to_rgba(rect.tint);
+    color = vec4<f32>(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
+
+    let light_dir = vec2<f32>(rect.light_dir_x, rect.light_dir_y);
+    let sdf = quad_sdf(input.position.xy, rect.bounds, rect.corner_radii);
+    let edge_dist = abs(sdf);
+    let splay_px = max(rect.splay, 1.0);
+    let corner_avg = 0.25 * (
+        rect.corner_radii.top_left
+        + rect.corner_radii.top_right
+        + rect.corner_radii.bottom_right
+        + rect.corner_radii.bottom_left
+    );
+    let edge_band = max(corner_avg * 0.5, splay_px);
+    let edge_falloff = smoothstep(edge_band, 0.0, edge_dist);
+    let facing = select(
+        1.0,
+        clamp(dot(direction, light_dir), 0.0, 1.0),
+        local_len > 0.001,
+    );
+    let edge_glow = edge_falloff * facing * rect.light_intensity;
+    color = color + vec4<f32>(edge_glow, edge_glow, edge_glow, 0.0);
+
+    let antialias_threshold = 0.5;
+    let aa = saturate(antialias_threshold - sdf);
+    return blend_color(color, aa);
+}

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -1372,9 +1372,8 @@ struct LensRect {
     depth: f32,
     dispersion: f32,
     splay: f32,
-    // Stored as two scalars to match Rust's `Point<f32>` natural alignment.
-    light_dir_x: f32,
-    light_dir_y: f32,
+    light_angle_radians: f32,
+    pad_light: f32,
     light_intensity: f32,
     pad: f32,
     tint: Hsla,
@@ -1432,6 +1431,7 @@ struct LensRectVarying {
     @builtin(position) position: vec4<f32>,
     @location(0) @interpolate(flat) rect_id: u32,
     @location(1) clip_distances: vec4<f32>,
+    @location(2) @interpolate(flat) light_dir: vec2<f32>,
 }
 
 @vertex
@@ -1445,6 +1445,10 @@ fn vs_lens_rect(
     out.position = to_device_position(unit_vertex, rect.bounds);
     out.rect_id = instance_id;
     out.clip_distances = distance_from_clip_rect(unit_vertex, rect.bounds, rect.content_mask);
+    out.light_dir = vec2<f32>(
+        cos(rect.light_angle_radians),
+        sin(rect.light_angle_radians),
+    );
     return out;
 }
 
@@ -1484,7 +1488,7 @@ fn fs_lens_rect(input: LensRectVarying) -> @location(0) vec4<f32> {
     let tint_rgba = hsla_to_rgba(rect.tint);
     color = vec4<f32>(mix(color.rgb, tint_rgba.rgb, tint_rgba.a), 1.0);
 
-    let light_dir = vec2<f32>(rect.light_dir_x, rect.light_dir_y);
+    let light_dir = input.light_dir;
     let sdf = quad_sdf(input.position.xy, rect.bounds, rect.corner_radii);
     let edge_dist = abs(sdf);
     let splay_px = max(rect.splay, 1.0);

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -127,9 +127,10 @@ struct WgpuBindGroupLayouts {
     instances_with_texture: wgpu::BindGroupLayout,
     surfaces: wgpu::BindGroupLayout,
     blur_io: wgpu::BindGroupLayout,
-    blur_rect: wgpu::BindGroupLayout,
-    lens_rect: wgpu::BindGroupLayout,
-    mirror_rect: wgpu::BindGroupLayout,
+    blur_scene: wgpu::BindGroupLayout,
+    blur_rect_instances: wgpu::BindGroupLayout,
+    lens_rect_instances: wgpu::BindGroupLayout,
+    mirror_rect_instances: wgpu::BindGroupLayout,
 }
 
 /// Shared GPU context reference, used to coordinate device recovery across multiple windows.
@@ -170,6 +171,12 @@ struct WgpuResources {
     /// populated directly by the render passes, with no intermediate
     /// inter-texture copies.
     blur_down_bind_groups: [Option<wgpu::BindGroup>; BLUR_PYRAMID_LEVELS - 1],
+    /// Cached group(1) bind group shared by blur_rect, lens_rect, and
+    /// mirror_rect pipelines. Contains the pyramid view, sampler, and
+    /// scene_blur_params — all frame-stable resources that only change when
+    /// the pyramid is rebuilt. Created alongside the pyramid in
+    /// `ensure_intermediate_textures`, cleared on invalidation.
+    blur_scene_bind_group: Option<wgpu::BindGroup>,
     blur_sampler: wgpu::Sampler,
     /// Uniform buffer with per-pass `BlurParams` packed at
     /// `min_uniform_buffer_offset_alignment`-sized strides. Bound with
@@ -223,6 +230,7 @@ impl WgpuResources {
         for slot in &mut self.blur_down_bind_groups {
             *slot = None;
         }
+        self.blur_scene_bind_group = None;
     }
 }
 
@@ -619,6 +627,7 @@ impl WgpuRenderer {
             blur_pyramid_view: None,
             blur_pyramid_mip_views: Default::default(),
             blur_down_bind_groups: Default::default(),
+            blur_scene_bind_group: None,
             blur_sampler,
             blur_params_buffer,
             blur_params_slot_stride,
@@ -815,10 +824,10 @@ impl WgpuRenderer {
             },
             count: None,
         };
-        let blur_rect = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("blur_rect_layout"),
+
+        let blur_scene = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("blur_scene_layout"),
             entries: &[
-                storage_buffer_entry(0),
                 wgpu::BindGroupLayoutEntry {
                     binding: 2,
                     visibility: wgpu::ShaderStages::FRAGMENT,
@@ -839,53 +848,19 @@ impl WgpuRenderer {
             ],
         });
 
-        let lens_rect = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("lens_rect_layout"),
-            entries: &[
-                storage_buffer_entry(1),
-                wgpu::BindGroupLayoutEntry {
-                    binding: 2,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Texture {
-                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                        view_dimension: wgpu::TextureViewDimension::D2,
-                        multisampled: false,
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 3,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                    count: None,
-                },
-                storage_buffer_entry(4),
-                scene_blur_params_entry,
-            ],
+        let blur_rect_instances = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("blur_rect_instances_layout"),
+            entries: &[storage_buffer_entry(0)],
         });
 
-        let mirror_rect = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("mirror_rect_layout"),
-            entries: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 2,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Texture {
-                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                        view_dimension: wgpu::TextureViewDimension::D2,
-                        multisampled: false,
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 3,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                    count: None,
-                },
-                storage_buffer_entry(5),
-                scene_blur_params_entry,
-            ],
+        let lens_rect_instances = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("lens_rect_instances_layout"),
+            entries: &[storage_buffer_entry(1), storage_buffer_entry(4)],
+        });
+
+        let mirror_rect_instances = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("mirror_rect_instances_layout"),
+            entries: &[storage_buffer_entry(5)],
         });
 
         WgpuBindGroupLayouts {
@@ -894,9 +869,10 @@ impl WgpuRenderer {
             instances_with_texture,
             surfaces,
             blur_io,
-            blur_rect,
-            lens_rect,
-            mirror_rect,
+            blur_scene,
+            blur_rect_instances,
+            lens_rect_instances,
+            mirror_rect_instances,
         }
     }
 
@@ -1219,37 +1195,78 @@ impl WgpuRenderer {
 
         let blur_downsample = make_blur_io_pipeline("blur_downsample", "fs_blur_downsample");
 
-        let blur_rect = create_pipeline(
+        let create_blur_pipeline = |name: &str,
+                                    vs_entry: &str,
+                                    fs_entry: &str,
+                                    instances_layout: &wgpu::BindGroupLayout,
+                                    color_targets: &[Option<wgpu::ColorTargetState>],
+                                    module: &wgpu::ShaderModule| {
+            let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some(&format!("{name}_layout")),
+                bind_group_layouts: &[
+                    Some(&layouts.globals),
+                    Some(&layouts.blur_scene),
+                    Some(instances_layout),
+                ],
+                immediate_size: 0,
+            });
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some(name),
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module,
+                    entry_point: Some(vs_entry),
+                    buffers: &[],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module,
+                    entry_point: Some(fs_entry),
+                    targets: color_targets,
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleStrip,
+                    strip_index_format: None,
+                    front_face: wgpu::FrontFace::Ccw,
+                    cull_mode: None,
+                    polygon_mode: wgpu::PolygonMode::Fill,
+                    unclipped_depth: false,
+                    conservative: false,
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState {
+                    count: 1,
+                    mask: !0,
+                    alpha_to_coverage_enabled: false,
+                },
+                multiview_mask: None,
+                cache: None,
+            })
+        };
+
+        let blur_rect = create_blur_pipeline(
             "blur_rect",
             "vs_blur_rect",
             "fs_blur_rect",
-            &layouts.globals,
-            &layouts.blur_rect,
-            wgpu::PrimitiveTopology::TriangleStrip,
+            &layouts.blur_rect_instances,
             &[Some(color_target.clone())],
-            1,
             &shader_module,
         );
-        let lens_rect = create_pipeline(
+        let lens_rect = create_blur_pipeline(
             "lens_rect",
             "vs_lens_rect",
             "fs_lens_rect",
-            &layouts.globals,
-            &layouts.lens_rect,
-            wgpu::PrimitiveTopology::TriangleStrip,
+            &layouts.lens_rect_instances,
             &[Some(color_target.clone())],
-            1,
             &shader_module,
         );
-        let mirror_rect = create_pipeline(
+        let mirror_rect = create_blur_pipeline(
             "mirror_rect",
             "vs_mirror_rect",
             "fs_mirror_rect",
-            &layouts.globals,
-            &layouts.mirror_rect,
-            wgpu::PrimitiveTopology::TriangleStrip,
+            &layouts.mirror_rect_instances,
             &[Some(color_target)],
-            1,
             &shader_module,
         );
 
@@ -1481,8 +1498,35 @@ impl WgpuRenderer {
         }
 
         resources.blur_pyramid_texture = Some(pyramid_texture);
-        resources.blur_pyramid_view = Some(pyramid_view);
+        resources.blur_pyramid_view = Some(pyramid_view.clone());
         resources.blur_pyramid_mip_views = mip_views;
+
+        // Cache the group(1) bind group shared by blur/lens/mirror pipelines.
+        // Contains only frame-stable resources (pyramid view, sampler,
+        // scene_blur_params), so it survives across frames until the pyramid
+        // is invalidated.
+        resources.blur_scene_bind_group = Some(
+            resources
+                .device
+                .create_bind_group(&wgpu::BindGroupDescriptor {
+                    label: Some("blur_scene_bind_group"),
+                    layout: &resources.bind_group_layouts.blur_scene,
+                    entries: &[
+                        wgpu::BindGroupEntry {
+                            binding: 2,
+                            resource: wgpu::BindingResource::TextureView(&pyramid_view),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 3,
+                            resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 6,
+                            resource: resources.scene_blur_params_buffer.as_entire_binding(),
+                        },
+                    ],
+                }),
+        );
 
         // Pre-build one bind group per downsample pass. Pass `i` samples
         // `mip_views[i]` and writes `mip_views[i + 1]`. Only pairs up to
@@ -2357,36 +2401,23 @@ impl WgpuRenderer {
             return false;
         };
         let resources = self.resources();
-        let Some(pyramid_view) = resources.blur_pyramid_view.as_ref() else {
+        let Some(scene_bind_group) = resources.blur_scene_bind_group.as_ref() else {
             return true;
         };
-        let bind_group = resources
+        let instances_bind_group = resources
             .device
             .create_bind_group(&wgpu::BindGroupDescriptor {
-                label: Some("blur_rect_bind_group"),
-                layout: &resources.bind_group_layouts.blur_rect,
-                entries: &[
-                    wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: self.instance_binding(offset, size),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 2,
-                        resource: wgpu::BindingResource::TextureView(pyramid_view),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 3,
-                        resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 6,
-                        resource: resources.scene_blur_params_buffer.as_entire_binding(),
-                    },
-                ],
+                label: Some("blur_rect_instances_bind_group"),
+                layout: &resources.bind_group_layouts.blur_rect_instances,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: self.instance_binding(offset, size),
+                }],
             });
         pass.set_pipeline(&resources.pipelines.blur_rect);
         pass.set_bind_group(0, &resources.globals_bind_group, &[]);
-        pass.set_bind_group(1, &bind_group, &[]);
+        pass.set_bind_group(1, scene_bind_group, &[]);
+        pass.set_bind_group(2, &instances_bind_group, &[]);
         pass.draw(0..4, 0..rects.len() as u32);
         true
     }
@@ -2417,40 +2448,29 @@ impl WgpuRenderer {
             return false;
         };
         let resources = self.resources();
-        let Some(pyramid_view) = resources.blur_pyramid_view.as_ref() else {
+        let Some(scene_bind_group) = resources.blur_scene_bind_group.as_ref() else {
             return true;
         };
-        let bind_group = resources
+        let instances_bind_group = resources
             .device
             .create_bind_group(&wgpu::BindGroupDescriptor {
-                label: Some("lens_rect_bind_group"),
-                layout: &resources.bind_group_layouts.lens_rect,
+                label: Some("lens_rect_instances_bind_group"),
+                layout: &resources.bind_group_layouts.lens_rect_instances,
                 entries: &[
                     wgpu::BindGroupEntry {
                         binding: 1,
                         resource: self.instance_binding(rects_offset, rects_size),
                     },
                     wgpu::BindGroupEntry {
-                        binding: 2,
-                        resource: wgpu::BindingResource::TextureView(pyramid_view),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 3,
-                        resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
-                    },
-                    wgpu::BindGroupEntry {
                         binding: 4,
                         resource: self.instance_binding(shapes_offset, shapes_size),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 6,
-                        resource: resources.scene_blur_params_buffer.as_entire_binding(),
                     },
                 ],
             });
         pass.set_pipeline(&resources.pipelines.lens_rect);
         pass.set_bind_group(0, &resources.globals_bind_group, &[]);
-        pass.set_bind_group(1, &bind_group, &[]);
+        pass.set_bind_group(1, scene_bind_group, &[]);
+        pass.set_bind_group(2, &instances_bind_group, &[]);
         pass.draw(0..4, 0..rects.len() as u32);
         true
     }
@@ -2469,36 +2489,23 @@ impl WgpuRenderer {
             return false;
         };
         let resources = self.resources();
-        let Some(pyramid_view) = resources.blur_pyramid_view.as_ref() else {
+        let Some(scene_bind_group) = resources.blur_scene_bind_group.as_ref() else {
             return true;
         };
-        let bind_group = resources
+        let instances_bind_group = resources
             .device
             .create_bind_group(&wgpu::BindGroupDescriptor {
-                label: Some("mirror_rect_bind_group"),
-                layout: &resources.bind_group_layouts.mirror_rect,
-                entries: &[
-                    wgpu::BindGroupEntry {
-                        binding: 2,
-                        resource: wgpu::BindingResource::TextureView(pyramid_view),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 3,
-                        resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 5,
-                        resource: self.instance_binding(offset, size),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 6,
-                        resource: resources.scene_blur_params_buffer.as_entire_binding(),
-                    },
-                ],
+                label: Some("mirror_rect_instances_bind_group"),
+                layout: &resources.bind_group_layouts.mirror_rect_instances,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 5,
+                    resource: self.instance_binding(offset, size),
+                }],
             });
         pass.set_pipeline(&resources.pipelines.mirror_rect);
         pass.set_bind_group(0, &resources.globals_bind_group, &[]);
-        pass.set_bind_group(1, &bind_group, &[]);
+        pass.set_bind_group(1, scene_bind_group, &[]);
+        pass.set_bind_group(2, &instances_bind_group, &[]);
         pass.draw(0..4, 0..rects.len() as u32);
         true
     }

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -2363,6 +2363,28 @@ impl WgpuRenderer {
             self.surface_config.present_mode = mode;
         }
 
+        // The new surface's adapter may advertise different capabilities than
+        // the original. Re-query COPY_SRC so blur/lens draws don't panic in
+        // `surface.configure` (if the flag was previously true but the new
+        // adapter doesn't support it) or stay silently skipped forever (if
+        // the flag was previously false but the new adapter does support it).
+        let surface_supports_copy_src = self
+            .context
+            .as_ref()
+            .and_then(|ctx| ctx.borrow().as_ref().map(|wgpu_ctx| {
+                surface
+                    .get_capabilities(&wgpu_ctx.adapter)
+                    .usages
+                    .contains(wgpu::TextureUsages::COPY_SRC)
+            }))
+            .unwrap_or(false);
+        if surface_supports_copy_src {
+            self.surface_config.usage |= wgpu::TextureUsages::COPY_SRC;
+        } else {
+            self.surface_config.usage -= wgpu::TextureUsages::COPY_SRC;
+        }
+        self.surface_supports_copy_src = surface_supports_copy_src;
+
         {
             let res = self
                 .resources

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -1081,61 +1081,27 @@ impl WgpuRenderer {
         let blur_downsample = make_blur_io_pipeline("blur_downsample", "fs_blur_downsample");
         let blur_upsample = make_blur_io_pipeline("blur_upsample", "fs_blur_upsample");
 
-        let make_rect_pipeline = |name: &str,
-                                  vs_entry: &str,
-                                  fs_entry: &str,
-                                  data_layout: &wgpu::BindGroupLayout| {
-            let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                label: Some(&format!("{name}_pipeline_layout")),
-                bind_group_layouts: &[Some(&layouts.globals), Some(data_layout)],
-                immediate_size: 0,
-            });
-            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                label: Some(name),
-                layout: Some(&pipeline_layout),
-                vertex: wgpu::VertexState {
-                    module: &shader_module,
-                    entry_point: Some(vs_entry),
-                    buffers: &[],
-                    compilation_options: wgpu::PipelineCompilationOptions::default(),
-                },
-                fragment: Some(wgpu::FragmentState {
-                    module: &shader_module,
-                    entry_point: Some(fs_entry),
-                    targets: &[Some(color_target.clone())],
-                    compilation_options: wgpu::PipelineCompilationOptions::default(),
-                }),
-                primitive: wgpu::PrimitiveState {
-                    topology: wgpu::PrimitiveTopology::TriangleStrip,
-                    strip_index_format: None,
-                    front_face: wgpu::FrontFace::Ccw,
-                    cull_mode: None,
-                    polygon_mode: wgpu::PolygonMode::Fill,
-                    unclipped_depth: false,
-                    conservative: false,
-                },
-                depth_stencil: None,
-                multisample: wgpu::MultisampleState {
-                    count: 1,
-                    mask: !0,
-                    alpha_to_coverage_enabled: false,
-                },
-                multiview_mask: None,
-                cache: None,
-            })
-        };
-
-        let blur_rect = make_rect_pipeline(
+        let blur_rect = create_pipeline(
             "blur_rect",
             "vs_blur_rect",
             "fs_blur_rect",
+            &layouts.globals,
             &layouts.blur_rect,
+            wgpu::PrimitiveTopology::TriangleStrip,
+            &[Some(color_target.clone())],
+            1,
+            &shader_module,
         );
-        let lens_rect = make_rect_pipeline(
+        let lens_rect = create_pipeline(
             "lens_rect",
             "vs_lens_rect",
             "fs_lens_rect",
+            &layouts.globals,
             &layouts.lens_rect,
+            wgpu::PrimitiveTopology::TriangleStrip,
+            &[Some(color_target.clone())],
+            1,
+            &shader_module,
         );
 
         WgpuPipelines {

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -2650,14 +2650,24 @@ mod tests {
     async fn try_headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
         let instance =
             wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
-        let adapter = instance
+        let adapter = match instance
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::default(),
                 compatible_surface: None,
                 force_fallback_adapter: false,
             })
             .await
-            .ok()?;
+        {
+            Ok(a) => a,
+            Err(_) => instance
+                .request_adapter(&wgpu::RequestAdapterOptions {
+                    power_preference: wgpu::PowerPreference::default(),
+                    compatible_surface: None,
+                    force_fallback_adapter: true,
+                })
+                .await
+                .ok()?,
+        };
         let (device, queue) = adapter
             .request_device(&wgpu::DeviceDescriptor {
                 label: Some("gpui_wgpu_pipeline_smoke"),
@@ -2672,12 +2682,41 @@ mod tests {
         Some((device, queue))
     }
 
+    /// Parse every WGSL source file used by the renderer via naga. Catches
+    /// syntax / type errors without needing a GPU, which is important
+    /// because `pipeline_creation_smoke` silently skips on adapter-less CI.
+    #[test]
+    fn wgsl_shaders_parse() {
+        let base = include_str!("shaders.wgsl");
+        let subpixel = include_str!("shaders_subpixel.wgsl");
+        let blur_io = include_str!("blur_io_shaders.wgsl");
+        let dual_source_bundle =
+            format!("enable dual_source_blending;\n{base}\n{subpixel}");
+        let sources = [
+            ("shaders.wgsl", base.to_string()),
+            ("blur_io_shaders.wgsl", blur_io.to_string()),
+            (
+                "shaders.wgsl + shaders_subpixel.wgsl (dual-source)",
+                dual_source_bundle,
+            ),
+        ];
+        for (name, source) in sources {
+            naga::front::wgsl::parse_str(&source)
+                .unwrap_or_else(|err| panic!("{name}: WGSL parse error: {err}"));
+        }
+    }
+
     /// Compiles every render pipeline used by the renderer, including the
     /// new `blur_downsample` / `blur_upsample` / `blur_rect` / `lens_rect`
-    /// ones. Skipped when no wgpu adapter is available (CI without a GPU).
+    /// ones. Silently skipped locally when no adapter is available; panics
+    /// on CI (`CI` env var set) so a missing adapter is loud rather than
+    /// hidden in green build output.
     #[test]
     fn pipeline_creation_smoke() {
         let Some((device, _queue)) = pollster::block_on(try_headless_device()) else {
+            if std::env::var("CI").is_ok() {
+                panic!("pipeline_creation_smoke requires a wgpu adapter on CI");
+            }
             eprintln!("skipping pipeline_creation_smoke: no wgpu adapter available");
             return;
         };

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -58,7 +58,7 @@ struct GammaParams {
 struct BlurParams {
     viewport_size: [f32; 2],
     offset_multiplier: f32,
-    _pad: f32,
+    pad: f32,
 }
 
 #[derive(Clone, Debug)]
@@ -1935,12 +1935,12 @@ impl WgpuRenderer {
         let blur_params_full = BlurParams {
             viewport_size: [width as f32, height as f32],
             offset_multiplier: 1.0,
-            _pad: 0.0,
+            pad: 0.0,
         };
         let blur_params_half = BlurParams {
             viewport_size: [half_width as f32, half_height as f32],
             offset_multiplier: 1.0,
-            _pad: 0.0,
+            pad: 0.0,
         };
 
         let resources = self.resources();

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -134,12 +134,27 @@ struct WgpuResources {
     path_intermediate_view: Option<wgpu::TextureView>,
     path_msaa_texture: Option<wgpu::Texture>,
     path_msaa_view: Option<wgpu::TextureView>,
-    blur_snapshot_texture: Option<wgpu::Texture>,
-    blur_snapshot_view: Option<wgpu::TextureView>,
-    blur_half_texture: Option<wgpu::Texture>,
-    blur_half_view: Option<wgpu::TextureView>,
+    /// Dual-Kawase scratch chain. `blur_chain_textures[0]` is surface-sized
+    /// and receives the framebuffer snapshot; each subsequent level is
+    /// half-sized. `BlurEffect::kernel_levels` selects the depth used per
+    /// frame (1..=5).
+    blur_chain_textures: [Option<wgpu::Texture>; BLUR_CHAIN_LEVELS],
+    blur_chain_views: [Option<wgpu::TextureView>; BLUR_CHAIN_LEVELS],
+    /// Bind groups pre-built for downsample/upsample passes. Downsample
+    /// pass `i` samples level `i` and writes level `i + 1`; upsample pass
+    /// `i` samples level `i + 1` and writes level `i`.
+    blur_down_bind_groups: [Option<wgpu::BindGroup>; BLUR_CHAIN_LEVELS - 1],
+    blur_up_bind_groups: [Option<wgpu::BindGroup>; BLUR_CHAIN_LEVELS - 1],
     blur_sampler: wgpu::Sampler,
+    /// Uniform buffer with per-pass `BlurParams` packed at
+    /// `min_uniform_buffer_offset_alignment`-sized strides. Bound with
+    /// dynamic offsets so each of the 2 × `BLUR_CHAIN_LEVELS - 1` passes
+    /// reads its own slot.
     blur_params_buffer: wgpu::Buffer,
+    /// Stride between adjacent `BlurParams` slots in `blur_params_buffer`,
+    /// equal to `size_of::<BlurParams>()` rounded up to
+    /// `min_uniform_buffer_offset_alignment`.
+    blur_params_slot_stride: u64,
 }
 
 impl WgpuResources {
@@ -148,12 +163,31 @@ impl WgpuResources {
         self.path_intermediate_view = None;
         self.path_msaa_texture = None;
         self.path_msaa_view = None;
-        self.blur_snapshot_texture = None;
-        self.blur_snapshot_view = None;
-        self.blur_half_texture = None;
-        self.blur_half_view = None;
+        for slot in &mut self.blur_chain_textures {
+            *slot = None;
+        }
+        for slot in &mut self.blur_chain_views {
+            *slot = None;
+        }
+        for slot in &mut self.blur_down_bind_groups {
+            *slot = None;
+        }
+        for slot in &mut self.blur_up_bind_groups {
+            *slot = None;
+        }
     }
 }
+
+/// Maximum blur chain depth (`kernel_levels` is clamped to this). Each
+/// level is half the resolution of the previous; level 0 is the surface
+/// snapshot.
+const BLUR_CHAIN_LEVELS: usize = 6;
+/// One `BlurParams` slot per Kawase pass (down + up over the transitions
+/// between adjacent chain levels).
+const BLUR_PARAMS_SLOT_COUNT: usize = 2 * (BLUR_CHAIN_LEVELS - 1);
+/// Reference blur radius. `BlurEffect::radius` scales the Kawase offset
+/// multiplier linearly relative to this.
+const BLUR_REFERENCE_RADIUS_PX: f32 = 20.0;
 
 pub struct WgpuRenderer {
     /// Shared GPU context for device recovery coordination (unused on WASM).
@@ -418,18 +452,20 @@ impl WgpuRenderer {
             ..Default::default()
         });
 
-        let blur_params_buffer = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("blur_params_buffer"),
-            size: std::mem::size_of::<BlurParams>() as u64,
-            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-
         let uniform_alignment = device.limits().min_uniform_buffer_offset_alignment as u64;
         let globals_size = std::mem::size_of::<GlobalParams>() as u64;
         let gamma_size = std::mem::size_of::<GammaParams>() as u64;
         let path_globals_offset = globals_size.next_multiple_of(uniform_alignment);
         let gamma_offset = (path_globals_offset + globals_size).next_multiple_of(uniform_alignment);
+
+        let blur_params_slot_stride = (std::mem::size_of::<BlurParams>() as u64)
+            .next_multiple_of(uniform_alignment);
+        let blur_params_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("blur_params_buffer"),
+            size: blur_params_slot_stride * BLUR_PARAMS_SLOT_COUNT as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
 
         let globals_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("globals_buffer"),
@@ -520,12 +556,13 @@ impl WgpuRenderer {
             path_intermediate_view: None,
             path_msaa_texture: None,
             path_msaa_view: None,
-            blur_snapshot_texture: None,
-            blur_snapshot_view: None,
-            blur_half_texture: None,
-            blur_half_view: None,
+            blur_chain_textures: Default::default(),
+            blur_chain_views: Default::default(),
+            blur_down_bind_groups: Default::default(),
+            blur_up_bind_groups: Default::default(),
             blur_sampler,
             blur_params_buffer,
+            blur_params_slot_stride,
         };
 
         Ok(Self {
@@ -694,7 +731,7 @@ impl WgpuRenderer {
                     visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
+                        has_dynamic_offset: true,
                         min_binding_size: NonZeroU64::new(
                             std::mem::size_of::<BlurParams>() as u64
                         ),
@@ -1210,11 +1247,10 @@ impl WgpuRenderer {
             if let Some(ref texture) = resources.path_msaa_texture {
                 texture.destroy();
             }
-            if let Some(ref texture) = resources.blur_snapshot_texture {
-                texture.destroy();
-            }
-            if let Some(ref texture) = resources.blur_half_texture {
-                texture.destroy();
+            for slot in &resources.blur_chain_textures {
+                if let Some(texture) = slot.as_ref() {
+                    texture.destroy();
+                }
             }
 
             resources
@@ -1229,7 +1265,9 @@ impl WgpuRenderer {
     }
 
     fn ensure_intermediate_textures(&mut self) {
-        if self.resources().path_intermediate_texture.is_some() {
+        let needs_path = self.resources().path_intermediate_texture.is_none();
+        let needs_blur = self.resources().blur_chain_textures[0].is_none();
+        if !needs_path && !needs_blur {
             return;
         }
 
@@ -1239,72 +1277,119 @@ impl WgpuRenderer {
         let path_sample_count = self.rendering_params.path_sample_count;
         let resources = self.resources_mut();
 
-        let (t, v) = Self::create_path_intermediate(&resources.device, format, width, height);
-        resources.path_intermediate_texture = Some(t);
-        resources.path_intermediate_view = Some(v);
+        if needs_path {
+            let (t, v) = Self::create_path_intermediate(&resources.device, format, width, height);
+            resources.path_intermediate_texture = Some(t);
+            resources.path_intermediate_view = Some(v);
 
-        let (path_msaa_texture, path_msaa_view) = Self::create_msaa_if_needed(
-            &resources.device,
-            format,
-            width,
-            height,
-            path_sample_count,
-        )
-        .map(|(t, v)| (Some(t), Some(v)))
-        .unwrap_or((None, None));
-        resources.path_msaa_texture = path_msaa_texture;
-        resources.path_msaa_view = path_msaa_view;
-    }
-
-    fn ensure_blur_textures(&mut self) {
-        if self.resources().blur_snapshot_texture.is_some() {
-            return;
-        }
-
-        let format = self.surface_config.format;
-        let width = self.surface_config.width.max(1);
-        let height = self.surface_config.height.max(1);
-        let half_width = (width / 2).max(1);
-        let half_height = (height / 2).max(1);
-        let resources = self.resources_mut();
-
-        let snapshot = resources.device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("blur_snapshot"),
-            size: wgpu::Extent3d {
+            let (path_msaa_texture, path_msaa_view) = Self::create_msaa_if_needed(
+                &resources.device,
+                format,
                 width,
                 height,
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format,
-            usage: wgpu::TextureUsages::COPY_DST
-                | wgpu::TextureUsages::RENDER_ATTACHMENT
-                | wgpu::TextureUsages::TEXTURE_BINDING,
-            view_formats: &[],
-        });
-        let snapshot_view = snapshot.create_view(&wgpu::TextureViewDescriptor::default());
-        resources.blur_snapshot_texture = Some(snapshot);
-        resources.blur_snapshot_view = Some(snapshot_view);
+                path_sample_count,
+            )
+            .map(|(t, v)| (Some(t), Some(v)))
+            .unwrap_or((None, None));
+            resources.path_msaa_texture = path_msaa_texture;
+            resources.path_msaa_view = path_msaa_view;
+        }
 
-        let half = resources.device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("blur_half"),
-            size: wgpu::Extent3d {
-                width: half_width,
-                height: half_height,
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
-            view_formats: &[],
-        });
-        let half_view = half.create_view(&wgpu::TextureViewDescriptor::default());
-        resources.blur_half_texture = Some(half);
-        resources.blur_half_view = Some(half_view);
+        if needs_blur {
+            Self::create_blur_chain(resources, format, width, height);
+        }
+    }
+
+    fn create_blur_chain(
+        resources: &mut WgpuResources,
+        surface_format: wgpu::TextureFormat,
+        width: u32,
+        height: u32,
+    ) {
+        // Use the non-sRGB variant of the surface format so the manual
+        // gamma chain in `blur_io_shaders.wgsl` is not double-applied when
+        // the surface itself is sRGB. When the surface is already
+        // non-sRGB this is a no-op.
+        let chain_format = surface_format.remove_srgb_suffix();
+
+        for level in 0..BLUR_CHAIN_LEVELS {
+            let level_width = (width >> level).max(1);
+            let level_height = (height >> level).max(1);
+            let usage = if level == 0 {
+                wgpu::TextureUsages::COPY_DST
+                    | wgpu::TextureUsages::RENDER_ATTACHMENT
+                    | wgpu::TextureUsages::TEXTURE_BINDING
+            } else {
+                wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING
+            };
+            let texture = resources.device.create_texture(&wgpu::TextureDescriptor {
+                label: Some(&format!("blur_chain_{level}")),
+                size: wgpu::Extent3d {
+                    width: level_width,
+                    height: level_height,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: chain_format,
+                usage,
+                view_formats: &[],
+            });
+            let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+            resources.blur_chain_textures[level] = Some(texture);
+            resources.blur_chain_views[level] = Some(view);
+        }
+
+        // Pre-build every bind group for the passes the chain can host.
+        // Each pass reads one level and writes the adjacent level; the
+        // bind-group inputs (source view + sampler + params buffer) are
+        // stable for the lifetime of the chain.
+        for i in 0..BLUR_CHAIN_LEVELS - 1 {
+            let src_view = resources.blur_chain_views[i]
+                .as_ref()
+                .expect("chain view allocated above");
+            resources.blur_down_bind_groups[i] =
+                Some(Self::create_blur_io_bind_group(resources, src_view, "blur_down"));
+        }
+        for i in 0..BLUR_CHAIN_LEVELS - 1 {
+            let src_view = resources.blur_chain_views[i + 1]
+                .as_ref()
+                .expect("chain view allocated above");
+            resources.blur_up_bind_groups[i] =
+                Some(Self::create_blur_io_bind_group(resources, src_view, "blur_up"));
+        }
+    }
+
+    fn create_blur_io_bind_group(
+        resources: &WgpuResources,
+        source_view: &wgpu::TextureView,
+        label_prefix: &str,
+    ) -> wgpu::BindGroup {
+        resources
+            .device
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some(&format!("{label_prefix}_bind_group")),
+                layout: &resources.bind_group_layouts.blur_io,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(source_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                            buffer: &resources.blur_params_buffer,
+                            offset: 0,
+                            size: NonZeroU64::new(std::mem::size_of::<BlurParams>() as u64),
+                        }),
+                    },
+                ],
+            })
     }
 
     pub fn update_transparency(&mut self, transparent: bool) {
@@ -1480,6 +1565,10 @@ impl WgpuRenderer {
             );
         }
 
+        let blur_kernel_levels = scene.max_blur_kernel_levels();
+        let blur_radius = scene.max_blur_radius().0;
+        let blur_offset_multiplier = (blur_radius / BLUR_REFERENCE_RADIUS_PX).clamp(0.1, 4.0);
+
         loop {
             let mut instance_offset: u64 = 0;
             let mut overflow = false;
@@ -1595,8 +1684,12 @@ impl WgpuRenderer {
 
                             drop(pass);
 
-                            let did_snapshot =
-                                self.snapshot_and_blur_frame(&mut encoder, &frame.texture);
+                            let did_snapshot = self.snapshot_and_blur_frame(
+                                &mut encoder,
+                                &frame.texture,
+                                blur_kernel_levels,
+                                blur_offset_multiplier,
+                            );
 
                             pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                                 label: Some("main_pass_continued_blur"),
@@ -1627,8 +1720,12 @@ impl WgpuRenderer {
 
                             drop(pass);
 
-                            let did_snapshot =
-                                self.snapshot_and_blur_frame(&mut encoder, &frame.texture);
+                            let did_snapshot = self.snapshot_and_blur_frame(
+                                &mut encoder,
+                                &frame.texture,
+                                blur_kernel_levels,
+                                blur_offset_multiplier,
+                            );
 
                             pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                                 label: Some("main_pass_continued_lens"),
@@ -1876,50 +1973,80 @@ impl WgpuRenderer {
         }
     }
 
-    /// Copy the current swapchain contents into `blur_snapshot_texture` and
-    /// run a dual-Kawase down/up pass that leaves the blurred result back in
-    /// `blur_snapshot_texture`. Returns `false` if the platform cannot
-    /// snapshot the framebuffer (COPY_SRC missing) or if scratch textures
-    /// aren't allocated yet; callers should skip the blur/lens draw in that
-    /// case.
+    /// Copy the current swapchain contents into `blur_chain_textures[0]`
+    /// and run `kernel_levels` downsample + upsample passes (dual-Kawase).
+    /// The blurred result ends up back in `blur_chain_textures[0]`, which
+    /// `fs_blur_rect` / `fs_lens_rect` sample.
+    ///
+    /// `offset_multiplier` scales the Kawase tap offset; typically
+    /// `BlurEffect::radius / BLUR_REFERENCE_RADIUS_PX`.
+    ///
+    /// Returns `false` if the platform cannot snapshot the framebuffer
+    /// (COPY_SRC missing) or if scratch textures aren't allocated yet;
+    /// callers should skip the blur/lens draw in that case.
     fn snapshot_and_blur_frame(
         &mut self,
         encoder: &mut wgpu::CommandEncoder,
         frame_texture: &wgpu::Texture,
+        kernel_levels: u32,
+        offset_multiplier: f32,
     ) -> bool {
         if !self.surface_supports_copy_src {
             return false;
         }
 
-        self.ensure_blur_textures();
+        let kernel_levels = kernel_levels.clamp(1, (BLUR_CHAIN_LEVELS - 1) as u32) as usize;
+        self.ensure_intermediate_textures();
 
         let width = self.surface_config.width.max(1);
         let height = self.surface_config.height.max(1);
-        let half_width = (width / 2).max(1);
-        let half_height = (height / 2).max(1);
-
-        let blur_params_full = BlurParams {
-            viewport_size: [width as f32, height as f32],
-            offset_multiplier: 1.0,
-            pad: 0.0,
-        };
-        let blur_params_half = BlurParams {
-            viewport_size: [half_width as f32, half_height as f32],
-            offset_multiplier: 1.0,
-            pad: 0.0,
-        };
-
         let resources = self.resources();
-        let (Some(snapshot_tex), Some(snapshot_view), Some(half_tex), Some(half_view)) = (
-            resources.blur_snapshot_texture.as_ref(),
-            resources.blur_snapshot_view.as_ref(),
-            resources.blur_half_texture.as_ref(),
-            resources.blur_half_view.as_ref(),
-        ) else {
-            return false;
-        };
 
-        let _ = half_tex;
+        if resources.blur_chain_textures[0].is_none() {
+            return false;
+        }
+
+        // Pack per-pass BlurParams. Slot layout:
+        //   0..kernel_levels              → downsample passes (i → i+1)
+        //   kernel_levels..2*kernel_levels → upsample passes  (i+1 → i),
+        //                                     iterated back down.
+        let slot_stride = resources.blur_params_slot_stride;
+        let mut slot_bytes = vec![0u8; (slot_stride as usize) * BLUR_PARAMS_SLOT_COUNT];
+        let write_slot = |slot_bytes: &mut [u8], slot: usize, params: BlurParams| {
+            let offset = slot * slot_stride as usize;
+            slot_bytes[offset..offset + std::mem::size_of::<BlurParams>()]
+                .copy_from_slice(bytemuck::bytes_of(&params));
+        };
+        for i in 0..kernel_levels {
+            let src_w = (width >> i).max(1);
+            let src_h = (height >> i).max(1);
+            write_slot(
+                &mut slot_bytes,
+                i,
+                BlurParams {
+                    viewport_size: [src_w as f32, src_h as f32],
+                    offset_multiplier,
+                    pad: 0.0,
+                },
+            );
+        }
+        for step in 0..kernel_levels {
+            let src_level = kernel_levels - step;
+            let src_w = (width >> src_level).max(1);
+            let src_h = (height >> src_level).max(1);
+            write_slot(
+                &mut slot_bytes,
+                kernel_levels + step,
+                BlurParams {
+                    viewport_size: [src_w as f32, src_h as f32],
+                    offset_multiplier,
+                    pad: 0.0,
+                },
+            );
+        }
+        resources
+            .queue
+            .write_buffer(&resources.blur_params_buffer, 0, &slot_bytes);
 
         encoder.copy_texture_to_texture(
             wgpu::TexelCopyTextureInfo {
@@ -1929,7 +2056,9 @@ impl WgpuRenderer {
                 aspect: wgpu::TextureAspect::All,
             },
             wgpu::TexelCopyTextureInfo {
-                texture: snapshot_tex,
+                texture: resources.blur_chain_textures[0]
+                    .as_ref()
+                    .expect("chain level 0 checked above"),
                 mip_level: 0,
                 origin: wgpu::Origin3d::ZERO,
                 aspect: wgpu::TextureAspect::All,
@@ -1941,37 +2070,18 @@ impl WgpuRenderer {
             },
         );
 
-        // Downsample: snapshot (full) → half.
-        resources.queue.write_buffer(
-            &resources.blur_params_buffer,
-            0,
-            bytemuck::bytes_of(&blur_params_full),
-        );
-        let down_bind_group = resources
-            .device
-            .create_bind_group(&wgpu::BindGroupDescriptor {
-                label: Some("blur_downsample_bind_group"),
-                layout: &resources.bind_group_layouts.blur_io,
-                entries: &[
-                    wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: wgpu::BindingResource::TextureView(snapshot_view),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 1,
-                        resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 2,
-                        resource: resources.blur_params_buffer.as_entire_binding(),
-                    },
-                ],
-            });
-        {
+        for i in 0..kernel_levels {
+            let dst_view = resources.blur_chain_views[i + 1]
+                .as_ref()
+                .expect("chain view allocated");
+            let bind_group = resources.blur_down_bind_groups[i]
+                .as_ref()
+                .expect("down bind group allocated");
+            let dynamic_offset = (i as u64 * slot_stride) as u32;
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("blur_downsample_pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: half_view,
+                    view: dst_view,
                     resolve_target: None,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
@@ -1983,41 +2093,23 @@ impl WgpuRenderer {
                 ..Default::default()
             });
             pass.set_pipeline(&resources.pipelines.blur_downsample);
-            pass.set_bind_group(0, &down_bind_group, &[]);
+            pass.set_bind_group(0, bind_group, &[dynamic_offset]);
             pass.draw(0..3, 0..1);
         }
 
-        // Upsample: half → snapshot (overwrites snapshot with the blurred result).
-        resources.queue.write_buffer(
-            &resources.blur_params_buffer,
-            0,
-            bytemuck::bytes_of(&blur_params_half),
-        );
-        let up_bind_group = resources
-            .device
-            .create_bind_group(&wgpu::BindGroupDescriptor {
-                label: Some("blur_upsample_bind_group"),
-                layout: &resources.bind_group_layouts.blur_io,
-                entries: &[
-                    wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: wgpu::BindingResource::TextureView(half_view),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 1,
-                        resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 2,
-                        resource: resources.blur_params_buffer.as_entire_binding(),
-                    },
-                ],
-            });
-        {
+        for step in 0..kernel_levels {
+            let dst_level = kernel_levels - step - 1;
+            let dst_view = resources.blur_chain_views[dst_level]
+                .as_ref()
+                .expect("chain view allocated");
+            let bind_group = resources.blur_up_bind_groups[dst_level]
+                .as_ref()
+                .expect("up bind group allocated");
+            let dynamic_offset = ((kernel_levels + step) as u64 * slot_stride) as u32;
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("blur_upsample_pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: snapshot_view,
+                    view: dst_view,
                     resolve_target: None,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
@@ -2029,7 +2121,7 @@ impl WgpuRenderer {
                 ..Default::default()
             });
             pass.set_pipeline(&resources.pipelines.blur_upsample);
-            pass.set_bind_group(0, &up_bind_group, &[]);
+            pass.set_bind_group(0, bind_group, &[dynamic_offset]);
             pass.draw(0..3, 0..1);
         }
 
@@ -2050,7 +2142,7 @@ impl WgpuRenderer {
             return false;
         };
         let resources = self.resources();
-        let Some(snapshot_view) = resources.blur_snapshot_view.as_ref() else {
+        let Some(snapshot_view) = resources.blur_chain_views[0].as_ref() else {
             return true;
         };
         let bind_group = resources
@@ -2094,7 +2186,7 @@ impl WgpuRenderer {
             return false;
         };
         let resources = self.resources();
-        let Some(snapshot_view) = resources.blur_snapshot_view.as_ref() else {
+        let Some(snapshot_view) = resources.blur_chain_views[0].as_ref() else {
             return true;
         };
         let bind_group = resources

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -116,7 +116,6 @@ struct WgpuPipelines {
     #[allow(dead_code)]
     surfaces: wgpu::RenderPipeline,
     blur_downsample: wgpu::RenderPipeline,
-    blur_upsample: wgpu::RenderPipeline,
     blur_rect: wgpu::RenderPipeline,
     lens_rect: wgpu::RenderPipeline,
     mirror_rect: wgpu::RenderPipeline,
@@ -152,68 +151,90 @@ struct WgpuResources {
     path_intermediate_view: Option<wgpu::TextureView>,
     path_msaa_texture: Option<wgpu::Texture>,
     path_msaa_view: Option<wgpu::TextureView>,
-    /// Dual-Kawase scratch chain. `blur_chain_textures[0]` is surface-sized
-    /// and receives the framebuffer snapshot; each subsequent level is
-    /// half-sized. `BlurEffect::kernel_levels` selects the depth used per
-    /// frame (1..=5).
-    blur_chain_textures: [Option<wgpu::Texture>; BLUR_CHAIN_LEVELS],
-    blur_chain_views: [Option<wgpu::TextureView>; BLUR_CHAIN_LEVELS],
-    /// Preserved downsample pyramid: a single mipmapped texture where mip
-    /// 0 is the un-blurred framebuffer snapshot and each subsequent mip
-    /// holds the Kawase-downsample result of the previous level. Fragment
-    /// shaders sample this with `textureSampleLevel` at fractional LOD to
-    /// produce a per-pixel variable-radius blur.
+    /// Downsample pyramid: a single mipmapped texture where mip 0 is the
+    /// un-blurred framebuffer snapshot and each subsequent mip holds the
+    /// Kawase-downsample result of the previous level. Used as both a
+    /// render target (via per-mip views) and a sampled input (via a
+    /// full-mip view so `fs_blur_rect` / `fs_lens_rect` can pick fractional
+    /// LOD for a per-pixel variable-radius blur).
     blur_pyramid_texture: Option<wgpu::Texture>,
     blur_pyramid_view: Option<wgpu::TextureView>,
-    /// Bind groups pre-built for downsample/upsample passes. Downsample
-    /// pass `i` samples level `i` and writes level `i + 1`; upsample pass
-    /// `i` samples level `i + 1` and writes level `i`.
-    blur_down_bind_groups: [Option<wgpu::BindGroup>; BLUR_CHAIN_LEVELS - 1],
-    blur_up_bind_groups: [Option<wgpu::BindGroup>; BLUR_CHAIN_LEVELS - 1],
+    /// One single-mip view per pyramid level, used both as the render
+    /// target when writing mip `i + 1` and as the sampled input when
+    /// reading mip `i`. A mip-restricted view (`base_mip_level = i`,
+    /// `mip_level_count = 1`) keeps the downsample pass's read/write
+    /// subresources disjoint so wgpu's resource-tracking is satisfied.
+    blur_pyramid_mip_views: [Option<wgpu::TextureView>; BLUR_PYRAMID_LEVELS],
+    /// Bind groups pre-built for downsample passes. Pass `i` samples
+    /// pyramid mip `i` and writes pyramid mip `i + 1`; mips 1..N end up
+    /// populated directly by the render passes, with no intermediate
+    /// inter-texture copies.
+    blur_down_bind_groups: [Option<wgpu::BindGroup>; BLUR_PYRAMID_LEVELS - 1],
     blur_sampler: wgpu::Sampler,
     /// Uniform buffer with per-pass `BlurParams` packed at
     /// `min_uniform_buffer_offset_alignment`-sized strides. Bound with
-    /// dynamic offsets so each of the 2 × `BLUR_CHAIN_LEVELS - 1` passes
-    /// reads its own slot.
+    /// dynamic offsets so each of the `BLUR_PYRAMID_LEVELS - 1` downsample
+    /// passes reads its own slot.
     blur_params_buffer: wgpu::Buffer,
     /// Stride between adjacent `BlurParams` slots in `blur_params_buffer`,
     /// equal to `size_of::<BlurParams>()` rounded up to
     /// `min_uniform_buffer_offset_alignment`.
     blur_params_slot_stride: u64,
+    /// Reusable scratch for packing `BLUR_PARAMS_SLOT_COUNT` slots per
+    /// snapshot. Lives on the renderer so interleaved blur batches in one
+    /// frame don't each allocate their own ~2.5 KB scratch.
+    blur_params_scratch: Vec<u8>,
     /// Scene-wide gradient-blur params; written once per frame.
     scene_blur_params_buffer: wgpu::Buffer,
 }
 
 impl WgpuResources {
-    fn invalidate_intermediate_textures(&mut self) {
+    /// Drop intermediate textures whose dimensions no longer match the
+    /// current surface. When `target_size` matches the dimensions of the
+    /// existing pyramid mip 0, this is a no-op — the textures stay
+    /// allocated and `ensure_intermediate_textures` skips recreation. This
+    /// keeps Android background/rotation churn (where `replace_surface`
+    /// fires frequently at the same geometry) from stutter-allocating a
+    /// full W×H mip-chain every time.
+    fn invalidate_intermediate_textures(&mut self, target_size: (u32, u32)) {
+        let (target_width, target_height) = target_size;
+        let matches_target = |tex: Option<&wgpu::Texture>| -> bool {
+            tex.is_some_and(|t| t.width() == target_width && t.height() == target_height)
+        };
+
+        // Pyramid mip 0 doubles as the size-witness: if its dimensions
+        // still match, every chain / pyramid-view / bind-group allocated
+        // alongside it is also the right size.
+        let keep = matches_target(self.blur_pyramid_texture.as_ref())
+            && matches_target(self.path_intermediate_texture.as_ref());
+        if keep {
+            return;
+        }
+
         self.path_intermediate_texture = None;
         self.path_intermediate_view = None;
         self.path_msaa_texture = None;
         self.path_msaa_view = None;
-        for slot in &mut self.blur_chain_textures {
-            *slot = None;
-        }
-        for slot in &mut self.blur_chain_views {
-            *slot = None;
-        }
         self.blur_pyramid_texture = None;
         self.blur_pyramid_view = None;
-        for slot in &mut self.blur_down_bind_groups {
+        for slot in &mut self.blur_pyramid_mip_views {
             *slot = None;
         }
-        for slot in &mut self.blur_up_bind_groups {
+        for slot in &mut self.blur_down_bind_groups {
             *slot = None;
         }
     }
 }
 
-/// Maximum blur chain depth (`kernel_levels` is clamped to this). Each
-/// level is half the resolution of the previous; level 0 is the surface
+/// Maximum blur pyramid depth (`kernel_levels` is clamped to this). Each
+/// mip is half the resolution of the previous; mip 0 is the surface
 /// snapshot.
-const BLUR_CHAIN_LEVELS: usize = 6;
-/// One `BlurParams` slot per Kawase pass (down + up over the transitions
-/// between adjacent chain levels).
-const BLUR_PARAMS_SLOT_COUNT: usize = 2 * (BLUR_CHAIN_LEVELS - 1);
+const BLUR_PYRAMID_LEVELS: usize = 6;
+/// One `BlurParams` slot per Kawase downsample pass between adjacent
+/// pyramid mips. The upsample half of the original Kawase algorithm is
+/// not needed (fragment shaders sample the pyramid mips directly), so
+/// only `BLUR_PYRAMID_LEVELS - 1` slots are required.
+const BLUR_PARAMS_SLOT_COUNT: usize = BLUR_PYRAMID_LEVELS - 1;
 /// Reference blur radius. `BlurEffect::radius` scales the Kawase offset
 /// multiplier linearly relative to this.
 const BLUR_REFERENCE_RADIUS_PX: f32 = 20.0;
@@ -594,15 +615,17 @@ impl WgpuRenderer {
             path_intermediate_view: None,
             path_msaa_texture: None,
             path_msaa_view: None,
-            blur_chain_textures: Default::default(),
-            blur_chain_views: Default::default(),
             blur_pyramid_texture: None,
             blur_pyramid_view: None,
+            blur_pyramid_mip_views: Default::default(),
             blur_down_bind_groups: Default::default(),
-            blur_up_bind_groups: Default::default(),
             blur_sampler,
             blur_params_buffer,
             blur_params_slot_stride,
+            blur_params_scratch: vec![
+                0u8;
+                (blur_params_slot_stride as usize) * BLUR_PARAMS_SLOT_COUNT
+            ],
             scene_blur_params_buffer,
         };
 
@@ -860,8 +883,8 @@ impl WgpuRenderer {
                     ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                     count: None,
                 },
+                storage_buffer_entry(5),
                 scene_blur_params_entry,
-                storage_buffer_entry(7),
             ],
         });
 
@@ -1195,7 +1218,6 @@ impl WgpuRenderer {
         };
 
         let blur_downsample = make_blur_io_pipeline("blur_downsample", "fs_blur_downsample");
-        let blur_upsample = make_blur_io_pipeline("blur_upsample", "fs_blur_upsample");
 
         let blur_rect = create_pipeline(
             "blur_rect",
@@ -1242,7 +1264,6 @@ impl WgpuRenderer {
             poly_sprites,
             surfaces,
             blur_downsample,
-            blur_upsample,
             blur_rect,
             lens_rect,
             mirror_rect,
@@ -1338,10 +1359,8 @@ impl WgpuRenderer {
             if let Some(ref texture) = resources.path_msaa_texture {
                 texture.destroy();
             }
-            for slot in &resources.blur_chain_textures {
-                if let Some(texture) = slot.as_ref() {
-                    texture.destroy();
-                }
+            if let Some(ref pyramid) = resources.blur_pyramid_texture {
+                pyramid.destroy();
             }
 
             resources
@@ -1351,13 +1370,18 @@ impl WgpuRenderer {
             // Invalidate intermediate textures - they will be lazily recreated
             // in draw() after we confirm the surface is healthy. This avoids
             // panics when the device/surface is in an invalid state during resize.
-            resources.invalidate_intermediate_textures();
+            // Size is guaranteed to differ here (see the outer width/height
+            // guard), so pass the new size through.
+            resources.invalidate_intermediate_textures((
+                surface_config.width,
+                surface_config.height,
+            ));
         }
     }
 
     fn ensure_intermediate_textures(&mut self) {
         let needs_path = self.resources().path_intermediate_texture.is_none();
-        let needs_blur = self.resources().blur_chain_textures[0].is_none();
+        let needs_blur = self.resources().blur_pyramid_texture.is_none();
         if !needs_path && !needs_blur {
             return;
         }
@@ -1387,11 +1411,11 @@ impl WgpuRenderer {
         }
 
         if needs_blur {
-            Self::create_blur_chain(resources, format, width, height);
+            Self::create_blur_pyramid(resources, format, width, height);
         }
     }
 
-    fn create_blur_chain(
+    fn create_blur_pyramid(
         resources: &mut WgpuResources,
         surface_format: wgpu::TextureFormat,
         width: u32,
@@ -1401,47 +1425,17 @@ impl WgpuRenderer {
         // gamma chain in `blur_io_shaders.wgsl` is not double-applied when
         // the surface itself is sRGB. When the surface is already
         // non-sRGB this is a no-op.
-        let chain_format = surface_format.remove_srgb_suffix();
+        let pyramid_format = surface_format.remove_srgb_suffix();
 
-        for level in 0..BLUR_CHAIN_LEVELS {
-            let level_width = (width >> level).max(1);
-            let level_height = (height >> level).max(1);
-            let usage = if level == 0 {
-                wgpu::TextureUsages::COPY_DST
-                    | wgpu::TextureUsages::RENDER_ATTACHMENT
-                    | wgpu::TextureUsages::TEXTURE_BINDING
-            } else {
-                wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING
-            };
-            let texture = resources.device.create_texture(&wgpu::TextureDescriptor {
-                label: Some(&format!("blur_chain_{level}")),
-                size: wgpu::Extent3d {
-                    width: level_width,
-                    height: level_height,
-                    depth_or_array_layers: 1,
-                },
-                mip_level_count: 1,
-                sample_count: 1,
-                dimension: wgpu::TextureDimension::D2,
-                format: chain_format,
-                usage,
-                view_formats: &[],
-            });
-            let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
-            resources.blur_chain_textures[level] = Some(texture);
-            resources.blur_chain_views[level] = Some(view);
-        }
-
-        // Preserved downsample pyramid. Mip 0 holds the un-blurred
-        // framebuffer snapshot; each subsequent mip is the Kawase
-        // downsample result of the previous level. A single mipmapped
-        // texture plus trilinear sampling lets the fragment shader pick a
-        // fractional LOD per pixel, producing a smooth variable-radius
-        // blur. Clamp the mip count to what the surface size actually
-        // supports: a 16x16 surface can only host 5 mips, not 6.
+        // Mip 0 holds the un-blurred framebuffer snapshot; each subsequent
+        // mip is the Kawase-downsample result of the previous level. A
+        // single mipmapped texture plus trilinear sampling lets the
+        // fragment shader pick a fractional LOD per pixel. Clamp the mip
+        // count to what the surface size actually supports: a 16x16
+        // surface can only host 5 mips, not 6.
         let min_dim = width.min(height).max(1);
         let max_mips = 32 - min_dim.leading_zeros();
-        let pyramid_mip_count = (BLUR_CHAIN_LEVELS as u32).min(max_mips);
+        let pyramid_mip_count = (BLUR_PYRAMID_LEVELS as u32).min(max_mips);
         let pyramid_texture = resources.device.create_texture(&wgpu::TextureDescriptor {
             label: Some("blur_pyramid"),
             size: wgpu::Extent3d {
@@ -1452,31 +1446,54 @@ impl WgpuRenderer {
             mip_level_count: pyramid_mip_count,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
-            format: chain_format,
-            usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
+            format: pyramid_format,
+            // `COPY_DST` for the initial frame-to-mip-0 snapshot blit.
+            // `RENDER_ATTACHMENT` because downsample passes render directly
+            // into mips 1..N via per-mip views.
+            // `TEXTURE_BINDING` for both downsample sampling (per-mip views)
+            // and the full-mip view used by `fs_blur_rect` / `fs_lens_rect`.
+            usage: wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING,
             view_formats: &[],
         });
         let pyramid_view = pyramid_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        // Single-mip views: each restricted to `base_mip_level = i`,
+        // `mip_level_count = 1`. The downsample pass binds view `i` as
+        // sampled input AND view `i + 1` as render target — different
+        // subresources of the same texture, which wgpu's resource tracker
+        // allows (no read/write aliasing).
+        let mut mip_views: [Option<wgpu::TextureView>; BLUR_PYRAMID_LEVELS] = Default::default();
+        for level in 0..pyramid_mip_count as usize {
+            let view = pyramid_texture.create_view(&wgpu::TextureViewDescriptor {
+                label: Some(&format!("blur_pyramid_mip_{level}")),
+                format: None,
+                dimension: Some(wgpu::TextureViewDimension::D2),
+                aspect: wgpu::TextureAspect::All,
+                base_mip_level: level as u32,
+                mip_level_count: Some(1),
+                base_array_layer: 0,
+                array_layer_count: Some(1),
+                usage: None,
+            });
+            mip_views[level] = Some(view);
+        }
+
         resources.blur_pyramid_texture = Some(pyramid_texture);
         resources.blur_pyramid_view = Some(pyramid_view);
+        resources.blur_pyramid_mip_views = mip_views;
 
-        // Pre-build every bind group for the passes the chain can host.
-        // Each pass reads one level and writes the adjacent level; the
-        // bind-group inputs (source view + sampler + params buffer) are
-        // stable for the lifetime of the chain.
-        for i in 0..BLUR_CHAIN_LEVELS - 1 {
-            let src_view = resources.blur_chain_views[i]
-                .as_ref()
-                .expect("chain view allocated above");
+        // Pre-build one bind group per downsample pass. Pass `i` samples
+        // `mip_views[i]` and writes `mip_views[i + 1]`. Only pairs up to
+        // the actual `pyramid_mip_count - 1` are valid; the rest remain
+        // `None` and callers must not attempt passes past that point.
+        for i in 0..BLUR_PYRAMID_LEVELS - 1 {
+            let Some(src_view) = resources.blur_pyramid_mip_views[i].as_ref() else {
+                break;
+            };
             resources.blur_down_bind_groups[i] =
                 Some(Self::create_blur_io_bind_group(resources, src_view, "blur_down"));
-        }
-        for i in 0..BLUR_CHAIN_LEVELS - 1 {
-            let src_view = resources.blur_chain_views[i + 1]
-                .as_ref()
-                .expect("chain view allocated above");
-            resources.blur_up_bind_groups[i] =
-                Some(Self::create_blur_io_bind_group(resources, src_view, "blur_up"));
         }
     }
 
@@ -1586,8 +1603,9 @@ impl WgpuRenderer {
 
             // TBD. Does retrying more actually help?
             if self.failed_frame_count > 5 {
+                let size = (self.surface_config.width, self.surface_config.height);
                 if let Some(res) = self.resources.as_mut() {
-                    res.invalidate_intermediate_textures();
+                    res.invalidate_intermediate_textures(size);
                 }
                 self.atlas.clear();
                 self.needs_redraw = true;
@@ -1704,7 +1722,7 @@ impl WgpuRenderer {
         loop {
             let mut instance_offset: u64 = 0;
             let mut overflow = false;
-            // Tracks whether the cached blur chain already reflects the
+            // Tracks whether the cached blur pyramid already reflects the
             // contents of `frame.texture` as of the last non-blur batch.
             // Reset to `false` at frame start and whenever a primitive
             // batch draws to the main target.
@@ -1920,14 +1938,17 @@ impl WgpuRenderer {
 
                             drop(pass);
 
-                            let levels = blur_kernel_levels.max(1);
+                            // Pass `blur_kernel_levels` directly: when no
+                            // primitive in the scene requests blur this is 0,
+                            // and `snapshot_and_blur_frame` then does a
+                            // copy-only fast path for mirror-no-blur batches.
                             let did_snapshot = if blur_snapshot_valid {
                                 true
                             } else {
                                 let ok = self.snapshot_and_blur_frame(
                                     &mut encoder,
                                     &frame.texture,
-                                    levels,
+                                    blur_kernel_levels,
                                     blur_offset_multiplier,
                                 );
                                 if ok {
@@ -2187,17 +2208,17 @@ impl WgpuRenderer {
         }
     }
 
-    /// Copy the current swapchain contents into `blur_chain_textures[0]`
-    /// and run `kernel_levels` downsample + upsample passes (dual-Kawase).
-    /// The blurred result ends up back in `blur_chain_textures[0]`, which
-    /// `fs_blur_rect` / `fs_lens_rect` sample.
+    /// Copy the current swapchain contents into pyramid mip 0, then run
+    /// `kernel_levels` Kawase downsample passes that render directly into
+    /// mips 1..N+1 of the same pyramid. `fs_blur_rect` / `fs_lens_rect`
+    /// subsequently sample the full pyramid at a fractional LOD.
     ///
     /// `offset_multiplier` scales the Kawase tap offset; typically
     /// `BlurEffect::radius / BLUR_REFERENCE_RADIUS_PX`.
     ///
     /// Returns `false` if the platform cannot snapshot the framebuffer
-    /// (COPY_SRC missing) or if scratch textures aren't allocated yet;
-    /// callers should skip the blur/lens draw in that case.
+    /// (COPY_SRC missing) or if the pyramid isn't allocated yet; callers
+    /// should skip the blur/lens draw in that case.
     fn snapshot_and_blur_frame(
         &mut self,
         encoder: &mut wgpu::CommandEncoder,
@@ -2209,23 +2230,34 @@ impl WgpuRenderer {
             return false;
         }
 
-        let kernel_levels = kernel_levels.clamp(1, (BLUR_CHAIN_LEVELS - 1) as u32) as usize;
+        // `kernel_levels == 0` means no primitive in the scene asked for
+        // blur; skip the Kawase passes and snapshot mip 0 only.
+        let kernel_levels = kernel_levels.min((BLUR_PYRAMID_LEVELS - 1) as u32) as usize;
         self.ensure_intermediate_textures();
 
         let width = self.surface_config.width.max(1);
         let height = self.surface_config.height.max(1);
-        let resources = self.resources();
+        let resources = self.resources_mut();
 
-        if resources.blur_chain_textures[0].is_none() {
+        if resources.blur_pyramid_texture.is_none() {
             return false;
         }
+        // The pyramid may have fewer mips than requested on small surfaces
+        // (see `create_blur_pyramid`'s clamp). Cap the pass count so we
+        // never try to sample or render a mip the pyramid doesn't have.
+        let available_mips = resources
+            .blur_pyramid_texture
+            .as_ref()
+            .map(|t| t.mip_level_count() as usize)
+            .unwrap_or(0);
+        let kernel_levels = kernel_levels.min(available_mips.saturating_sub(1));
 
-        // Pack per-pass BlurParams. Slot layout:
-        //   0..kernel_levels              → downsample passes (i → i+1)
-        //   kernel_levels..2*kernel_levels → upsample passes  (i+1 → i),
-        //                                     iterated back down.
+        // Pack per-pass BlurParams, one slot per downsample pass (`i`
+        // samples pyramid mip `i` and writes pyramid mip `i + 1`).
         let slot_stride = resources.blur_params_slot_stride;
-        let mut slot_bytes = vec![0u8; (slot_stride as usize) * BLUR_PARAMS_SLOT_COUNT];
+        let slot_bytes_len = (slot_stride as usize) * BLUR_PARAMS_SLOT_COUNT;
+        resources.blur_params_scratch.clear();
+        resources.blur_params_scratch.resize(slot_bytes_len, 0);
         let write_slot = |slot_bytes: &mut [u8], slot: usize, params: BlurParams| {
             let offset = slot * slot_stride as usize;
             slot_bytes[offset..offset + std::mem::size_of::<BlurParams>()]
@@ -2235,7 +2267,7 @@ impl WgpuRenderer {
             let src_w = (width >> i).max(1);
             let src_h = (height >> i).max(1);
             write_slot(
-                &mut slot_bytes,
+                &mut resources.blur_params_scratch,
                 i,
                 BlurParams {
                     viewport_size: [src_w as f32, src_h as f32],
@@ -2244,29 +2276,19 @@ impl WgpuRenderer {
                 },
             );
         }
-        for step in 0..kernel_levels {
-            let src_level = kernel_levels - step;
-            let src_w = (width >> src_level).max(1);
-            let src_h = (height >> src_level).max(1);
-            write_slot(
-                &mut slot_bytes,
-                kernel_levels + step,
-                BlurParams {
-                    viewport_size: [src_w as f32, src_h as f32],
-                    offset_multiplier,
-                    pad: 0.0,
-                },
-            );
-        }
-        resources
-            .queue
-            .write_buffer(&resources.blur_params_buffer, 0, &slot_bytes);
+        resources.queue.write_buffer(
+            &resources.blur_params_buffer,
+            0,
+            &resources.blur_params_scratch,
+        );
+        let resources = self.resources();
 
-        let copy_extent = wgpu::Extent3d {
-            width,
-            height,
-            depth_or_array_layers: 1,
-        };
+        let pyramid = resources
+            .blur_pyramid_texture
+            .as_ref()
+            .expect("pyramid checked above");
+
+        // Initial snapshot: swapchain → pyramid mip 0.
         encoder.copy_texture_to_texture(
             wgpu::TexelCopyTextureInfo {
                 texture: frame_texture,
@@ -2275,40 +2297,29 @@ impl WgpuRenderer {
                 aspect: wgpu::TextureAspect::All,
             },
             wgpu::TexelCopyTextureInfo {
-                texture: resources.blur_chain_textures[0]
-                    .as_ref()
-                    .expect("chain level 0 checked above"),
+                texture: pyramid,
                 mip_level: 0,
                 origin: wgpu::Origin3d::ZERO,
                 aspect: wgpu::TextureAspect::All,
             },
-            copy_extent,
+            wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
         );
-        if let Some(pyramid) = resources.blur_pyramid_texture.as_ref() {
-            encoder.copy_texture_to_texture(
-                wgpu::TexelCopyTextureInfo {
-                    texture: frame_texture,
-                    mip_level: 0,
-                    origin: wgpu::Origin3d::ZERO,
-                    aspect: wgpu::TextureAspect::All,
-                },
-                wgpu::TexelCopyTextureInfo {
-                    texture: pyramid,
-                    mip_level: 0,
-                    origin: wgpu::Origin3d::ZERO,
-                    aspect: wgpu::TextureAspect::All,
-                },
-                copy_extent,
-            );
-        }
 
+        // Kawase downsample: each pass samples pyramid mip `i` via a
+        // single-mip view and renders into pyramid mip `i + 1` via
+        // another single-mip view. Different subresources of the same
+        // texture, which wgpu treats as read/write-disjoint.
         for i in 0..kernel_levels {
-            let dst_view = resources.blur_chain_views[i + 1]
+            let dst_view = resources.blur_pyramid_mip_views[i + 1]
                 .as_ref()
-                .expect("chain view allocated");
+                .expect("pyramid mip view allocated for active pass");
             let bind_group = resources.blur_down_bind_groups[i]
                 .as_ref()
-                .expect("down bind group allocated");
+                .expect("down bind group allocated for active pass");
             let dynamic_offset = (i as u64 * slot_stride) as u32;
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("blur_downsample_pass"),
@@ -2325,74 +2336,6 @@ impl WgpuRenderer {
                 ..Default::default()
             });
             pass.set_pipeline(&resources.pipelines.blur_downsample);
-            pass.set_bind_group(0, bind_group, &[dynamic_offset]);
-            pass.draw(0..3, 0..1);
-        }
-
-        // Preserve the downsample chain into the pyramid before the
-        // upsample loop overwrites `chain[0..kernel_levels-1]`. Each
-        // `chain[i]` is the /2^i-sized result of `i` Kawase downsample
-        // passes, which maps to pyramid mip level `i`. Clamp the copy
-        // extent to the pyramid mip count in case the surface was too
-        // small to host every mip (ensure_intermediate_textures clamps
-        // pyramid mips based on the surface size).
-        if let Some(pyramid) = resources.blur_pyramid_texture.as_ref() {
-            let pyramid_mip_count = pyramid.mip_level_count();
-            for i in 1..=kernel_levels {
-                if (i as u32) >= pyramid_mip_count {
-                    break;
-                }
-                let chain_texture = resources.blur_chain_textures[i]
-                    .as_ref()
-                    .expect("chain level allocated");
-                let level_width = (width >> i).max(1);
-                let level_height = (height >> i).max(1);
-                encoder.copy_texture_to_texture(
-                    wgpu::TexelCopyTextureInfo {
-                        texture: chain_texture,
-                        mip_level: 0,
-                        origin: wgpu::Origin3d::ZERO,
-                        aspect: wgpu::TextureAspect::All,
-                    },
-                    wgpu::TexelCopyTextureInfo {
-                        texture: pyramid,
-                        mip_level: i as u32,
-                        origin: wgpu::Origin3d::ZERO,
-                        aspect: wgpu::TextureAspect::All,
-                    },
-                    wgpu::Extent3d {
-                        width: level_width,
-                        height: level_height,
-                        depth_or_array_layers: 1,
-                    },
-                );
-            }
-        }
-
-        for step in 0..kernel_levels {
-            let dst_level = kernel_levels - step - 1;
-            let dst_view = resources.blur_chain_views[dst_level]
-                .as_ref()
-                .expect("chain view allocated");
-            let bind_group = resources.blur_up_bind_groups[dst_level]
-                .as_ref()
-                .expect("up bind group allocated");
-            let dynamic_offset = ((kernel_levels + step) as u64 * slot_stride) as u32;
-            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: Some("blur_upsample_pass"),
-                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: dst_view,
-                    resolve_target: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
-                        store: wgpu::StoreOp::Store,
-                    },
-                    depth_slice: None,
-                })],
-                depth_stencil_attachment: None,
-                ..Default::default()
-            });
-            pass.set_pipeline(&resources.pipelines.blur_upsample);
             pass.set_bind_group(0, bind_group, &[dynamic_offset]);
             pass.draw(0..3, 0..1);
         }
@@ -2544,12 +2487,12 @@ impl WgpuRenderer {
                         resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
                     },
                     wgpu::BindGroupEntry {
-                        binding: 6,
-                        resource: resources.scene_blur_params_buffer.as_entire_binding(),
+                        binding: 5,
+                        resource: self.instance_binding(offset, size),
                     },
                     wgpu::BindGroupEntry {
-                        binding: 7,
-                        resource: self.instance_binding(offset, size),
+                        binding: 6,
+                        resource: resources.scene_blur_params_buffer.as_entire_binding(),
                     },
                 ],
             });
@@ -2723,8 +2666,9 @@ impl WgpuRenderer {
     pub fn unconfigure_surface(&mut self) {
         self.surface_configured = false;
         // Drop intermediate textures since they reference the old surface size.
+        let size = (self.surface_config.width, self.surface_config.height);
         if let Some(res) = self.resources.as_mut() {
-            res.invalidate_intermediate_textures();
+            res.invalidate_intermediate_textures(size);
         }
     }
 
@@ -2795,8 +2739,11 @@ impl WgpuRenderer {
             surface.configure(&res.device, &self.surface_config);
             res.surface = surface;
 
-            // Invalidate intermediate textures — they'll be recreated lazily.
-            res.invalidate_intermediate_textures();
+            // Invalidate intermediate textures — they'll be recreated lazily
+            // if the new surface geometry differs. Same-size replace_surface
+            // (common on Android rotation back-and-forth) keeps the existing
+            // pyramid + chain so the next frame doesn't stutter.
+            res.invalidate_intermediate_textures((width, height));
         }
 
         self.surface_configured = true;
@@ -3021,7 +2968,7 @@ mod tests {
     }
 
     /// Compiles every render pipeline used by the renderer, including the
-    /// new `blur_downsample` / `blur_upsample` / `blur_rect` / `lens_rect`
+    /// new `blur_downsample` / `blur_rect` / `lens_rect` / `mirror_rect`
     /// ones. Silently skipped locally when no adapter is available; panics
     /// on CI (`CI` env var set) so a missing adapter is loud rather than
     /// hidden in green build output.
@@ -3056,7 +3003,6 @@ mod tests {
         let _ = &pipelines.poly_sprites;
         let _ = &pipelines.surfaces;
         let _ = &pipelines.blur_downsample;
-        let _ = &pipelines.blur_upsample;
         let _ = &pipelines.blur_rect;
         let _ = &pipelines.lens_rect;
         let _ = &pipelines.mirror_rect;

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -1136,7 +1136,7 @@ impl WgpuRenderer {
             &layouts.globals,
             &layouts.lens_rect,
             wgpu::PrimitiveTopology::TriangleStrip,
-            &[Some(color_target.clone())],
+            &[Some(color_target)],
             1,
             &shader_module,
         );

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -1,9 +1,9 @@
 use crate::{CompositorGpuHint, WgpuAtlas, WgpuContext};
 use bytemuck::{Pod, Zeroable};
 use gpui::{
-    AtlasTextureId, Background, BlurRect, Bounds, DevicePixels, GpuSpecs, LensRect,
-    MonochromeSprite, Path, Point, PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene,
-    Shadow, Size, SubpixelSprite, Underline, get_gamma_correction_ratios,
+    AtlasTextureId, Background, BlurRect, Bounds, DevicePixels, GpuSpecs, LensRect, LensShape,
+    MirrorRect, MonochromeSprite, Path, Point, PolychromeSprite, PrimitiveBatch, Quad,
+    ScaledPixels, Scene, Shadow, Size, SubpixelSprite, Underline, get_gamma_correction_ratios,
 };
 use log::warn;
 #[cfg(not(target_family = "wasm"))]
@@ -61,6 +61,22 @@ struct BlurParams {
     pad: f32,
 }
 
+/// Scene-wide blur parameters used by the gradient-blur shaders to
+/// compute a per-pixel mip level into the preserved downsample pyramid.
+/// Written once per frame and bound to every blur-consuming pipeline.
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct SceneBlurParams {
+    /// Maximum `blur_radius` anywhere in the scene (see
+    /// `Scene::max_blur_radius`). The per-pixel `target_radius / max`
+    /// ratio becomes the `strength` input to the log2 mip-level formula.
+    max_blur_radius: f32,
+    /// Number of Kawase downsample passes actually run this frame, as an
+    /// `f32` for the shader's `log2(strength)` clamping math.
+    kernel_levels: f32,
+    _pad: [f32; 2],
+}
+
 #[derive(Clone, Debug)]
 #[repr(C)]
 struct PathSprite {
@@ -103,6 +119,7 @@ struct WgpuPipelines {
     blur_upsample: wgpu::RenderPipeline,
     blur_rect: wgpu::RenderPipeline,
     lens_rect: wgpu::RenderPipeline,
+    mirror_rect: wgpu::RenderPipeline,
 }
 
 struct WgpuBindGroupLayouts {
@@ -113,6 +130,7 @@ struct WgpuBindGroupLayouts {
     blur_io: wgpu::BindGroupLayout,
     blur_rect: wgpu::BindGroupLayout,
     lens_rect: wgpu::BindGroupLayout,
+    mirror_rect: wgpu::BindGroupLayout,
 }
 
 /// Shared GPU context reference, used to coordinate device recovery across multiple windows.
@@ -140,6 +158,13 @@ struct WgpuResources {
     /// frame (1..=5).
     blur_chain_textures: [Option<wgpu::Texture>; BLUR_CHAIN_LEVELS],
     blur_chain_views: [Option<wgpu::TextureView>; BLUR_CHAIN_LEVELS],
+    /// Preserved downsample pyramid: a single mipmapped texture where mip
+    /// 0 is the un-blurred framebuffer snapshot and each subsequent mip
+    /// holds the Kawase-downsample result of the previous level. Fragment
+    /// shaders sample this with `textureSampleLevel` at fractional LOD to
+    /// produce a per-pixel variable-radius blur.
+    blur_pyramid_texture: Option<wgpu::Texture>,
+    blur_pyramid_view: Option<wgpu::TextureView>,
     /// Bind groups pre-built for downsample/upsample passes. Downsample
     /// pass `i` samples level `i` and writes level `i + 1`; upsample pass
     /// `i` samples level `i + 1` and writes level `i`.
@@ -155,6 +180,8 @@ struct WgpuResources {
     /// equal to `size_of::<BlurParams>()` rounded up to
     /// `min_uniform_buffer_offset_alignment`.
     blur_params_slot_stride: u64,
+    /// Scene-wide gradient-blur params; written once per frame.
+    scene_blur_params_buffer: wgpu::Buffer,
 }
 
 impl WgpuResources {
@@ -169,6 +196,8 @@ impl WgpuResources {
         for slot in &mut self.blur_chain_views {
             *slot = None;
         }
+        self.blur_pyramid_texture = None;
+        self.blur_pyramid_view = None;
         for slot in &mut self.blur_down_bind_groups {
             *slot = None;
         }
@@ -448,7 +477,9 @@ impl WgpuRenderer {
             address_mode_w: wgpu::AddressMode::ClampToEdge,
             mag_filter: wgpu::FilterMode::Linear,
             min_filter: wgpu::FilterMode::Linear,
-            mipmap_filter: wgpu::MipmapFilterMode::Nearest,
+            // Trilinear filtering between pyramid mip levels gives the
+            // per-pixel variable-radius blur its smooth gradient.
+            mipmap_filter: wgpu::MipmapFilterMode::Linear,
             ..Default::default()
         });
 
@@ -463,6 +494,13 @@ impl WgpuRenderer {
         let blur_params_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("blur_params_buffer"),
             size: blur_params_slot_stride * BLUR_PARAMS_SLOT_COUNT as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let scene_blur_params_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("scene_blur_params_buffer"),
+            size: std::mem::size_of::<SceneBlurParams>() as u64,
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
@@ -558,11 +596,14 @@ impl WgpuRenderer {
             path_msaa_view: None,
             blur_chain_textures: Default::default(),
             blur_chain_views: Default::default(),
+            blur_pyramid_texture: None,
+            blur_pyramid_view: None,
             blur_down_bind_groups: Default::default(),
             blur_up_bind_groups: Default::default(),
             blur_sampler,
             blur_params_buffer,
             blur_params_slot_stride,
+            scene_blur_params_buffer,
         };
 
         Ok(Self {
@@ -741,6 +782,16 @@ impl WgpuRenderer {
             ],
         });
 
+        let scene_blur_params_entry = wgpu::BindGroupLayoutEntry {
+            binding: 6,
+            visibility: wgpu::ShaderStages::FRAGMENT,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Uniform,
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        };
         let blur_rect = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             label: Some("blur_rect_layout"),
             entries: &[
@@ -761,6 +812,7 @@ impl WgpuRenderer {
                     ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                     count: None,
                 },
+                scene_blur_params_entry,
             ],
         });
 
@@ -784,6 +836,32 @@ impl WgpuRenderer {
                     ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                     count: None,
                 },
+                storage_buffer_entry(4),
+                scene_blur_params_entry,
+            ],
+        });
+
+        let mirror_rect = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("mirror_rect_layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 3,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+                scene_blur_params_entry,
+                storage_buffer_entry(7),
             ],
         });
 
@@ -795,6 +873,7 @@ impl WgpuRenderer {
             blur_io,
             blur_rect,
             lens_rect,
+            mirror_rect,
         }
     }
 
@@ -1136,6 +1215,17 @@ impl WgpuRenderer {
             &layouts.globals,
             &layouts.lens_rect,
             wgpu::PrimitiveTopology::TriangleStrip,
+            &[Some(color_target.clone())],
+            1,
+            &shader_module,
+        );
+        let mirror_rect = create_pipeline(
+            "mirror_rect",
+            "vs_mirror_rect",
+            "fs_mirror_rect",
+            &layouts.globals,
+            &layouts.mirror_rect,
+            wgpu::PrimitiveTopology::TriangleStrip,
             &[Some(color_target)],
             1,
             &shader_module,
@@ -1155,6 +1245,7 @@ impl WgpuRenderer {
             blur_upsample,
             blur_rect,
             lens_rect,
+            mirror_rect,
         }
     }
 
@@ -1340,6 +1431,34 @@ impl WgpuRenderer {
             resources.blur_chain_textures[level] = Some(texture);
             resources.blur_chain_views[level] = Some(view);
         }
+
+        // Preserved downsample pyramid. Mip 0 holds the un-blurred
+        // framebuffer snapshot; each subsequent mip is the Kawase
+        // downsample result of the previous level. A single mipmapped
+        // texture plus trilinear sampling lets the fragment shader pick a
+        // fractional LOD per pixel, producing a smooth variable-radius
+        // blur. Clamp the mip count to what the surface size actually
+        // supports: a 16x16 surface can only host 5 mips, not 6.
+        let min_dim = width.min(height).max(1);
+        let max_mips = 32 - min_dim.leading_zeros();
+        let pyramid_mip_count = (BLUR_CHAIN_LEVELS as u32).min(max_mips);
+        let pyramid_texture = resources.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("blur_pyramid"),
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: pyramid_mip_count,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: chain_format,
+            usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        let pyramid_view = pyramid_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        resources.blur_pyramid_texture = Some(pyramid_texture);
+        resources.blur_pyramid_view = Some(pyramid_view);
 
         // Pre-build every bind group for the passes the chain can host.
         // Each pass reads one level and writes the adjacent level; the
@@ -1568,6 +1687,19 @@ impl WgpuRenderer {
         let blur_kernel_levels = scene.max_blur_kernel_levels();
         let blur_radius = scene.max_blur_radius().0;
         let blur_offset_multiplier = (blur_radius / BLUR_REFERENCE_RADIUS_PX).clamp(0.1, 4.0);
+        {
+            let params = SceneBlurParams {
+                max_blur_radius: blur_radius,
+                kernel_levels: blur_kernel_levels as f32,
+                _pad: [0.0; 2],
+            };
+            let resources = self.resources();
+            resources.queue.write_buffer(
+                &resources.scene_blur_params_buffer,
+                0,
+                bytemuck::bytes_of(&params),
+            );
+        }
 
         loop {
             let mut instance_offset: u64 = 0;
@@ -1604,7 +1736,9 @@ impl WgpuRenderer {
                 for batch in scene.batches() {
                     let is_blur_batch = matches!(
                         batch,
-                        PrimitiveBatch::BlurRects(_) | PrimitiveBatch::LensRects(_)
+                        PrimitiveBatch::BlurRects(_)
+                            | PrimitiveBatch::LensRects(_)
+                            | PrimitiveBatch::MirrorRects(_)
                     );
                     let ok = match batch {
                         PrimitiveBatch::Quads(range) => {
@@ -1768,7 +1902,57 @@ impl WgpuRenderer {
                             });
 
                             if did_snapshot {
-                                self.draw_lens_rects(rects, &mut instance_offset, &mut pass)
+                                self.draw_lens_rects(
+                                    rects,
+                                    &scene.lens_shapes,
+                                    &mut instance_offset,
+                                    &mut pass,
+                                )
+                            } else {
+                                true
+                            }
+                        }
+                        PrimitiveBatch::MirrorRects(range) => {
+                            let rects = &scene.mirror_rects[range];
+                            if rects.is_empty() {
+                                continue;
+                            }
+
+                            drop(pass);
+
+                            let levels = blur_kernel_levels.max(1);
+                            let did_snapshot = if blur_snapshot_valid {
+                                true
+                            } else {
+                                let ok = self.snapshot_and_blur_frame(
+                                    &mut encoder,
+                                    &frame.texture,
+                                    levels,
+                                    blur_offset_multiplier,
+                                );
+                                if ok {
+                                    blur_snapshot_valid = true;
+                                }
+                                ok
+                            };
+
+                            pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                                label: Some("main_pass_continued_mirror"),
+                                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                                    view: &frame_view,
+                                    resolve_target: None,
+                                    ops: wgpu::Operations {
+                                        load: wgpu::LoadOp::Load,
+                                        store: wgpu::StoreOp::Store,
+                                    },
+                                    depth_slice: None,
+                                })],
+                                depth_stencil_attachment: None,
+                                ..Default::default()
+                            });
+
+                            if did_snapshot {
+                                self.draw_mirror_rects(rects, &mut instance_offset, &mut pass)
                             } else {
                                 true
                             }
@@ -2078,6 +2262,11 @@ impl WgpuRenderer {
             .queue
             .write_buffer(&resources.blur_params_buffer, 0, &slot_bytes);
 
+        let copy_extent = wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        };
         encoder.copy_texture_to_texture(
             wgpu::TexelCopyTextureInfo {
                 texture: frame_texture,
@@ -2093,12 +2282,25 @@ impl WgpuRenderer {
                 origin: wgpu::Origin3d::ZERO,
                 aspect: wgpu::TextureAspect::All,
             },
-            wgpu::Extent3d {
-                width,
-                height,
-                depth_or_array_layers: 1,
-            },
+            copy_extent,
         );
+        if let Some(pyramid) = resources.blur_pyramid_texture.as_ref() {
+            encoder.copy_texture_to_texture(
+                wgpu::TexelCopyTextureInfo {
+                    texture: frame_texture,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                wgpu::TexelCopyTextureInfo {
+                    texture: pyramid,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                copy_extent,
+            );
+        }
 
         for i in 0..kernel_levels {
             let dst_view = resources.blur_chain_views[i + 1]
@@ -2125,6 +2327,46 @@ impl WgpuRenderer {
             pass.set_pipeline(&resources.pipelines.blur_downsample);
             pass.set_bind_group(0, bind_group, &[dynamic_offset]);
             pass.draw(0..3, 0..1);
+        }
+
+        // Preserve the downsample chain into the pyramid before the
+        // upsample loop overwrites `chain[0..kernel_levels-1]`. Each
+        // `chain[i]` is the /2^i-sized result of `i` Kawase downsample
+        // passes, which maps to pyramid mip level `i`. Clamp the copy
+        // extent to the pyramid mip count in case the surface was too
+        // small to host every mip (ensure_intermediate_textures clamps
+        // pyramid mips based on the surface size).
+        if let Some(pyramid) = resources.blur_pyramid_texture.as_ref() {
+            let pyramid_mip_count = pyramid.mip_level_count();
+            for i in 1..=kernel_levels {
+                if (i as u32) >= pyramid_mip_count {
+                    break;
+                }
+                let chain_texture = resources.blur_chain_textures[i]
+                    .as_ref()
+                    .expect("chain level allocated");
+                let level_width = (width >> i).max(1);
+                let level_height = (height >> i).max(1);
+                encoder.copy_texture_to_texture(
+                    wgpu::TexelCopyTextureInfo {
+                        texture: chain_texture,
+                        mip_level: 0,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::All,
+                    },
+                    wgpu::TexelCopyTextureInfo {
+                        texture: pyramid,
+                        mip_level: i as u32,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::All,
+                    },
+                    wgpu::Extent3d {
+                        width: level_width,
+                        height: level_height,
+                        depth_or_array_layers: 1,
+                    },
+                );
+            }
         }
 
         for step in 0..kernel_levels {
@@ -2172,7 +2414,7 @@ impl WgpuRenderer {
             return false;
         };
         let resources = self.resources();
-        let Some(snapshot_view) = resources.blur_chain_views[0].as_ref() else {
+        let Some(pyramid_view) = resources.blur_pyramid_view.as_ref() else {
             return true;
         };
         let bind_group = resources
@@ -2187,11 +2429,15 @@ impl WgpuRenderer {
                     },
                     wgpu::BindGroupEntry {
                         binding: 2,
-                        resource: wgpu::BindingResource::TextureView(snapshot_view),
+                        resource: wgpu::BindingResource::TextureView(pyramid_view),
                     },
                     wgpu::BindGroupEntry {
                         binding: 3,
                         resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 6,
+                        resource: resources.scene_blur_params_buffer.as_entire_binding(),
                     },
                 ],
             });
@@ -2205,6 +2451,70 @@ impl WgpuRenderer {
     fn draw_lens_rects(
         &self,
         rects: &[LensRect],
+        shapes: &[LensShape],
+        instance_offset: &mut u64,
+        pass: &mut wgpu::RenderPass<'_>,
+    ) -> bool {
+        if rects.is_empty() {
+            return true;
+        }
+        if shapes.is_empty() {
+            return false;
+        }
+        let rects_data = unsafe { Self::instance_bytes(rects) };
+        let Some((rects_offset, rects_size)) =
+            self.write_to_instance_buffer(instance_offset, rects_data)
+        else {
+            return false;
+        };
+        let shapes_data = unsafe { Self::instance_bytes(shapes) };
+        let Some((shapes_offset, shapes_size)) =
+            self.write_to_instance_buffer(instance_offset, shapes_data)
+        else {
+            return false;
+        };
+        let resources = self.resources();
+        let Some(pyramid_view) = resources.blur_pyramid_view.as_ref() else {
+            return true;
+        };
+        let bind_group = resources
+            .device
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("lens_rect_bind_group"),
+                layout: &resources.bind_group_layouts.lens_rect,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: self.instance_binding(rects_offset, rects_size),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: wgpu::BindingResource::TextureView(pyramid_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 3,
+                        resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 4,
+                        resource: self.instance_binding(shapes_offset, shapes_size),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 6,
+                        resource: resources.scene_blur_params_buffer.as_entire_binding(),
+                    },
+                ],
+            });
+        pass.set_pipeline(&resources.pipelines.lens_rect);
+        pass.set_bind_group(0, &resources.globals_bind_group, &[]);
+        pass.set_bind_group(1, &bind_group, &[]);
+        pass.draw(0..4, 0..rects.len() as u32);
+        true
+    }
+
+    fn draw_mirror_rects(
+        &self,
+        rects: &[MirrorRect],
         instance_offset: &mut u64,
         pass: &mut wgpu::RenderPass<'_>,
     ) -> bool {
@@ -2216,30 +2526,34 @@ impl WgpuRenderer {
             return false;
         };
         let resources = self.resources();
-        let Some(snapshot_view) = resources.blur_chain_views[0].as_ref() else {
+        let Some(pyramid_view) = resources.blur_pyramid_view.as_ref() else {
             return true;
         };
         let bind_group = resources
             .device
             .create_bind_group(&wgpu::BindGroupDescriptor {
-                label: Some("lens_rect_bind_group"),
-                layout: &resources.bind_group_layouts.lens_rect,
+                label: Some("mirror_rect_bind_group"),
+                layout: &resources.bind_group_layouts.mirror_rect,
                 entries: &[
                     wgpu::BindGroupEntry {
-                        binding: 1,
-                        resource: self.instance_binding(offset, size),
-                    },
-                    wgpu::BindGroupEntry {
                         binding: 2,
-                        resource: wgpu::BindingResource::TextureView(snapshot_view),
+                        resource: wgpu::BindingResource::TextureView(pyramid_view),
                     },
                     wgpu::BindGroupEntry {
                         binding: 3,
                         resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
                     },
+                    wgpu::BindGroupEntry {
+                        binding: 6,
+                        resource: resources.scene_blur_params_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 7,
+                        resource: self.instance_binding(offset, size),
+                    },
                 ],
             });
-        pass.set_pipeline(&resources.pipelines.lens_rect);
+        pass.set_pipeline(&resources.pipelines.mirror_rect);
         pass.set_bind_group(0, &resources.globals_bind_group, &[]);
         pass.set_bind_group(1, &bind_group, &[]);
         pass.draw(0..4, 0..rects.len() as u32);
@@ -2745,5 +3059,6 @@ mod tests {
         let _ = &pipelines.blur_upsample;
         let _ = &pipelines.blur_rect;
         let _ = &pipelines.lens_rect;
+        let _ = &pipelines.mirror_rect;
     }
 }

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -1,9 +1,9 @@
 use crate::{CompositorGpuHint, WgpuAtlas, WgpuContext};
 use bytemuck::{Pod, Zeroable};
 use gpui::{
-    AtlasTextureId, Background, Bounds, DevicePixels, GpuSpecs, MonochromeSprite, Path, Point,
-    PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size, SubpixelSprite,
-    Underline, get_gamma_correction_ratios,
+    AtlasTextureId, Background, BlurRect, Bounds, DevicePixels, GpuSpecs, LensRect,
+    MonochromeSprite, Path, Point, PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene,
+    Shadow, Size, SubpixelSprite, Underline, get_gamma_correction_ratios,
 };
 use log::warn;
 #[cfg(not(target_family = "wasm"))]
@@ -53,6 +53,14 @@ struct GammaParams {
     _pad: [f32; 2],
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct BlurParams {
+    viewport_size: [f32; 2],
+    offset_multiplier: f32,
+    _pad: f32,
+}
+
 #[derive(Clone, Debug)]
 #[repr(C)]
 struct PathSprite {
@@ -91,6 +99,10 @@ struct WgpuPipelines {
     poly_sprites: wgpu::RenderPipeline,
     #[allow(dead_code)]
     surfaces: wgpu::RenderPipeline,
+    blur_downsample: wgpu::RenderPipeline,
+    blur_upsample: wgpu::RenderPipeline,
+    blur_rect: wgpu::RenderPipeline,
+    lens_rect: wgpu::RenderPipeline,
 }
 
 struct WgpuBindGroupLayouts {
@@ -98,6 +110,9 @@ struct WgpuBindGroupLayouts {
     instances: wgpu::BindGroupLayout,
     instances_with_texture: wgpu::BindGroupLayout,
     surfaces: wgpu::BindGroupLayout,
+    blur_io: wgpu::BindGroupLayout,
+    blur_rect: wgpu::BindGroupLayout,
+    lens_rect: wgpu::BindGroupLayout,
 }
 
 /// Shared GPU context reference, used to coordinate device recovery across multiple windows.
@@ -119,6 +134,12 @@ struct WgpuResources {
     path_intermediate_view: Option<wgpu::TextureView>,
     path_msaa_texture: Option<wgpu::Texture>,
     path_msaa_view: Option<wgpu::TextureView>,
+    blur_snapshot_texture: Option<wgpu::Texture>,
+    blur_snapshot_view: Option<wgpu::TextureView>,
+    blur_half_texture: Option<wgpu::Texture>,
+    blur_half_view: Option<wgpu::TextureView>,
+    blur_sampler: wgpu::Sampler,
+    blur_params_buffer: wgpu::Buffer,
 }
 
 impl WgpuResources {
@@ -127,6 +148,10 @@ impl WgpuResources {
         self.path_intermediate_view = None;
         self.path_msaa_texture = None;
         self.path_msaa_view = None;
+        self.blur_snapshot_texture = None;
+        self.blur_snapshot_view = None;
+        self.blur_half_texture = None;
+        self.blur_half_view = None;
     }
 }
 
@@ -156,6 +181,10 @@ pub struct WgpuRenderer {
     device_lost: std::sync::Arc<std::sync::atomic::AtomicBool>,
     surface_configured: bool,
     needs_redraw: bool,
+    /// True when the surface was configured with `COPY_SRC`, which is required
+    /// to sample the framebuffer inside `BlurRect` / `LensRect` draws. When
+    /// false those primitives skip rendering rather than panicking.
+    surface_supports_copy_src: bool,
 }
 
 impl WgpuRenderer {
@@ -328,8 +357,20 @@ impl WgpuRenderer {
             );
         }
 
+        // Swapchain textures need COPY_SRC so `BlurRect` / `LensRect` draws
+        // can snapshot the framebuffer into an offscreen texture prior to
+        // downsampling. If the platform doesn't advertise that usage we fall
+        // back to RENDER_ATTACHMENT alone and skip blur draws at render time.
+        let surface_supports_copy_src = surface_caps
+            .usages
+            .contains(wgpu::TextureUsages::COPY_SRC);
+        let surface_usages = if surface_supports_copy_src {
+            wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC
+        } else {
+            wgpu::TextureUsages::RENDER_ATTACHMENT
+        };
         let surface_config = wgpu::SurfaceConfiguration {
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            usage: surface_usages,
             format: surface_format,
             width: clamped_width.max(1),
             height: clamped_height.max(1),
@@ -364,6 +405,24 @@ impl WgpuRenderer {
             mag_filter: wgpu::FilterMode::Linear,
             min_filter: wgpu::FilterMode::Linear,
             ..Default::default()
+        });
+
+        let blur_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("blur_sampler"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::MipmapFilterMode::Nearest,
+            ..Default::default()
+        });
+
+        let blur_params_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("blur_params_buffer"),
+            size: std::mem::size_of::<BlurParams>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
         });
 
         let uniform_alignment = device.limits().min_uniform_buffer_offset_alignment as u64;
@@ -461,6 +520,12 @@ impl WgpuRenderer {
             path_intermediate_view: None,
             path_msaa_texture: None,
             path_msaa_view: None,
+            blur_snapshot_texture: None,
+            blur_snapshot_view: None,
+            blur_half_texture: None,
+            blur_half_view: None,
+            blur_sampler,
+            blur_params_buffer,
         };
 
         Ok(Self {
@@ -485,6 +550,7 @@ impl WgpuRenderer {
             device_lost: context.device_lost_flag(),
             surface_configured: true,
             needs_redraw: false,
+            surface_supports_copy_src,
         })
     }
 
@@ -604,11 +670,94 @@ impl WgpuRenderer {
             ],
         });
 
+        let blur_io = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("blur_io_layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: NonZeroU64::new(
+                            std::mem::size_of::<BlurParams>() as u64
+                        ),
+                    },
+                    count: None,
+                },
+            ],
+        });
+
+        let blur_rect = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("blur_rect_layout"),
+            entries: &[
+                storage_buffer_entry(0),
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 3,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+
+        let lens_rect = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("lens_rect_layout"),
+            entries: &[
+                storage_buffer_entry(1),
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 3,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+
         WgpuBindGroupLayouts {
             globals,
             instances,
             instances_with_texture,
             surfaces,
+            blur_io,
+            blur_rect,
+            lens_rect,
         }
     }
 
@@ -869,9 +1018,124 @@ impl WgpuRenderer {
             &layouts.globals,
             &layouts.surfaces,
             wgpu::PrimitiveTopology::TriangleStrip,
-            &[Some(color_target)],
+            &[Some(color_target.clone())],
             1,
             &shader_module,
+        );
+
+        let blur_io_shader_source = include_str!("blur_io_shaders.wgsl");
+        let blur_io_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("gpui_blur_io_shaders"),
+            source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(blur_io_shader_source)),
+        });
+
+        let blur_io_pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("blur_io_pipeline_layout"),
+                bind_group_layouts: &[Some(&layouts.blur_io)],
+                immediate_size: 0,
+            });
+
+        let blur_io_color_target = wgpu::ColorTargetState {
+            format: surface_format,
+            blend: None,
+            write_mask: wgpu::ColorWrites::ALL,
+        };
+
+        let make_blur_io_pipeline = |name: &str, entry: &str| {
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some(name),
+                layout: Some(&blur_io_pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &blur_io_module,
+                    entry_point: Some("vs_blur_fullscreen"),
+                    buffers: &[],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &blur_io_module,
+                    entry_point: Some(entry),
+                    targets: &[Some(blur_io_color_target.clone())],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
+                    strip_index_format: None,
+                    front_face: wgpu::FrontFace::Ccw,
+                    cull_mode: None,
+                    polygon_mode: wgpu::PolygonMode::Fill,
+                    unclipped_depth: false,
+                    conservative: false,
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState {
+                    count: 1,
+                    mask: !0,
+                    alpha_to_coverage_enabled: false,
+                },
+                multiview_mask: None,
+                cache: None,
+            })
+        };
+
+        let blur_downsample = make_blur_io_pipeline("blur_downsample", "fs_blur_downsample");
+        let blur_upsample = make_blur_io_pipeline("blur_upsample", "fs_blur_upsample");
+
+        let make_rect_pipeline = |name: &str,
+                                  vs_entry: &str,
+                                  fs_entry: &str,
+                                  data_layout: &wgpu::BindGroupLayout| {
+            let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some(&format!("{name}_pipeline_layout")),
+                bind_group_layouts: &[Some(&layouts.globals), Some(data_layout)],
+                immediate_size: 0,
+            });
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some(name),
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader_module,
+                    entry_point: Some(vs_entry),
+                    buffers: &[],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader_module,
+                    entry_point: Some(fs_entry),
+                    targets: &[Some(color_target.clone())],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleStrip,
+                    strip_index_format: None,
+                    front_face: wgpu::FrontFace::Ccw,
+                    cull_mode: None,
+                    polygon_mode: wgpu::PolygonMode::Fill,
+                    unclipped_depth: false,
+                    conservative: false,
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState {
+                    count: 1,
+                    mask: !0,
+                    alpha_to_coverage_enabled: false,
+                },
+                multiview_mask: None,
+                cache: None,
+            })
+        };
+
+        let blur_rect = make_rect_pipeline(
+            "blur_rect",
+            "vs_blur_rect",
+            "fs_blur_rect",
+            &layouts.blur_rect,
+        );
+        let lens_rect = make_rect_pipeline(
+            "lens_rect",
+            "vs_lens_rect",
+            "fs_lens_rect",
+            &layouts.lens_rect,
         );
 
         WgpuPipelines {
@@ -884,6 +1148,10 @@ impl WgpuRenderer {
             subpixel_sprites,
             poly_sprites,
             surfaces,
+            blur_downsample,
+            blur_upsample,
+            blur_rect,
+            lens_rect,
         }
     }
 
@@ -976,6 +1244,12 @@ impl WgpuRenderer {
             if let Some(ref texture) = resources.path_msaa_texture {
                 texture.destroy();
             }
+            if let Some(ref texture) = resources.blur_snapshot_texture {
+                texture.destroy();
+            }
+            if let Some(ref texture) = resources.blur_half_texture {
+                texture.destroy();
+            }
 
             resources
                 .surface
@@ -1014,6 +1288,57 @@ impl WgpuRenderer {
         .unwrap_or((None, None));
         resources.path_msaa_texture = path_msaa_texture;
         resources.path_msaa_view = path_msaa_view;
+    }
+
+    fn ensure_blur_textures(&mut self) {
+        if self.resources().blur_snapshot_texture.is_some() {
+            return;
+        }
+
+        let format = self.surface_config.format;
+        let width = self.surface_config.width.max(1);
+        let height = self.surface_config.height.max(1);
+        let half_width = (width / 2).max(1);
+        let half_height = (height / 2).max(1);
+        let resources = self.resources_mut();
+
+        let snapshot = resources.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("blur_snapshot"),
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        let snapshot_view = snapshot.create_view(&wgpu::TextureViewDescriptor::default());
+        resources.blur_snapshot_texture = Some(snapshot);
+        resources.blur_snapshot_view = Some(snapshot_view);
+
+        let half = resources.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("blur_half"),
+            size: wgpu::Extent3d {
+                width: half_width,
+                height: half_height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        let half_view = half.create_view(&wgpu::TextureViewDescriptor::default());
+        resources.blur_half_texture = Some(half);
+        resources.blur_half_view = Some(half_view);
     }
 
     pub fn update_transparency(&mut self, transparent: bool) {
@@ -1296,6 +1621,70 @@ impl WgpuRenderer {
                             // Not implemented for Linux/wgpu
                             true
                         }
+                        PrimitiveBatch::BlurRects(range) => {
+                            let rects = &scene.blur_rects[range];
+                            if rects.is_empty() {
+                                continue;
+                            }
+
+                            drop(pass);
+
+                            let did_snapshot =
+                                self.snapshot_and_blur_frame(&mut encoder, &frame.texture);
+
+                            pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                                label: Some("main_pass_continued_blur"),
+                                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                                    view: &frame_view,
+                                    resolve_target: None,
+                                    ops: wgpu::Operations {
+                                        load: wgpu::LoadOp::Load,
+                                        store: wgpu::StoreOp::Store,
+                                    },
+                                    depth_slice: None,
+                                })],
+                                depth_stencil_attachment: None,
+                                ..Default::default()
+                            });
+
+                            if did_snapshot {
+                                self.draw_blur_rects(rects, &mut instance_offset, &mut pass)
+                            } else {
+                                true
+                            }
+                        }
+                        PrimitiveBatch::LensRects(range) => {
+                            let rects = &scene.lens_rects[range];
+                            if rects.is_empty() {
+                                continue;
+                            }
+
+                            drop(pass);
+
+                            let did_snapshot =
+                                self.snapshot_and_blur_frame(&mut encoder, &frame.texture);
+
+                            pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                                label: Some("main_pass_continued_lens"),
+                                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                                    view: &frame_view,
+                                    resolve_target: None,
+                                    ops: wgpu::Operations {
+                                        load: wgpu::LoadOp::Load,
+                                        store: wgpu::StoreOp::Store,
+                                    },
+                                    depth_slice: None,
+                                })],
+                                depth_stencil_attachment: None,
+                                ..Default::default()
+                            });
+
+                            if did_snapshot {
+                                self.draw_lens_rects(rects, &mut instance_offset, &mut pass)
+                            } else {
+                                true
+                            }
+                        }
                     };
                     if !ok {
                         overflow = true;
@@ -1519,6 +1908,254 @@ impl WgpuRenderer {
                 std::mem::size_of_val(instances),
             )
         }
+    }
+
+    /// Copy the current swapchain contents into `blur_snapshot_texture` and
+    /// run a dual-Kawase down/up pass that leaves the blurred result back in
+    /// `blur_snapshot_texture`. Returns `false` if the platform cannot
+    /// snapshot the framebuffer (COPY_SRC missing) or if scratch textures
+    /// aren't allocated yet; callers should skip the blur/lens draw in that
+    /// case.
+    fn snapshot_and_blur_frame(
+        &mut self,
+        encoder: &mut wgpu::CommandEncoder,
+        frame_texture: &wgpu::Texture,
+    ) -> bool {
+        if !self.surface_supports_copy_src {
+            return false;
+        }
+
+        self.ensure_blur_textures();
+
+        let width = self.surface_config.width.max(1);
+        let height = self.surface_config.height.max(1);
+        let half_width = (width / 2).max(1);
+        let half_height = (height / 2).max(1);
+
+        let blur_params_full = BlurParams {
+            viewport_size: [width as f32, height as f32],
+            offset_multiplier: 1.0,
+            _pad: 0.0,
+        };
+        let blur_params_half = BlurParams {
+            viewport_size: [half_width as f32, half_height as f32],
+            offset_multiplier: 1.0,
+            _pad: 0.0,
+        };
+
+        let resources = self.resources();
+        let (Some(snapshot_tex), Some(snapshot_view), Some(half_tex), Some(half_view)) = (
+            resources.blur_snapshot_texture.as_ref(),
+            resources.blur_snapshot_view.as_ref(),
+            resources.blur_half_texture.as_ref(),
+            resources.blur_half_view.as_ref(),
+        ) else {
+            return false;
+        };
+
+        let _ = half_tex;
+
+        encoder.copy_texture_to_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: frame_texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyTextureInfo {
+                texture: snapshot_tex,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+        );
+
+        // Downsample: snapshot (full) → half.
+        resources.queue.write_buffer(
+            &resources.blur_params_buffer,
+            0,
+            bytemuck::bytes_of(&blur_params_full),
+        );
+        let down_bind_group = resources
+            .device
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("blur_downsample_bind_group"),
+                layout: &resources.bind_group_layouts.blur_io,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(snapshot_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: resources.blur_params_buffer.as_entire_binding(),
+                    },
+                ],
+            });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("blur_downsample_pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: half_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                    depth_slice: None,
+                })],
+                depth_stencil_attachment: None,
+                ..Default::default()
+            });
+            pass.set_pipeline(&resources.pipelines.blur_downsample);
+            pass.set_bind_group(0, &down_bind_group, &[]);
+            pass.draw(0..3, 0..1);
+        }
+
+        // Upsample: half → snapshot (overwrites snapshot with the blurred result).
+        resources.queue.write_buffer(
+            &resources.blur_params_buffer,
+            0,
+            bytemuck::bytes_of(&blur_params_half),
+        );
+        let up_bind_group = resources
+            .device
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("blur_upsample_bind_group"),
+                layout: &resources.bind_group_layouts.blur_io,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(half_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: resources.blur_params_buffer.as_entire_binding(),
+                    },
+                ],
+            });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("blur_upsample_pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: snapshot_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                    depth_slice: None,
+                })],
+                depth_stencil_attachment: None,
+                ..Default::default()
+            });
+            pass.set_pipeline(&resources.pipelines.blur_upsample);
+            pass.set_bind_group(0, &up_bind_group, &[]);
+            pass.draw(0..3, 0..1);
+        }
+
+        true
+    }
+
+    fn draw_blur_rects(
+        &self,
+        rects: &[BlurRect],
+        instance_offset: &mut u64,
+        pass: &mut wgpu::RenderPass<'_>,
+    ) -> bool {
+        if rects.is_empty() {
+            return true;
+        }
+        let data = unsafe { Self::instance_bytes(rects) };
+        let Some((offset, size)) = self.write_to_instance_buffer(instance_offset, data) else {
+            return false;
+        };
+        let resources = self.resources();
+        let Some(snapshot_view) = resources.blur_snapshot_view.as_ref() else {
+            return true;
+        };
+        let bind_group = resources
+            .device
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("blur_rect_bind_group"),
+                layout: &resources.bind_group_layouts.blur_rect,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: self.instance_binding(offset, size),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: wgpu::BindingResource::TextureView(snapshot_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 3,
+                        resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
+                    },
+                ],
+            });
+        pass.set_pipeline(&resources.pipelines.blur_rect);
+        pass.set_bind_group(0, &resources.globals_bind_group, &[]);
+        pass.set_bind_group(1, &bind_group, &[]);
+        pass.draw(0..4, 0..rects.len() as u32);
+        true
+    }
+
+    fn draw_lens_rects(
+        &self,
+        rects: &[LensRect],
+        instance_offset: &mut u64,
+        pass: &mut wgpu::RenderPass<'_>,
+    ) -> bool {
+        if rects.is_empty() {
+            return true;
+        }
+        let data = unsafe { Self::instance_bytes(rects) };
+        let Some((offset, size)) = self.write_to_instance_buffer(instance_offset, data) else {
+            return false;
+        };
+        let resources = self.resources();
+        let Some(snapshot_view) = resources.blur_snapshot_view.as_ref() else {
+            return true;
+        };
+        let bind_group = resources
+            .device
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("lens_rect_bind_group"),
+                layout: &resources.bind_group_layouts.lens_rect,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: self.instance_binding(offset, size),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: wgpu::BindingResource::TextureView(snapshot_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 3,
+                        resource: wgpu::BindingResource::Sampler(&resources.blur_sampler),
+                    },
+                ],
+            });
+        pass.set_pipeline(&resources.pipelines.lens_rect);
+        pass.set_bind_group(0, &resources.globals_bind_group, &[]);
+        pass.set_bind_group(1, &bind_group, &[]);
+        pass.draw(0..4, 0..rects.len() as u32);
+        true
     }
 
     fn draw_paths_from_intermediate(
@@ -1892,5 +2529,72 @@ impl RenderingParameters {
             grayscale_enhanced_contrast,
             subpixel_enhanced_contrast,
         }
+    }
+}
+
+#[cfg(test)]
+#[cfg(not(target_family = "wasm"))]
+mod tests {
+    use super::*;
+
+    async fn try_headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
+        let instance =
+            wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::default(),
+                compatible_surface: None,
+                force_fallback_adapter: false,
+            })
+            .await
+            .ok()?;
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("gpui_wgpu_pipeline_smoke"),
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::downlevel_defaults(),
+                memory_hints: wgpu::MemoryHints::default(),
+                trace: wgpu::Trace::Off,
+                experimental_features: wgpu::ExperimentalFeatures::disabled(),
+            })
+            .await
+            .ok()?;
+        Some((device, queue))
+    }
+
+    /// Compiles every render pipeline used by the renderer, including the
+    /// new `blur_downsample` / `blur_upsample` / `blur_rect` / `lens_rect`
+    /// ones. Skipped when no wgpu adapter is available (CI without a GPU).
+    #[test]
+    fn pipeline_creation_smoke() {
+        let Some((device, _queue)) = pollster::block_on(try_headless_device()) else {
+            eprintln!("skipping pipeline_creation_smoke: no wgpu adapter available");
+            return;
+        };
+
+        let layouts = WgpuRenderer::create_bind_group_layouts(&device);
+        let pipelines = WgpuRenderer::create_pipelines(
+            &device,
+            &layouts,
+            wgpu::TextureFormat::Bgra8UnormSrgb,
+            wgpu::CompositeAlphaMode::Auto,
+            1,
+            false,
+        );
+
+        // Touch each pipeline field so a missing entry point or binding
+        // mismatch surfaces as a compilation failure inside `create_pipelines`.
+        let _ = &pipelines.quads;
+        let _ = &pipelines.shadows;
+        let _ = &pipelines.path_rasterization;
+        let _ = &pipelines.paths;
+        let _ = &pipelines.underlines;
+        let _ = &pipelines.mono_sprites;
+        let _ = &pipelines.poly_sprites;
+        let _ = &pipelines.surfaces;
+        let _ = &pipelines.blur_downsample;
+        let _ = &pipelines.blur_upsample;
+        let _ = &pipelines.blur_rect;
+        let _ = &pipelines.lens_rect;
     }
 }

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -1572,6 +1572,11 @@ impl WgpuRenderer {
         loop {
             let mut instance_offset: u64 = 0;
             let mut overflow = false;
+            // Tracks whether the cached blur chain already reflects the
+            // contents of `frame.texture` as of the last non-blur batch.
+            // Reset to `false` at frame start and whenever a primitive
+            // batch draws to the main target.
+            let mut blur_snapshot_valid = false;
 
             let mut encoder =
                 self.resources()
@@ -1597,6 +1602,10 @@ impl WgpuRenderer {
                 });
 
                 for batch in scene.batches() {
+                    let is_blur_batch = matches!(
+                        batch,
+                        PrimitiveBatch::BlurRects(_) | PrimitiveBatch::LensRects(_)
+                    );
                     let ok = match batch {
                         PrimitiveBatch::Quads(range) => {
                             self.draw_quads(&scene.quads[range], &mut instance_offset, &mut pass)
@@ -1684,12 +1693,20 @@ impl WgpuRenderer {
 
                             drop(pass);
 
-                            let did_snapshot = self.snapshot_and_blur_frame(
-                                &mut encoder,
-                                &frame.texture,
-                                blur_kernel_levels,
-                                blur_offset_multiplier,
-                            );
+                            let did_snapshot = if blur_snapshot_valid {
+                                true
+                            } else {
+                                let ok = self.snapshot_and_blur_frame(
+                                    &mut encoder,
+                                    &frame.texture,
+                                    blur_kernel_levels,
+                                    blur_offset_multiplier,
+                                );
+                                if ok {
+                                    blur_snapshot_valid = true;
+                                }
+                                ok
+                            };
 
                             pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                                 label: Some("main_pass_continued_blur"),
@@ -1720,12 +1737,20 @@ impl WgpuRenderer {
 
                             drop(pass);
 
-                            let did_snapshot = self.snapshot_and_blur_frame(
-                                &mut encoder,
-                                &frame.texture,
-                                blur_kernel_levels,
-                                blur_offset_multiplier,
-                            );
+                            let did_snapshot = if blur_snapshot_valid {
+                                true
+                            } else {
+                                let ok = self.snapshot_and_blur_frame(
+                                    &mut encoder,
+                                    &frame.texture,
+                                    blur_kernel_levels,
+                                    blur_offset_multiplier,
+                                );
+                                if ok {
+                                    blur_snapshot_valid = true;
+                                }
+                                ok
+                            };
 
                             pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                                 label: Some("main_pass_continued_lens"),
@@ -1752,6 +1777,11 @@ impl WgpuRenderer {
                     if !ok {
                         overflow = true;
                         break;
+                    }
+                    if !is_blur_batch {
+                        // Drawing to the main target invalidates the cached
+                        // blur snapshot.
+                        blur_snapshot_valid = false;
                     }
                 }
             }

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -335,17 +335,18 @@ impl DirectXRenderer {
                     self.draw_polychrome_sprites(texture_id, range.start, range.len())
                 }
                 PrimitiveBatch::Surfaces(range) => self.draw_surfaces(&scene.surfaces[range]),
-                PrimitiveBatch::BlurRects(_) | PrimitiveBatch::LensRects(_) => {
-                    // Stage 1 API plumbing only. Renderer implementation lives in a
-                    // follow-up commit; the target shaders are reference implementations
-                    // in tahoe-gpui/src/foundations/shaders/ (dual_kawase.wgsl and
-                    // glass_composite.wgsl).
+                PrimitiveBatch::BlurRects(_) => {
+                    // Not yet implemented on DirectX; tracked as a follow-up.
+                    Ok(())
+                }
+                PrimitiveBatch::LensRects(_) => {
+                    // Not yet implemented on DirectX; tracked as a follow-up.
                     Ok(())
                 }
             }
             .context(format!(
                 "scene too large:\
-                {} paths, {} shadows, {} quads, {} underlines, {} mono, {} subpixel, {} poly, {} surfaces",
+                {} paths, {} shadows, {} quads, {} underlines, {} mono, {} subpixel, {} poly, {} surfaces, {} blur rects, {} lens rects",
                 scene.paths.len(),
                 scene.shadows.len(),
                 scene.quads.len(),
@@ -354,6 +355,8 @@ impl DirectXRenderer {
                 scene.subpixel_sprites.len(),
                 scene.polychrome_sprites.len(),
                 scene.surfaces.len(),
+                scene.blur_rects.len(),
+                scene.lens_rects.len(),
             ))?;
         }
         self.present()

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -335,6 +335,13 @@ impl DirectXRenderer {
                     self.draw_polychrome_sprites(texture_id, range.start, range.len())
                 }
                 PrimitiveBatch::Surfaces(range) => self.draw_surfaces(&scene.surfaces[range]),
+                PrimitiveBatch::BlurRects(_) | PrimitiveBatch::LensRects(_) => {
+                    // Stage 1 API plumbing only. Renderer implementation lives in a
+                    // follow-up commit; the target shaders are reference implementations
+                    // in tahoe-gpui/src/foundations/shaders/ (dual_kawase.wgsl and
+                    // glass_composite.wgsl).
+                    Ok(())
+                }
             }
             .context(format!(
                 "scene too large:\

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -43,9 +43,28 @@ fn warn_once_primitive_unimplemented(
     if cell.set(()).is_ok() {
         log::warn!(
             "{primitive} is not yet implemented on the DirectX backend; \
-             these primitives will render as transparent. Tracked as a \
-             follow-up to the blur-primitive PR."
+             the backend falls back to a flat tinted rectangle until the \
+             full port lands. Tracked as a follow-up to the blur-primitive PR."
         );
+    }
+}
+
+/// Build a plain-quad fallback for a blur / lens / mirror rect. Returns a
+/// `Quad` tinted with `tint` and otherwise untouched, so the full port's
+/// missing features (refraction, Fresnel, source-sampling, gradient blur)
+/// degrade to a flat colored rectangle instead of a hole.
+fn fallback_quad(
+    bounds: Bounds<ScaledPixels>,
+    content_mask: ContentMask<ScaledPixels>,
+    corner_radii: Corners<ScaledPixels>,
+    tint: Hsla,
+) -> Quad {
+    Quad {
+        bounds,
+        content_mask,
+        corner_radii,
+        background: Background::from(tint),
+        ..Quad::default()
     }
 }
 
@@ -104,6 +123,11 @@ struct DirectXResources {
 struct DirectXRenderPipelines {
     shadow_pipeline: PipelineState<Shadow>,
     quad_pipeline: PipelineState<Quad>,
+    /// Dedicated quad pipeline used only for the BlurRect / LensRect /
+    /// MirrorRect fallback — reuses the quad shader but owns its own buffer
+    /// so it can be refreshed per batch without clobbering `quad_pipeline`'s
+    /// scene-wide contents.
+    blur_fallback_pipeline: PipelineState<Quad>,
     path_rasterization_pipeline: PipelineState<PathRasterizationSprite>,
     path_sprite_pipeline: PipelineState<PathSprite>,
     underline_pipeline: PipelineState<Underline>,
@@ -356,26 +380,38 @@ impl DirectXRenderer {
                     self.draw_polychrome_sprites(texture_id, range.start, range.len())
                 }
                 PrimitiveBatch::Surfaces(range) => self.draw_surfaces(&scene.surfaces[range]),
-                PrimitiveBatch::BlurRects(_) => {
+                PrimitiveBatch::BlurRects(range) => {
                     warn_once_primitive_unimplemented(
                         &BLUR_RECT_NOT_IMPLEMENTED_WARNED,
                         "BlurRect",
                     );
-                    Ok(())
+                    let fallback_quads: Vec<Quad> = scene.blur_rects[range]
+                        .iter()
+                        .map(|r| fallback_quad(r.bounds, r.content_mask, r.corner_radii, r.tint))
+                        .collect();
+                    self.draw_fallback_quads(&fallback_quads)
                 }
-                PrimitiveBatch::LensRects(_) => {
+                PrimitiveBatch::LensRects(range) => {
                     warn_once_primitive_unimplemented(
                         &LENS_RECT_NOT_IMPLEMENTED_WARNED,
                         "LensRect",
                     );
-                    Ok(())
+                    let fallback_quads: Vec<Quad> = scene.lens_rects[range]
+                        .iter()
+                        .map(|r| fallback_quad(r.bounds, r.content_mask, Corners::default(), r.tint))
+                        .collect();
+                    self.draw_fallback_quads(&fallback_quads)
                 }
-                PrimitiveBatch::MirrorRects(_) => {
+                PrimitiveBatch::MirrorRects(range) => {
                     warn_once_primitive_unimplemented(
                         &MIRROR_RECT_NOT_IMPLEMENTED_WARNED,
                         "MirrorRect",
                     );
-                    Ok(())
+                    let fallback_quads: Vec<Quad> = scene.mirror_rects[range]
+                        .iter()
+                        .map(|r| fallback_quad(r.bounds, r.content_mask, r.corner_radii, r.tint))
+                        .collect();
+                    self.draw_fallback_quads(&fallback_quads)
                 }
             }
             .context(format!(
@@ -536,6 +572,37 @@ impl DirectXRenderer {
             4,
             start as u32,
             len as u32,
+        )
+    }
+
+    /// Draw synthesized quads for the BlurRect / LensRect / MirrorRect
+    /// fallback. Uses a dedicated pipeline so `update_buffer` here does
+    /// not clobber the scene-wide `quad_pipeline` contents that earlier /
+    /// later batches in the same frame still depend on.
+    fn draw_fallback_quads(&mut self, quads: &[Quad]) -> Result<()> {
+        if quads.is_empty() {
+            return Ok(());
+        }
+        let devices = self.devices.as_ref().context("devices missing")?;
+        self.pipelines.blur_fallback_pipeline.update_buffer(
+            &devices.device,
+            &devices.device_context,
+            quads,
+        )?;
+        self.pipelines.blur_fallback_pipeline.draw_range(
+            &devices.device,
+            &devices.device_context,
+            slice::from_ref(
+                &self
+                    .resources
+                    .as_ref()
+                    .context("resources missing")?
+                    .viewport,
+            ),
+            slice::from_ref(&self.globals.global_params_buffer),
+            4,
+            0,
+            quads.len() as u32,
         )
     }
 
@@ -880,6 +947,13 @@ impl DirectXRenderPipelines {
             64,
             create_blend_state(device)?,
         )?;
+        let blur_fallback_pipeline = PipelineState::new(
+            device,
+            "blur_fallback_pipeline",
+            ShaderModule::Quad,
+            16,
+            create_blend_state(device)?,
+        )?;
         let path_rasterization_pipeline = PipelineState::new(
             device,
             "path_rasterization_pipeline",
@@ -926,6 +1000,7 @@ impl DirectXRenderPipelines {
         Ok(Self {
             shadow_pipeline,
             quad_pipeline,
+            blur_fallback_pipeline,
             path_rasterization_pipeline,
             path_sprite_pipeline,
             underline_pipeline,

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -28,6 +28,27 @@ const RENDER_TARGET_FORMAT: DXGI_FORMAT = DXGI_FORMAT_B8G8R8A8_UNORM;
 // This configuration is used for MSAA rendering on paths only, and it's guaranteed to be supported by DirectX 11.
 const PATH_MULTISAMPLE_COUNT: u32 = 4;
 
+// Track whether we've already logged the "not implemented on DirectX"
+// warning for each blur-adjacent primitive kind. The full port is tracked
+// separately; until then, we emit one warning per primitive kind per
+// process so the degradation is visible without spamming every frame.
+static BLUR_RECT_NOT_IMPLEMENTED_WARNED: OnceLock<()> = OnceLock::new();
+static LENS_RECT_NOT_IMPLEMENTED_WARNED: OnceLock<()> = OnceLock::new();
+static MIRROR_RECT_NOT_IMPLEMENTED_WARNED: OnceLock<()> = OnceLock::new();
+
+fn warn_once_primitive_unimplemented(
+    cell: &'static OnceLock<()>,
+    primitive: &'static str,
+) {
+    if cell.set(()).is_ok() {
+        log::warn!(
+            "{primitive} is not yet implemented on the DirectX backend; \
+             these primitives will render as transparent. Tracked as a \
+             follow-up to the blur-primitive PR."
+        );
+    }
+}
+
 pub(crate) struct FontInfo {
     pub gamma_ratios: [f32; 4],
     pub grayscale_enhanced_contrast: f32,
@@ -336,17 +357,30 @@ impl DirectXRenderer {
                 }
                 PrimitiveBatch::Surfaces(range) => self.draw_surfaces(&scene.surfaces[range]),
                 PrimitiveBatch::BlurRects(_) => {
-                    // Not yet implemented on DirectX; tracked as a follow-up.
+                    warn_once_primitive_unimplemented(
+                        &BLUR_RECT_NOT_IMPLEMENTED_WARNED,
+                        "BlurRect",
+                    );
                     Ok(())
                 }
                 PrimitiveBatch::LensRects(_) => {
-                    // Not yet implemented on DirectX; tracked as a follow-up.
+                    warn_once_primitive_unimplemented(
+                        &LENS_RECT_NOT_IMPLEMENTED_WARNED,
+                        "LensRect",
+                    );
+                    Ok(())
+                }
+                PrimitiveBatch::MirrorRects(_) => {
+                    warn_once_primitive_unimplemented(
+                        &MIRROR_RECT_NOT_IMPLEMENTED_WARNED,
+                        "MirrorRect",
+                    );
                     Ok(())
                 }
             }
             .context(format!(
                 "scene too large:\
-                {} paths, {} shadows, {} quads, {} underlines, {} mono, {} subpixel, {} poly, {} surfaces, {} blur rects, {} lens rects",
+                {} paths, {} shadows, {} quads, {} underlines, {} mono, {} subpixel, {} poly, {} surfaces, {} blur rects, {} lens rects, {} mirror rects",
                 scene.paths.len(),
                 scene.shadows.len(),
                 scene.quads.len(),
@@ -357,6 +391,7 @@ impl DirectXRenderer {
                 scene.surfaces.len(),
                 scene.blur_rects.len(),
                 scene.lens_rects.len(),
+                scene.mirror_rects.len(),
             ))?;
         }
         self.present()


### PR DESCRIPTION
## Summary
- Splits the monolithic blur/lens/mirror bind group (@group(1)) into two groups: group(1) for frame-stable resources (pyramid view, sampler, scene_blur_params) and group(2) for per-batch instance storage buffers
- Caches group(1) for the lifetime of the pyramid texture, avoiding a full `create_bind_group` call per primitive per frame — only the small group(2) with instance buffer entries is recreated each frame
- Updates WGSL bindings and Rust bind group layouts, pipeline creation, and draw methods accordingly

## Test plan
- [ ] `cargo clippy -p gpui_wgpu -- -D warnings` passes (verified locally)
- [ ] Visual check: blur rects, lens rects, and mirror rects render identically to before
- [ ] Confirm no shader compilation errors via the existing pipeline smoke tests

Release Notes:

- N/A